### PR TITLE
Release v1.2.0

### DIFF
--- a/CLOUD_INIT_TEMPLATE_VARIABLES.md
+++ b/CLOUD_INIT_TEMPLATE_VARIABLES.md
@@ -34,6 +34,16 @@ These variables are available if configured in `.env` or environment:
 | `{{vpn_dns_servers}}` | `VPN_DNS_SERVERS` | VPN DNS servers (comma-separated) |
 | `{{vpn_allowed_ips}}` | `VPN_ALLOWED_IPS` | Allowed IPs for VPN routing |
 
+### Dynamic Download URLs
+Generate presigned URLs for any file in R2 at render time:
+
+| Variable | Config Settings | Description |
+|----------|----------------|-------------|
+| `{{r2_url:<object_key>}}` | `R2_*`, `CLOUD_INIT_LINK_EXPIRY` | Presigned download URL for the given R2 object key. Supports nested paths. |
+
+**Required config:** `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`
+**Optional config:** `R2_CUSTOM_DOMAIN`, `CLOUD_INIT_LINK_EXPIRY` (default: 14400s / 4 hours)
+
 ## Configuration
 
 ### Step 1: Set Environment Variables
@@ -48,6 +58,14 @@ FRONTEND_URL=https://dev.cyberxredteam.org
 
 # Download URLs
 DOWNLOAD_BASE_URL=https://files.example.com
+
+# Signed Download URLs (for {{r2_url:...}} in cloud-init templates)
+R2_ACCOUNT_ID=your-cloudflare-account-id
+R2_ACCESS_KEY_ID=your-r2-access-key
+R2_SECRET_ACCESS_KEY=your-r2-secret-key
+R2_BUCKET=your-bucket-name
+R2_CUSTOM_DOMAIN=                          # Optional
+CLOUD_INIT_LINK_EXPIRY=14400               # 4 hours (default)
 
 # VPN Configuration (if using WireGuard)
 VPN_SERVER_PUBLIC_KEY=your-wg-public-key
@@ -67,8 +85,10 @@ Example cloud-init template:
 ssh_authorized_keys:
   - {{ssh_public_key}}
 
-# License activation
+# License activation and file downloads
 runcmd:
+  - curl -o /tmp/agent.tar.gz "{{r2_url:packages/linux/agent.tar.gz}}"
+  - curl -o /tmp/setup.sh "{{r2_url:scripts/setup.sh}}"
   - |
     python3 /opt/hexio/hexio_setup.py \
       --license-url "{{license_server}}" \
@@ -101,10 +121,12 @@ The following will be implemented as part of the full OpenStack integration:
 - **Variable:** `{{license_token}}` is auto-generated using `secrets.token_urlsafe(32)`
 - **Future:** Will be enhanced with database tracking, expiry, and single-use validation via LicenseService
 
-### Signed Download URLs
-- **Current:** `DOWNLOAD_BASE_URL` is static
-- **Future:** Each instance will get unique signed URLs for file downloads (R2 or nginx secure_link)
-- **Variable:** `{{download_url}}` will be auto-generated (not yet implemented)
+### ✅ Signed Download URLs (IMPLEMENTED)
+- **Status:** ✅ Complete
+- **Syntax:** `{{r2_url:path/to/file}}` — generates a time-limited presigned URL for any file in the R2 bucket (or nginx signed URL depending on `DOWNLOAD_LINK_MODE`)
+- **Expiry:** Controlled by `CLOUD_INIT_LINK_EXPIRY` (default 4 hours / 14400 seconds)
+- **Nested paths:** Fully supported (e.g., `{{r2_url:events/cyberx-2026/tools/linux/agent.tar.gz}}`)
+- **Behavior:** Duplicate paths share one URL; if R2 is not configured, placeholders are left as-is with a warning logged
 
 ### Per-Instance VPN Config
 - **Current:** VPN settings are static (shared server config)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -50,6 +50,16 @@ CPE_CONVERSION_MODE=gotenberg          # "gotenberg" or "libreoffice"
 GOTENBERG_URL=                         # e.g. http://localhost:3000
 CPE_HOURS_DEFAULT=32.0
 
