### PR TITLE
Release v1.3.0 — Independent agent DNS, raw VPN configs in R2

### DIFF
--- a/agent/cyberx-agent.py
+++ b/agent/cyberx-agent.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 """CyberX Instance Agent — polls for tasks and executes them.
 
-Zero external dependencies (stdlib only).
 Runs as a systemd service, logs to journald via stderr.
+
+DNS resolution is handled independently of the system resolver so that
+isolated-network DNS and C2 frameworks that hijack /etc/resolv.conf cannot
+prevent the agent from reaching the management API.
+
+Dependencies: dnspython, requests
 """
-import json
 import logging
 import os
 import subprocess
 import sys
 import time
-import urllib.error
-import urllib.request
+from urllib.parse import urlparse
+
+import dns.resolver
+import requests
+from requests.adapters import HTTPAdapter
 
 # ─── Configuration ──────────────────────────────────────────────────
 
@@ -29,6 +36,15 @@ WG_CONFIG_PATH = os.environ.get(
 
 MAX_BACKOFF = 300  # 5 minutes
 
+# External DNS servers to query directly, bypassing /etc/resolv.conf.
+# Comma-separated list via env var, defaults to Cloudflare + Google.
+DNS_SERVERS = os.environ.get(
+    "CYBERX_DNS_SERVERS", "1.1.1.1,8.8.8.8"
+).split(",")
+
+# How long (seconds) to cache a DNS result before re-resolving.
+DNS_CACHE_TTL = int(os.environ.get("CYBERX_DNS_CACHE_TTL", "300"))
+
 # ─── Logging ────────────────────────────────────────────────────────
 
 logging.basicConfig(
@@ -38,7 +54,93 @@ logging.basicConfig(
 )
 log = logging.getLogger("cyberx-agent")
 
+# ─── Independent DNS resolver ──────────────────────────────────────
+
+_dns_cache: dict[str, tuple[str, float]] = {}
+
+
+def _resolve_host(hostname: str) -> str:
+    """Resolve *hostname* → IP using external DNS, bypassing the system resolver.
+
+    Results are cached for DNS_CACHE_TTL seconds.
+    """
+    now = time.monotonic()
+    cached = _dns_cache.get(hostname)
+    if cached and (now - cached[1]) < DNS_CACHE_TTL:
+        return cached[0]
+
+    resolver = dns.resolver.Resolver(configure=False)
+    resolver.nameservers = list(DNS_SERVERS)
+    resolver.lifetime = 10  # seconds total timeout
+
+    try:
+        answers = resolver.resolve(hostname, "A")
+        ip = str(answers[0])
+        _dns_cache[hostname] = (ip, now)
+        log.info("Resolved %s → %s (via %s)", hostname, ip, DNS_SERVERS[0])
+        return ip
+    except Exception as e:
+        log.error("DNS resolution failed for %s: %s", hostname, e)
+        raise
+
+# ─── HTTP session with custom DNS ──────────────────────────────────
+
+
+class _DirectDNSAdapter(HTTPAdapter):
+    """Requests adapter that resolves hostnames via our own DNS resolver
+    and connects to the resolved IP while preserving the original Host
+    header and TLS SNI."""
+
+    def send(self, request, stream=False, timeout=None,
+             verify=True, cert=None, proxies=None):
+        parsed = urlparse(request.url)
+        hostname = str(parsed.hostname or "")
+
+        # Resolve via our independent DNS
+        ip = _resolve_host(hostname)
+
+        # Rewrite the URL to use the resolved IP, keep everything else
+        port_suffix = f":{parsed.port}" if parsed.port else ""
+        request.url = request.url.replace(
+            f"{parsed.scheme}://{parsed.hostname}{port_suffix}",
+            f"{parsed.scheme}://{ip}{port_suffix}",
+            1,
+        )
+
+        # Ensure the original Host header is set (required for virtual hosts / TLS SNI)
+        request.headers.setdefault("Host", hostname)
+
+        # Store the real hostname so init_poolmanager can use it for TLS SNI
+        self._real_hostname = hostname
+
+        return super().send(request, stream=stream, timeout=timeout,
+                            verify=verify, cert=cert, proxies=proxies)
+
+    def init_poolmanager(self, *args, **kwargs):
+        # Use the real hostname for TLS certificate validation and SNI
+        hostname = getattr(self, "_real_hostname", None)
+        if hostname:
+            kwargs["assert_hostname"] = hostname
+            kwargs["server_hostname"] = hostname
+        super().init_poolmanager(*args, **kwargs)
+
+
+def _build_session(token: str) -> requests.Session:
+    """Create a requests.Session that uses our independent DNS resolver."""
+    session = requests.Session()
+    session.headers.update({
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    })
+    adapter = _DirectDNSAdapter()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
 # ─── HTTP helpers ───────────────────────────────────────────────────
+
+# Global session, initialised in main()
+_session: requests.Session | None = None
 
 
 def _read_token() -> str:
@@ -52,26 +154,21 @@ def _api_request(
 ) -> dict | None:
     """Make an authenticated API request. Returns parsed JSON or None."""
     url = f"{API_ENDPOINT}{path}"
-    data = json.dumps(body).encode() if body else None
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    req = urllib.request.Request(url, data=data, headers=headers, method=method)
 
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as e:
-        body_text = ""
-        try:
-            body_text = e.read().decode()
-        except Exception:
-            pass
-        log.error("HTTP %d on %s %s: %s", e.code, method, path, body_text)
+        resp = _session.request(method, url, json=body, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.HTTPError as e:
+        body_text = e.response.text[:500] if e.response is not None else ""
+        log.error(
+            "HTTP %d on %s %s: %s",
+            e.response.status_code if e.response is not None else 0,
+            method, path, body_text,
+        )
         raise
-    except urllib.error.URLError as e:
-        log.error("Connection error on %s %s: %s", method, path, e.reason)
+    except requests.exceptions.ConnectionError as e:
+        log.error("Connection error on %s %s: %s", method, path, e)
         raise
 
 
@@ -171,7 +268,14 @@ def main():
         sys.exit(1)
 
     token = _read_token()
-    log.info("Agent started. Polling %s every %ds", API_ENDPOINT, POLL_INTERVAL)
+
+    global _session
+    _session = _build_session(token)
+
+    log.info(
+        "Agent started. Polling %s every %ds (DNS via %s)",
+        API_ENDPOINT, POLL_INTERVAL, ", ".join(DNS_SERVERS),
+    )
 
     backoff = POLL_INTERVAL
 

--- a/agent/cyberx-agent.py
+++ b/agent/cyberx-agent.py
@@ -11,14 +11,13 @@ Dependencies: dnspython, requests
 """
 import logging
 import os
+import socket
 import subprocess
 import sys
 import time
-from urllib.parse import urlparse
 
 import dns.resolver
 import requests
-from requests.adapters import HTTPAdapter
 
 # ─── Configuration ──────────────────────────────────────────────────
 
@@ -83,58 +82,39 @@ def _resolve_host(hostname: str) -> str:
         log.error("DNS resolution failed for %s: %s", hostname, e)
         raise
 
-# ─── HTTP session with custom DNS ──────────────────────────────────
+# ─── Patch socket DNS to use our resolver ─────────────────────────
+
+_original_getaddrinfo = socket.getaddrinfo
 
 
-class _DirectDNSAdapter(HTTPAdapter):
-    """Requests adapter that resolves hostnames via our own DNS resolver
-    and connects to the resolved IP while preserving the original Host
-    header and TLS SNI."""
+def _patched_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+    """Override socket.getaddrinfo to resolve via our external DNS.
 
-    def send(self, request, stream=False, timeout=None,
-             verify=True, cert=None, proxies=None):
-        parsed = urlparse(request.url)
-        hostname = str(parsed.hostname or "")
-
-        # Resolve via our independent DNS
-        ip = _resolve_host(hostname)
-
-        # Rewrite the URL to use the resolved IP, keep everything else
-        port_suffix = f":{parsed.port}" if parsed.port else ""
-        request.url = request.url.replace(
-            f"{parsed.scheme}://{parsed.hostname}{port_suffix}",
-            f"{parsed.scheme}://{ip}{port_suffix}",
-            1,
-        )
-
-        # Ensure the original Host header is set (required for virtual hosts / TLS SNI)
-        request.headers.setdefault("Host", hostname)
-
-        # Store the real hostname so init_poolmanager can use it for TLS SNI
-        self._real_hostname = hostname
-
-        return super().send(request, stream=stream, timeout=timeout,
-                            verify=verify, cert=cert, proxies=proxies)
-
-    def init_poolmanager(self, *args, **kwargs):
-        # Use the real hostname for TLS certificate validation and SNI
-        hostname = getattr(self, "_real_hostname", None)
-        if hostname:
-            kwargs["assert_hostname"] = hostname
-            kwargs["server_hostname"] = hostname
-        super().init_poolmanager(*args, **kwargs)
+    This ensures that all libraries (requests, urllib3, ssl) see the IP we
+    resolved, while TLS/SNI still uses the original hostname automatically
+    because requests/urllib3 pass the hostname for SNI separately.
+    """
+    try:
+        ip = _resolve_host(host)
+        # Return a result pointing at our resolved IP
+        return _original_getaddrinfo(ip, port, family, type, proto, flags)
+    except Exception:
+        # Fall back to system resolver if our DNS fails
+        log.warning("Custom DNS failed for %s, falling back to system", host)
+        return _original_getaddrinfo(host, port, family, type, proto, flags)
 
 
 def _build_session(token: str) -> requests.Session:
-    """Create a requests.Session that uses our independent DNS resolver."""
+    """Create a requests.Session with auth headers pre-configured."""
+    # Patch socket-level DNS so all connections use our resolver.
+    # TLS SNI is unaffected — urllib3 passes the hostname for SNI separately.
+    socket.getaddrinfo = _patched_getaddrinfo
+
     session = requests.Session()
     session.headers.update({
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     })
-    adapter = _DirectDNSAdapter()
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
     return session
 
 # ─── HTTP helpers ───────────────────────────────────────────────────

--- a/agent/cyberx-agent.service
+++ b/agent/cyberx-agent.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /opt/cyberx-agent/cyberx-agent.py
+ExecStart=/opt/cyberx-agent/.venv/bin/python3 /opt/cyberx-agent/cyberx-agent.py
 Restart=on-failure
 RestartSec=10
 EnvironmentFile=-/etc/cyberx-agent/agent.env

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,0 +1,2 @@
+dnspython>=2.4
+requests>=2.31

--- a/backend/app/api/routes/agent.py
+++ b/backend/app/api/routes/agent.py
@@ -65,6 +65,17 @@ async def download_agent_service_unit():
     return PlainTextResponse(path.read_text(), media_type="text/plain")
 
 
+@agent_router.get(
+    "/install/requirements.txt", response_class=PlainTextResponse
+)
+async def download_agent_requirements():
+    """Serve the agent requirements.txt (unauthenticated)."""
+    path = _AGENT_DIR / "requirements.txt"
+    if not path.exists():
+        raise not_found("Agent requirements")
+    return PlainTextResponse(path.read_text(), media_type="text/plain")
+
+
 @agent_router.get("/tasks", response_model=AgentTaskListResponse)
 async def poll_tasks(
     instance: Instance = Depends(get_current_agent_instance),

--- a/backend/app/api/routes/cloud_init_vpn.py
+++ b/backend/app/api/routes/cloud_init_vpn.py
@@ -96,7 +96,7 @@ async def get_instance_vpn_config(
         raise not_found("No VPN assigned to this instance")
 
     # Generate WireGuard config
-    config = await service.generate_wireguard_config(vpn)
+    config = await service.get_raw_config(vpn)
 
     logger.info("VPN config retrieved by instance %d (name: %s) from IP: %s",
                instance.id, instance.name, request.client.host if request.client else "unknown")

--- a/backend/app/api/routes/email.py
+++ b/backend/app/api/routes/email.py
@@ -135,7 +135,7 @@ async def send_vpn_config_email(
         raise bad_request("Participant does not have a VPN assigned")
 
     # Generate config
-    config = await vpn_service.generate_wireguard_config(vpn)
+    config = await vpn_service.get_raw_config(vpn)
     filename = vpn_service.get_config_filename(participant, vpn)
 
     # Send email with attachment

--- a/backend/app/api/routes/vpn.py
+++ b/backend/app/api/routes/vpn.py
@@ -432,7 +432,7 @@ async def download_participant_vpn_configs(
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
         for i, vpn in enumerate(credentials, 1):
-            config = await vpn_service.generate_wireguard_config(vpn)
+            config = await vpn_service.get_raw_config(vpn)
             filename = vpn_service.format_filename(naming_pattern, vpn, participant, i)
             zf.writestr(filename, config)
 
@@ -581,7 +581,7 @@ async def get_my_vpn_config(
     if not vpn:
         raise not_found("You do not have any VPN credentials")
 
-    config = await service.generate_wireguard_config(vpn)
+    config = await service.get_raw_config(vpn)
     filename = service.get_config_filename(current_user, vpn)
 
     return VPNConfigResponse(config=config, filename=filename)
@@ -617,7 +617,7 @@ async def download_my_vpn_config(
     setting = result.scalar_one_or_none()
     pattern = setting.value if setting else "simnet_{ipv4_address}.conf"
 
-    config = await service.generate_wireguard_config(vpn)
+    config = await service.get_raw_config(vpn)
     filename = service.format_filename(pattern, vpn, current_user)
 
     return PlainTextResponse(
@@ -649,7 +649,7 @@ async def download_all_my_vpn_configs(
 
     with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
         for i, vpn in enumerate(credentials, 1):
-            config = await service.generate_wireguard_config(vpn)
+            config = await service.get_raw_config(vpn)
             filename = service.format_filename(naming_pattern, vpn, current_user, i)
             zf.writestr(filename, config)
 
@@ -718,7 +718,7 @@ async def download_batch_configs(
 
     with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
         for i, vpn in enumerate(credentials, 1):
-            config = await service.generate_wireguard_config(vpn)
+            config = await service.get_raw_config(vpn)
             filename = service.format_filename(naming_pattern, vpn, current_user, i)
             zf.writestr(filename, config)
 

--- a/backend/app/models/vpn.py
+++ b/backend/app/models/vpn.py
@@ -33,7 +33,6 @@ class VPNCredential(Base):
     # Optional fields from original config (NULL if not present - preserves exact structure)
     mtu = Column(String(10), nullable=True)  # MTU from original config
     dns = Column(Text, nullable=True)  # DNS servers from original config
-    dns_commented = Column(Boolean, default=False)  # Whether DNS line was commented out in original config
     public_key = Column(Text, nullable=True)  # Server public key from original config
     allowed_ips = Column(Text, nullable=True)  # AllowedIPs from original config
     persistent_keepalive = Column(String(10), nullable=True)  # PersistentKeepalive from original config
@@ -53,6 +52,7 @@ class VPNCredential(Base):
 
     # Tracking
     file_hash = Column(String(64), nullable=True)
+    r2_key = Column(String(500), nullable=True)  # R2 object key for raw config file
     file_id = Column(String(50), nullable=True)
     run_id = Column(String(100), nullable=True)
     request_batch_id = Column(String(50), nullable=True)  # Tracks which request batch this VPN was assigned in

--- a/backend/app/models/vpn.py
+++ b/backend/app/models/vpn.py
@@ -33,6 +33,7 @@ class VPNCredential(Base):
     # Optional fields from original config (NULL if not present - preserves exact structure)
     mtu = Column(String(10), nullable=True)  # MTU from original config
     dns = Column(Text, nullable=True)  # DNS servers from original config
+    dns_commented = Column(Boolean, default=False)  # Whether DNS line was commented out in original config
     public_key = Column(Text, nullable=True)  # Server public key from original config
     allowed_ips = Column(Text, nullable=True)  # AllowedIPs from original config
     persistent_keepalive = Column(String(10), nullable=True)  # PersistentKeepalive from original config

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -154,7 +154,7 @@ class AgentService:
         await self.session.commit()
 
         # Generate WireGuard config
-        config = await vpn_svc.generate_wireguard_config(new_vpn)
+        config = await vpn_svc.get_raw_config(new_vpn)
 
         logger.info(
             "Cycled VPN for instance %d: old=%s new=%d (ip=%s)",

--- a/backend/app/services/vpn_service.py
+++ b/backend/app/services/vpn_service.py
@@ -1,4 +1,5 @@
 """VPN service for managing VPN credentials."""
+import logging
 import re
 import zipfile
 import io
@@ -13,6 +14,7 @@ from app.models.user import User
 from app.models.vpn import VPNCredential
 from app.config import get_settings
 
+logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
@@ -23,6 +25,65 @@ class VPNService:
     def __init__(self, session: AsyncSession):
         """Initialize VPN service."""
         self.session = session
+
+    # ─── R2 helpers ──────────────────────────────────────────────────
+
+    def _get_r2_client(self):
+        """Get an S3 client configured for Cloudflare R2."""
+        import boto3
+        from botocore.config import Config as BotoConfig
+        return boto3.client(
+            "s3",
+            endpoint_url=f"https://{settings.R2_ACCOUNT_ID}.r2.cloudflarestorage.com",
+            aws_access_key_id=settings.R2_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+            region_name="auto",
+            config=BotoConfig(signature_version="s3v4"),
+        )
+
+    def _upload_to_r2(self, key: str, data: bytes) -> bool:
+        """Upload raw VPN config to R2."""
+        try:
+            s3 = self._get_r2_client()
+            s3.put_object(Bucket=settings.R2_BUCKET, Key=key, Body=data, ContentType="text/plain")
+            logger.info("Uploaded VPN config to R2: %s", key)
+            return True
+        except Exception as e:
+            logger.error("R2 upload failed for %s: %s", key, e)
+            return False
+
+    def _download_from_r2(self, key: str) -> Optional[bytes]:
+        """Download raw VPN config from R2."""
+        try:
+            s3 = self._get_r2_client()
+            response = s3.get_object(Bucket=settings.R2_BUCKET, Key=key)
+            return response["Body"].read()
+        except Exception as e:
+            logger.error("R2 download failed for %s: %s", key, e)
+            return None
+
+    def _delete_from_r2(self, key: str) -> bool:
+        """Delete a VPN config from R2."""
+        try:
+            s3 = self._get_r2_client()
+            s3.delete_object(Bucket=settings.R2_BUCKET, Key=key)
+            return True
+        except Exception as e:
+            logger.error("R2 delete failed for %s: %s", key, e)
+            return False
+
+    @staticmethod
+    def _make_r2_key(credential_id: int) -> str:
+        return f"vpn-configs/{credential_id}.conf"
+
+    async def get_raw_config(self, vpn: VPNCredential) -> str:
+        """Get raw config content from R2, falling back to generated config."""
+        if vpn.r2_key:
+            data = self._download_from_r2(vpn.r2_key)
+            if data:
+                return data.decode('utf-8')
+            logger.warning("R2 download failed for VPN %d, falling back to generation", vpn.id)
+        return await self.generate_wireguard_config(vpn)
 
     async def get_credential(self, vpn_id: int) -> Optional[VPNCredential]:
         """Get a VPN credential by ID."""
@@ -624,7 +685,6 @@ class VPNService:
         preshared_key = None
         mtu = None
         dns = None
-        dns_commented = False
         public_key = None
         allowed_ips = None
         persistent_keepalive = None
@@ -665,7 +725,6 @@ class VPNService:
                 match = re.match(r'#\s*DNS\s*=\s*(.+)', line)
                 if match:
                     dns = match.group(1).strip()
-                    dns_commented = True
             elif line.startswith('PublicKey'):
                 match = re.match(r'PublicKey\s*=\s*(.+)', line)
                 if match:
@@ -745,7 +804,6 @@ class VPNService:
             # Optional fields from original config (NULL if not present)
             mtu=mtu,
             dns=dns,
-            dns_commented=dns_commented,
             public_key=public_key,
             allowed_ips=allowed_ips,
             persistent_keepalive=persistent_keepalive,
@@ -759,6 +817,18 @@ class VPNService:
         )
 
         self.session.add(vpn)
+        await self.session.flush()  # Get auto-generated ID for R2 key
+
+        # Upload raw config to R2
+        r2_key = self._make_r2_key(vpn.id)
+        if self._upload_to_r2(r2_key, config_content.encode('utf-8')):
+            vpn.r2_key = r2_key
+        else:
+            logger.warning(
+                "Failed to upload VPN %d config to R2, downloads will use fallback generation",
+                vpn.id,
+            )
+
         return vpn
 
     async def get_server_settings(self) -> dict:
@@ -828,9 +898,7 @@ class VPNService:
         final_keepalive = vpn.persistent_keepalive if vpn.persistent_keepalive is not None else "25"
 
         # Build optional lines only if they were present in original config
-        if vpn.dns is not None and vpn.dns_commented:
-            dns_line = f"# DNS = {final_dns}\n"
-        elif vpn.dns is not None:
+        if vpn.dns is not None:
             dns_line = f"DNS = {final_dns}\n"
         else:
             dns_line = ""
@@ -1002,6 +1070,10 @@ PublicKey = {final_public_key}
                     failed_ids.append(vpn_id)
                     errors.append(f"VPN {vpn_id}: Not found")
                     continue
+
+                # Delete raw config from R2
+                if vpn.r2_key:
+                    self._delete_from_r2(vpn.r2_key)
 
                 # Delete the credential
                 await self.session.delete(vpn)

--- a/backend/app/services/vpn_service.py
+++ b/backend/app/services/vpn_service.py
@@ -624,6 +624,7 @@ class VPNService:
         preshared_key = None
         mtu = None
         dns = None
+        dns_commented = False
         public_key = None
         allowed_ips = None
         persistent_keepalive = None
@@ -660,6 +661,11 @@ class VPNService:
                 match = re.match(r'DNS\s*=\s*(.+)', line)
                 if match:
                     dns = match.group(1).strip()
+            elif line.startswith('#') and 'DNS' in line:
+                match = re.match(r'#\s*DNS\s*=\s*(.+)', line)
+                if match:
+                    dns = match.group(1).strip()
+                    dns_commented = True
             elif line.startswith('PublicKey'):
                 match = re.match(r'PublicKey\s*=\s*(.+)', line)
                 if match:
@@ -739,6 +745,7 @@ class VPNService:
             # Optional fields from original config (NULL if not present)
             mtu=mtu,
             dns=dns,
+            dns_commented=dns_commented,
             public_key=public_key,
             allowed_ips=allowed_ips,
             persistent_keepalive=persistent_keepalive,
@@ -821,7 +828,12 @@ class VPNService:
         final_keepalive = vpn.persistent_keepalive if vpn.persistent_keepalive is not None else "25"
 
         # Build optional lines only if they were present in original config
-        dns_line = f"DNS = {final_dns}\n" if vpn.dns is not None else ""
+        if vpn.dns is not None and vpn.dns_commented:
+            dns_line = f"# DNS = {final_dns}\n"
+        elif vpn.dns is not None:
+            dns_line = f"DNS = {final_dns}\n"
+        else:
+            dns_line = ""
         mtu_line = f"MTU = {final_mtu}\n" if vpn.mtu is not None else ""
         table_line = f"Table = {vpn.table}\n" if vpn.table is not None else ""
         save_config_line = f"SaveConfig = {vpn.save_config}\n" if vpn.save_config is not None else ""

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -4,4 +4,4 @@
 # - MAJOR: Breaking changes or significant architectural changes
 # - MINOR: New features, functionality additions
 # - PATCH: Bug fixes, small improvements
-VERSION = "1.2.0"
+VERSION = "1.2.1"

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -4,4 +4,4 @@
 # - MAJOR: Breaking changes or significant architectural changes
 # - MINOR: New features, functionality additions
 # - PATCH: Bug fixes, small improvements
-VERSION = "1.2.1"
+VERSION = "1.3.0"

--- a/backend/migrations/versions/20260320_000000_add_vpn_dns_commented_flag.py
+++ b/backend/migrations/versions/20260320_000000_add_vpn_dns_commented_flag.py
@@ -1,0 +1,31 @@
+"""Add dns_commented flag to vpn_credentials
+
+Tracks whether the DNS line in the original WireGuard config was
+commented out (e.g. '# DNS = 10.0.0.1'), so downloads preserve
+the commented line instead of silently dropping it.
+
+Revision ID: 20260320_000000
+Revises: 20260316_000000
+Create Date: 2026-03-20 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20260320_000000'
+down_revision = '20260316_000000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'vpn_credentials',
+        sa.Column('dns_commented', sa.Boolean(), nullable=True, server_default=sa.text('false')),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('vpn_credentials', 'dns_commented')

--- a/backend/migrations/versions/20260321_000000_add_vpn_r2_key_drop_dns_commented.py
+++ b/backend/migrations/versions/20260321_000000_add_vpn_r2_key_drop_dns_commented.py
@@ -1,0 +1,36 @@
+"""Add r2_key to vpn_credentials, drop dns_commented
+
+Store raw VPN config files in R2 for byte-perfect downloads.
+The dns_commented flag is no longer needed since the raw file
+preserves all formatting.
+
+Revision ID: 20260321_000000
+Revises: 20260320_000000
+Create Date: 2026-03-21 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20260321_000000'
+down_revision = '20260320_000000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'vpn_credentials',
+        sa.Column('r2_key', sa.String(500), nullable=True),
+    )
+    op.drop_column('vpn_credentials', 'dns_commented')
+
+
+def downgrade() -> None:
+    op.add_column(
+        'vpn_credentials',
+        sa.Column('dns_commented', sa.Boolean(), server_default=sa.text('false'), nullable=True),
+    )
+    op.drop_column('vpn_credentials', 'r2_key')

--- a/backend/tests/unit/test_email_routes.py
+++ b/backend/tests/unit/test_email_routes.py
@@ -287,7 +287,7 @@ class TestSendVPNConfigEmailRoute:
 
         mock_vpn_service = mocker.Mock()
         mock_vpn_service.get_user_credential = mocker.AsyncMock(return_value=mock_vpn)
-        mock_vpn_service.generate_wireguard_config = mocker.AsyncMock(return_value="[Interface]\n...")
+        mock_vpn_service.get_raw_config = mocker.AsyncMock(return_value="[Interface]\n...")
         mock_vpn_service.get_config_filename = mocker.Mock(return_value="test_user.conf")
 
         mock_email_service = mocker.Mock()

--- a/backend/tests/unit/test_vpn_service.py
+++ b/backend/tests/unit/test_vpn_service.py
@@ -9,11 +9,21 @@ import pytest
 import zipfile
 import io
 from datetime import datetime, timezone
+from unittest.mock import patch
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.vpn_service import VPNService
 from app.models.user import User
 from app.models.vpn import VPNCredential
+
+
+@pytest.fixture(autouse=True)
+def mock_r2():
+    """Mock R2 operations for all VPN tests."""
+    with patch.object(VPNService, '_upload_to_r2', return_value=True), \
+         patch.object(VPNService, '_download_from_r2', return_value=None), \
+         patch.object(VPNService, '_delete_from_r2', return_value=True):
+        yield
 
 
 # Sample WireGuard configuration for testing

--- a/frontend/templates/pages/admin/events.html
+++ b/frontend/templates/pages/admin/events.html
@@ -629,7 +629,8 @@
         }
 
         // Download public key
-        const publicBlob = new Blob([publicKey], { type: 'text/plain' });
+        const pubText = publicKey.endsWith('\n') ? publicKey : publicKey + '\n';
+        const publicBlob = new Blob([pubText], { type: 'text/plain' });
         const publicUrl = URL.createObjectURL(publicBlob);
         const publicLink = document.createElement('a');
         publicLink.href = publicUrl;
@@ -639,7 +640,8 @@
 
         // Download private key
         setTimeout(() => {
-            const privateBlob = new Blob([privateKey], { type: 'text/plain' });
+            const privText = privateKey.endsWith('\n') ? privateKey : privateKey + '\n';
+            const privateBlob = new Blob([privText], { type: 'text/plain' });
             const privateUrl = URL.createObjectURL(privateBlob);
             const privateLink = document.createElement('a');
             privateLink.href = privateUrl;

--- a/frontend/templates/pages/participant/ssh_key.html
+++ b/frontend/templates/pages/participant/ssh_key.html
@@ -170,7 +170,8 @@ function downloadPrivateKey() {
         return;
     }
 
-    const blob = new Blob([privateKeyData], { type: 'text/plain' });
+    const keyText = privateKeyData.endsWith('\n') ? privateKeyData : privateKeyData + '\n';
+    const blob = new Blob([keyText], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;

--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,17 @@
-# Render.com Blueprint for CyberX Event Management System - STAGING
+# Render.com Blueprint for CyberX Event Management System - PRODUCTION
 # Deploys: FastAPI app + Background Worker
 # Uses Supabase for PostgreSQL (configured via environment variables)
 # Estimated cost: ~$14/month (2x $7 services)
 # Trigger: DATABASE_URL will be injected via GitHub Actions
 
 services:
-  # FastAPI Web Application - STAGING
+  # FastAPI Web Application - PRODUCTION
   - type: web
-    name: cyberx-event-mgmt-staging
+    name: cyberx-event-mgmt-production
     runtime: python
     region: virginia  # US East
     plan: starter  # $7/month - 512MB RAM (sufficient for 100 users)
-    branch: staging  # Staging service watches staging branch
+    branch: main  # Production deploys from main branch
     autoDeploy: false  # Disable auto deploy - only deploy via GitHub Actions
     buildCommand: |
       cd backend
@@ -25,7 +25,7 @@ services:
       - key: PYTHON_VERSION
         value: 3.12.8
       - key: ENVIRONMENT
-        value: staging
+        value: production
       - key: DEBUG
         value: "false"
       # Database - Supabase connection string (set manually in Render dashboard)
@@ -46,7 +46,7 @@ services:
       - key: SENDGRID_FROM_NAME
         value: CyberX Red Team
       - key: SENDGRID_SANDBOX_MODE
-        value: "true"  # STAGING: Sandbox mode
+        value: "false"  # PRODUCTION: Send real emails
       # SendGrid webhook verification
       - key: SENDGRID_WEBHOOK_VERIFICATION_KEY
         sync: false
@@ -59,26 +59,30 @@ services:
         value: 10.20.200.1
       - key: VPN_ALLOWED_IPS
         value: 10.0.0.0/8,fd00:a::/32
-      # Application configuration - STAGING URLs
+      # Application configuration - PRODUCTION URLs
       - key: FRONTEND_URL
-        value: https://staging.events.cyberxredteam.org
+        value: https://events.cyberxredteam.org
       - key: ALLOWED_HOSTS
-        value: staging.events.cyberxredteam.org
+        value: events.cyberxredteam.org
       - key: SESSION_EXPIRY_HOURS
         value: 24
-      - key: CSRF_TOKEN_MAX_AGE
-        value: 30
       - key: BULK_EMAIL_INTERVAL_MINUTES
-        value: 45
+        value: 15
       # Reminder configuration
+      - key: REMINDER_1_ENABLED
+        value: "true"
       - key: REMINDER_1_DAYS_AFTER_INVITE
         value: 7
       - key: REMINDER_1_MIN_DAYS_BEFORE_EVENT
         value: 14
+      - key: REMINDER_2_ENABLED
+        value: "false"
       - key: REMINDER_2_DAYS_AFTER_INVITE
         value: 14
       - key: REMINDER_2_MIN_DAYS_BEFORE_EVENT
         value: 7
+      - key: REMINDER_3_ENABLED
+        value: "true"
       - key: REMINDER_3_DAYS_BEFORE_EVENT
         value: 3
       - key: REMINDER_CHECK_INTERVAL_HOURS
@@ -102,7 +106,7 @@ services:
       - key: DISCORD_BOT_TOKEN
         sync: false
       - key: DISCORD_INVITE_ENABLED
-        value: "false"
+        value: "true"
       # PowerDNS configuration
       - key: POWERDNS_API_URL
         sync: false
@@ -146,7 +150,7 @@ services:
       - key: CPE_SIGNER_2_NAME
         sync: false
       - key: GOTENBERG_URL
-        value: http://cyberx-gotenberg-staging:3000
+        value: http://cyberx-gotenberg-production:3000
       # Render API (for sidecar lifecycle management)
       - key: RENDER_API_KEY
         sync: false
@@ -167,7 +171,7 @@ services:
 
   # Gotenberg - DOCX to PDF conversion for CPE certificates
   - type: pserv
-    name: cyberx-gotenberg-staging
+    name: cyberx-gotenberg-production
     runtime: docker
     region: virginia
     plan: standard


### PR DESCRIPTION
## Summary

- **Independent DNS resolver for cyberx-agent** — agent resolves DNS via external servers (Cloudflare/Google) using `dnspython`, bypassing `/etc/resolv.conf`. Prevents C2 frameworks and isolated-network DNS from blocking agent communication.
- **Raw VPN configs stored in R2** — uploaded configs are stored byte-for-byte in R2 and served as-is on download, ensuring SHA256 hashes always match. Falls back to generated config for pre-migration records.
- **Agent install endpoint for requirements.txt** — cloud-init can now fetch agent dependencies via `/api/agent/install/requirements.txt`.
- **Systemd service updated** to run agent from a virtualenv (`/opt/cyberx-agent/.venv/bin/python3`).
- **Removed `dns_commented` column** — no longer needed since raw R2 files preserve all original formatting.

## Commits

- `4f33498` Fix downloaded VPN configs dropping commented DNS line and SSH key missing trailing newline
- `006f7c7` Add independent DNS resolver to cyberx-agent, bump to v1.3.0
- `d1a4d29` Add /install/requirements.txt endpoint and update service to use venv
- `b337e98` Fix TLS/SNI failure by patching socket.getaddrinfo instead of rewriting URLs
- `5214953` Store raw VPN configs in R2 for byte-perfect downloads

## Test plan

- [x] 572 tests passing, 13 skipped (pre-existing DB isolation skips)
- [ ] Verify agent connects and polls successfully on a test instance
- [ ] Verify VPN config download hash matches uploaded file
- [ ] Verify VPN cycle task returns raw config from R2
- [ ] Run migration on staging DB (`r2_key` added, `dns_commented` dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)