+# Download Link Generation (optional - for signed download URLs in cloud-init)
+DOWNLOAD_LINK_MODE=r2                      # "r2" or "nginx"
+DOWNLOAD_LINK_EXPIRY=3600                  # Default link lifetime in seconds (1 hour)
+CLOUD_INIT_LINK_EXPIRY=14400               # Link lifetime for cloud-init {{r2_url:...}} placeholders (4 hours)
+R2_ACCOUNT_ID=                             # Cloudflare account ID
+R2_ACCESS_KEY_ID=                          # R2 API token access key
+R2_SECRET_ACCESS_KEY=                      # R2 API token secret
+R2_BUCKET=                                 # R2 bucket name
+R2_CUSTOM_DOMAIN=                          # Optional: custom domain to replace R2 endpoint in URLs
+
 # Session Configuration
 SESSION_EXPIRY_HOURS=24
 

--- a/backend/app/api/routes/cloud_init.py
+++ b/backend/app/api/routes/cloud_init.py
@@ -124,4 +124,5 @@ async def preview_template(
         raise not_found("Cloud-init template", template_id)
 
     rendered = service.render_template(template.content, data.variables)
+    rendered = service.resolve_r2_url_placeholders(rendered)
     return CloudInitPreviewResponse(rendered=rendered)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -116,6 +116,7 @@ class Settings(BaseSettings):
     DOWNLOAD_BASE_URL: str = ""
     DOWNLOAD_LINK_MODE: str = "r2"     # "r2" or "nginx"
     DOWNLOAD_LINK_EXPIRY: int = 3600   # Default 1 hour
+    CLOUD_INIT_LINK_EXPIRY: int = 14400  # Default 4 hours (cloud-init may run late)
 
     # CPE Certificate Configuration
     CPE_TEMPLATE_R2_KEY: str = ""           # R2 object key for DOCX template (e.g. "templates/cpe_template.docx")

--- a/backend/app/services/cloud_init_service.py
+++ b/backend/app/services/cloud_init_service.py
@@ -167,6 +167,65 @@ class CloudInitService:
         return rendered
 
     @staticmethod
+    def resolve_r2_url_placeholders(
+        content: str, expires_in: int | None = None
+    ) -> str:
+        """Replace {{r2_url:path/to/file}} placeholders with presigned download URLs.
+
+        Args:
+            content: Rendered template content (after render_template).
+            expires_in: Link lifetime in seconds. Defaults to CLOUD_INIT_LINK_EXPIRY.
+
+        Returns:
+            Content with R2 URL placeholders replaced.
+        """
+        from app.config import get_settings
+        from app.services.download_service import DownloadService
+
+        pattern = re.compile(r"\{\{r2_url:([^}]+)\}\}")
+        matches = pattern.findall(content)
+
+        if not matches:
+            return content
+
+        if expires_in is None:
+            expires_in = get_settings().CLOUD_INIT_LINK_EXPIRY
+
+        try:
+            download_svc = DownloadService()
+        except Exception as e:
+            logger.warning("Cannot resolve r2_url placeholders: %s", e)
+            return content
+
+        # Cache generated URLs so duplicate paths get the same URL
+        url_cache: dict[str, str] = {}
+
+        for object_key in matches:
+            if object_key in url_cache:
+                continue
+            try:
+                url = download_svc.generate_link(object_key, expires_in)
+                url_cache[object_key] = url
+            except ValueError as e:
+                logger.warning(
+                    "Failed to generate presigned URL for '%s': %s",
+                    object_key, e,
+                )
+
+        for object_key, url in url_cache.items():
+            content = content.replace(f"{{{{r2_url:{object_key}}}}}", url)
+
+        # Warn about any remaining unresolved r2_url placeholders
+        remaining = pattern.findall(content)
+        if remaining:
+            logger.warning(
+                "Unresolved r2_url placeholders in cloud-init template: %s",
+                ", ".join(remaining),
+            )
+
+        return content
+
+    @staticmethod
     def encode_user_data(rendered_content: str) -> str:
         """Base64-encode rendered cloud-init content for Nova API.
 

--- a/backend/app/services/digitalocean_service.py
+++ b/backend/app/services/digitalocean_service.py
@@ -211,7 +211,7 @@ class DigitalOceanService:
         try:
             async with httpx.AsyncClient(timeout=15) as client:
                 resp = await client.get(
-                    f"{self.api_url}/sizes",
+                    f"{self.api_url}/sizes?per_page=200",
                     headers=self._headers(),
                 )
                 resp.raise_for_status()
@@ -229,7 +229,7 @@ class DigitalOceanService:
         try:
             async with httpx.AsyncClient(timeout=15) as client:
                 resp = await client.get(
-                    f"{self.api_url}/images?type=distribution",
+                    f"{self.api_url}/images?type=distribution&per_page=200",
                     headers=self._headers(),
                 )
                 resp.raise_for_status()
@@ -247,7 +247,7 @@ class DigitalOceanService:
         try:
             async with httpx.AsyncClient(timeout=15) as client:
                 resp = await client.get(
-                    f"{self.api_url}/regions",
+                    f"{self.api_url}/regions?per_page=200",
                     headers=self._headers(),
                 )
                 resp.raise_for_status()

--- a/backend/app/services/instance_service.py
+++ b/backend/app/services/instance_service.py
@@ -321,6 +321,10 @@ class InstanceService:
 
         # Render template
         user_data = cloud_init_svc.render_template(template.content, variables)
+
+        # Resolve {{r2_url:path}} placeholders into presigned download URLs
+        user_data = cloud_init_svc.resolve_r2_url_placeholders(user_data)
+
         logger.info("Rendered cloud-init template %d for instance %s", template_id, name)
 
         return user_data

--- a/backend/app/services/openstack_service.py
+++ b/backend/app/services/openstack_service.py
@@ -479,6 +479,10 @@ class OpenStackService:
 
                 # Render template
                 user_data = cloud_init_svc.render_template(template.content, variables)
+
+                # Resolve {{r2_url:path}} placeholders into presigned download URLs
+                user_data = cloud_init_svc.resolve_r2_url_placeholders(user_data)
+
                 logger.info("Rendered cloud-init template %d for instance %s", template_id, name)
 
         # VPN assignment (event-based)
@@ -528,6 +532,7 @@ class OpenStackService:
 
                         # Re-render template with VPN variables
                         user_data = cloud_init_svc.render_template(template.content, variables)
+                        user_data = cloud_init_svc.resolve_r2_url_placeholders(user_data)
                         logger.info("Re-rendered cloud-init template with VPN variables for instance %s", name)
                 else:
                     logger.warning("Failed to assign VPN to instance %s: %s", name, message)

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -4,4 +4,4 @@
 # - MAJOR: Breaking changes or significant architectural changes
 # - MINOR: New features, functionality additions
 # - PATCH: Bug fixes, small improvements
-VERSION = "1.1.2"
+VERSION = "1.1.3"

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -4,4 +4,4 @@
 # - MAJOR: Breaking changes or significant architectural changes
 # - MINOR: New features, functionality additions
 # - PATCH: Bug fixes, small improvements
-VERSION = "1.1.3"
+VERSION = "1.2.0"

--- a/backend/tests/unit/test_cloud_init_service.py
+++ b/backend/tests/unit/test_cloud_init_service.py
@@ -1,0 +1,181 @@
+"""
+Unit tests for CloudInitService.
+
+Tests template rendering and R2 URL placeholder resolution.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.services.cloud_init_service import CloudInitService
+
+
+class TestRenderTemplate:
+    """Tests for CloudInitService.render_template (sync, no DB needed)."""
+
+    def _make_service(self):
+        """Create a CloudInitService with a mock session (not used by render_template)."""
+        return CloudInitService(session=MagicMock())
+
+    def test_simple_substitution(self):
+        svc = self._make_service()
+        content = "#cloud-config\nhostname: {{hostname}}"
+        result = svc.render_template(content, {"hostname": "test-box"})
+        assert "hostname: test-box" in result
+
+    def test_multiple_variables(self):
+        svc = self._make_service()
+        content = "hostname: {{hostname}}\ntoken: {{license_token}}"
+        result = svc.render_template(content, {
+            "hostname": "box1",
+            "license_token": "abc123",
+        })
+        assert "hostname: box1" in result
+        assert "token: abc123" in result
+
+    def test_unsubstituted_placeholder_warns(self, caplog):
+        svc = self._make_service()
+        content = "hostname: {{hostname}}\nkey: {{missing_var}}"
+        result = svc.render_template(content, {"hostname": "box1"})
+        assert "hostname: box1" in result
+        assert "Unsubstituted placeholders" in caplog.text
+        assert "missing_var" in caplog.text
+
+    def test_removes_empty_list_items(self):
+        svc = self._make_service()
+        content = "ssh_authorized_keys:\n  - {{ssh_public_key}}"
+        result = svc.render_template(content, {})
+        # Both the empty list item and its parent key should be removed
+        assert "ssh_authorized_keys" not in result
+
+    def test_r2_url_placeholder_not_flagged_as_unsubstituted(self, caplog):
+        """{{r2_url:...}} uses a colon, so it should NOT match the \\w+ warning regex."""
+        svc = self._make_service()
+        content = "url: {{r2_url:tools/agent.tar.gz}}"
+        svc.render_template(content, {})
+        assert "Unsubstituted placeholders" not in caplog.text
+
+
+class TestResolveR2UrlPlaceholders:
+    """Tests for CloudInitService.resolve_r2_url_placeholders (static method)."""
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_single_placeholder(self, mock_settings, mock_dl_cls):
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+        mock_dl.generate_link.return_value = "https://r2.example.com/signed/agent.deb"
+
+        content = 'curl -o /tmp/agent.deb "{{r2_url:packages/agent.deb}}"'
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        assert "https://r2.example.com/signed/agent.deb" in result
+        assert "{{r2_url:" not in result
+        mock_dl.generate_link.assert_called_once_with("packages/agent.deb", 14400)
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_multiple_placeholders(self, mock_settings, mock_dl_cls):
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+        mock_dl.generate_link.side_effect = lambda key, _: f"https://signed/{key}"
+
+        content = (
+            'curl "{{r2_url:tools/linux/agent.tar.gz}}"\n'
+            'curl "{{r2_url:scripts/setup.sh}}"'
+        )
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        assert "https://signed/tools/linux/agent.tar.gz" in result
+        assert "https://signed/scripts/setup.sh" in result
+        assert "{{r2_url:" not in result
+        assert mock_dl.generate_link.call_count == 2
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_duplicate_paths_cached(self, mock_settings, mock_dl_cls):
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+        mock_dl.generate_link.return_value = "https://signed/agent.deb"
+
+        content = (
+            'curl "{{r2_url:packages/agent.deb}}"\n'
+            'echo "{{r2_url:packages/agent.deb}}"'
+        )
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        assert result.count("https://signed/agent.deb") == 2
+        # generate_link should only be called once for the same key
+        mock_dl.generate_link.assert_called_once()
+
+    def test_no_placeholders_passthrough(self):
+        content = "hostname: test-box\nruncmd:\n  - echo hello"
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        assert result == content
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_missing_r2_config_leaves_placeholder(self, mock_settings, mock_dl_cls, caplog):
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+        mock_dl.generate_link.side_effect = ValueError("R2 not configured")
+
+        content = 'curl "{{r2_url:packages/agent.deb}}"'
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        # Placeholder should remain since URL generation failed
+        assert "{{r2_url:packages/agent.deb}}" in result
+        assert "Failed to generate presigned URL" in caplog.text
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_custom_expiry(self, mock_settings, mock_dl_cls):
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+        mock_dl.generate_link.return_value = "https://signed/file"
+
+        content = 'curl "{{r2_url:file.tar.gz}}"'
+        CloudInitService.resolve_r2_url_placeholders(content, expires_in=7200)
+
+        mock_dl.generate_link.assert_called_once_with("file.tar.gz", 7200)
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_nested_directory_path(self, mock_settings, mock_dl_cls):
+        """Ensure deeply nested R2 keys work (slashes in path)."""
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+        mock_dl.generate_link.return_value = "https://signed/deep/path"
+
+        content = 'curl "{{r2_url:events/cyberx-2026/tools/linux/amd64/agent.tar.gz}}"'
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        assert "https://signed/deep/path" in result
+        mock_dl.generate_link.assert_called_once_with(
+            "events/cyberx-2026/tools/linux/amd64/agent.tar.gz", 14400
+        )
+
+    @patch("app.services.download_service.DownloadService")
+    @patch("app.config.get_settings")
+    def test_partial_failure_resolves_successful_ones(self, mock_settings, mock_dl_cls, caplog):
+        """If one URL fails, others should still resolve."""
+        mock_settings.return_value.CLOUD_INIT_LINK_EXPIRY = 14400
+        mock_dl = mock_dl_cls.return_value
+
+        def side_effect(key, _):
+            if key == "bad/file":
+                raise ValueError("not found")
+            return f"https://signed/{key}"
+
+        mock_dl.generate_link.side_effect = side_effect
+
+        content = (
+            'curl "{{r2_url:good/file}}"\n'
+            'curl "{{r2_url:bad/file}}"'
+        )
+        result = CloudInitService.resolve_r2_url_placeholders(content)
+
+        assert "https://signed/good/file" in result
+        assert "{{r2_url:bad/file}}" in result  # Failed one stays
+        assert "Failed to generate presigned URL" in caplog.text

--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,17 @@
-# Render.com Blueprint for CyberX Event Management System - STAGING
+# Render.com Blueprint for CyberX Event Management System - PRODUCTION
 # Deploys: FastAPI app + Background Worker
 # Uses Supabase for PostgreSQL (configured via environment variables)
 # Estimated cost: ~$14/month (2x $7 services)
 # Trigger: DATABASE_URL will be injected via GitHub Actions
 
 services:
-  # FastAPI Web Application - STAGING
+  # FastAPI Web Application - PRODUCTION
   - type: web
-    name: cyberx-event-mgmt-staging
+    name: cyberx-event-mgmt-production
     runtime: python
     region: virginia  # US East
     plan: starter  # $7/month - 512MB RAM (sufficient for 100 users)
-    branch: staging  # Staging service watches staging branch
+    branch: main  # Production deploys from main branch
     autoDeploy: false  # Disable auto deploy - only deploy via GitHub Actions
     buildCommand: |
       cd backend
@@ -25,7 +25,7 @@ services:
       - key: PYTHON_VERSION
         value: 3.12.8
       - key: ENVIRONMENT
-        value: staging
+        value: production
       - key: DEBUG
         value: "false"
       # Database - Supabase connection string (set manually in Render dashboard)
@@ -46,7 +46,7 @@ services:
       - key: SENDGRID_FROM_NAME
         value: CyberX Red Team
       - key: SENDGRID_SANDBOX_MODE
-        value: "true"  # STAGING: Sandbox mode
+        value: "false"  # PRODUCTION: Send real emails
       # SendGrid webhook verification
       - key: SENDGRID_WEBHOOK_VERIFICATION_KEY
         sync: false
@@ -59,15 +59,13 @@ services:
         value: 10.20.200.1
       - key: VPN_ALLOWED_IPS
         value: 10.0.0.0/8,fd00:a::/32
-      # Application configuration - STAGING URLs
+      # Application configuration - PRODUCTION URLs
       - key: FRONTEND_URL
-        value: https://staging.events.cyberxredteam.org
+        value: https://events.cyberxredteam.org
       - key: ALLOWED_HOSTS
-        value: staging.events.cyberxredteam.org
+        value: events.cyberxredteam.org
       - key: SESSION_EXPIRY_HOURS
         value: 24
-      - key: CSRF_TOKEN_MAX_AGE
-        value: 30
       - key: BULK_EMAIL_INTERVAL_MINUTES
         value: 45
       # Reminder configuration
@@ -146,7 +144,7 @@ services:
       - key: CPE_SIGNER_2_NAME
         sync: false
       - key: GOTENBERG_URL
-        value: http://cyberx-gotenberg-staging:3000
+        value: http://cyberx-gotenberg-production:3000
       # Render API (for sidecar lifecycle management)
       - key: RENDER_API_KEY
         sync: false
@@ -167,7 +165,7 @@ services:
 
   # Gotenberg - DOCX to PDF conversion for CPE certificates
   - type: pserv
-    name: cyberx-gotenberg-staging
+    name: cyberx-gotenberg-production
     runtime: docker
     region: virginia
     plan: standard


### PR DESCRIPTION
## Summary
- Add `{{r2_url:path/to/file}}` presigned download URLs in cloud-init templates
- Fetch all DigitalOcean sizes/images/regions for admin dropdowns (pagination fix)
- Use FRONTEND_URL config for login_url in credential emails, fix assign-role refresh bug
- Handle duplicate email on participant update with 409 instead of 500
- Fix admin-link email lookup to use normalize_email
- Add per-event discord_verified_at for bot verification tracking
- Add Discord bot API with DB-stored service API keys (v1.1.0)
- CSRF token refresh and configurable CSRF_TOKEN_MAX_AGE
- Allow sponsors to delete own invitees and redirect on 401

## Test plan
- [x] 572 unit tests passing, 13 skipped (pre-existing DB isolation)
- [ ] Verify cloud-init `{{r2_url:...}}` placeholder resolves in template preview
- [ ] Verify DO admin dropdowns show full size/image/region lists
- [ ] Smoke test instance provisioning on staging
- [ ] Verify Discord bot API endpoints functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)