### PR TITLE
feat: add nginx redirector management module

### DIFF
--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -1,0 +1,742 @@
+"""REST API routes for Redirector and StreamConfig management.
+
+All endpoints require admin authentication via get_current_admin_user.
+POST / PUT / DELETE operations require the X-CSRF-Token header (enforced
+by the global CSRFMiddleware — no per-route action needed).
+
+SSH private keys are NEVER returned in responses — always "**REDACTED**".
+Decrypted keys exist only as local variables inside route handlers and are
+passed directly to SSHService without logging or caching.
+
+Error mapping from SSHService exceptions:
+    SSHConnectionError  → 503 Service Unavailable
+    SSHAuthError        → 422 Unprocessable Entity
+    NginxTestError      → 200 OK with success=False (operator must see nginx output)
+    NginxReloadError    → 500 Internal Server Error
+"""
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_current_admin_user, get_db
+from app.models.user import User
+from app.models.redirector import Redirector, StreamConfig
+from app.schemas.redirector import (
+    RedirectorCreate, RedirectorUpdate, RedirectorOut, RedirectorListOut,
+    StreamConfigCreate, StreamConfigUpdate, StreamConfigOut,
+    DeployResult, TestConnectionResult, ConfigPreview,
+)
+from app.services.redirector_service import RedirectorService
+from app.services.ssh_service import (
+    SSHService,
+    SSHConnectionError, SSHAuthError, NginxReloadError, SSHCommandError,
+    run_test_connection, run_deploy_single, run_remove_single, run_deploy_all,
+    run_check_port, run_check_nginx_setup, run_fix_nginx_setup,
+    run_check_prereqs, run_fix_prereqs,
+)
+from app.services.nginx_config_service import generate_stream_config_preview
+from app.services.audit_service import AuditService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/redirectors", tags=["Redirectors"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_redirector_out(redirector: Redirector) -> RedirectorOut:
+    """Build RedirectorOut from ORM object, always redacting key fields."""
+    return RedirectorOut(
+        id=redirector.id,
+        name=redirector.name,
+        current_ip=redirector.current_ip,
+        ssh_port=redirector.ssh_port,
+        ssh_username=redirector.ssh_username,
+        ssh_private_key="**REDACTED**",
+        ssh_key_passphrase="**REDACTED**" if redirector.ssh_key_passphrase else None,
+        nginx_stream_dir=redirector.nginx_stream_dir,
+        notes=redirector.notes,
+        status=redirector.status,
+        last_deployed_at=redirector.last_deployed_at,
+        last_tested_at=redirector.last_tested_at,
+        stream_count=redirector.stream_count,
+        created_at=redirector.created_at,
+        updated_at=redirector.updated_at,
+    )
+
+
+def _make_ssh_service(svc: RedirectorService, redirector: Redirector) -> SSHService:
+    """Decrypt SSH credentials and return an SSHService instance."""
+    return SSHService(
+        hostname=redirector.current_ip,
+        port=redirector.ssh_port,
+        username=redirector.ssh_username,
+        private_key_pem=svc.get_decrypted_key(redirector),
+        passphrase=svc.get_decrypted_passphrase(redirector),
+    )
+
+
+def _ssh_connection_error(exc: SSHConnectionError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=f"Could not connect to redirector: {exc}",
+    )
+
+
+def _ssh_auth_error(exc: SSHAuthError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail=f"SSH authentication failed: {exc}",
+    )
+
+
+def _ssh_command_error(exc: Exception) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=f"SSH command error: {exc}",
+    )
+
+
+async def _get_redirector_or_404(
+    redirector_id: str, svc: RedirectorService
+) -> Redirector:
+    redir = await svc.get_redirector(redirector_id)
+    if not redir:
+        raise HTTPException(status_code=404, detail="Redirector not found.")
+    return redir
+
+
+async def _get_stream_or_404(
+    stream_id: str, redirector_id: str, svc: RedirectorService
+) -> StreamConfig:
+    stream = await svc.get_stream(stream_id, redirector_id)
+    if not stream:
+        raise HTTPException(status_code=404, detail="Stream config not found.")
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# Redirector CRUD
+# ---------------------------------------------------------------------------
+
+@router.get("/", response_model=RedirectorListOut)
+async def list_redirectors(
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all redirectors."""
+    svc = RedirectorService(db)
+    redirectors = await svc.list_redirectors()
+    return RedirectorListOut(
+        redirectors=[_build_redirector_out(r) for r in redirectors],
+        total=len(redirectors),
+    )
+
+
+@router.post("/", response_model=RedirectorOut, status_code=status.HTTP_201_CREATED)
+async def create_redirector(
+    payload: RedirectorCreate,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new redirector. SSH private key is encrypted before storage."""
+    svc = RedirectorService(db)
+
+    # Uniqueness check
+    existing = await svc.get_redirector_by_name(payload.name)
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A redirector named '{payload.name}' already exists.",
+        )
+
+    redirector = await svc.create_redirector(payload.model_dump())
+
+    audit = AuditService(db)
+    await audit.log(
+        action="REDIRECTOR_CREATE",
+        user_id=current_user.id,
+        resource_type="REDIRECTOR",
+        details={"redirector_id": redirector.id, "name": redirector.name},
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return _build_redirector_out(redirector)
+
+
+@router.get("/{redirector_id}", response_model=RedirectorOut)
+async def get_redirector(
+    redirector_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a single redirector with its stream count."""
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    return _build_redirector_out(redirector)
+
+
+@router.put("/{redirector_id}", response_model=RedirectorOut)
+async def update_redirector(
+    redirector_id: str,
+    payload: RedirectorUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update a redirector. Omit ssh_private_key to keep the existing key.
+    Send an empty string for ssh_key_passphrase to clear it.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    redirector = await svc.update_redirector(
+        redirector, payload.model_dump(exclude_unset=True)
+    )
+
+    audit = AuditService(db)
+    await audit.log(
+        action="REDIRECTOR_UPDATE",
+        user_id=current_user.id,
+        resource_type="REDIRECTOR",
+        details={"redirector_id": redirector_id},
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return _build_redirector_out(redirector)
+
+
+@router.delete("/{redirector_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_redirector(
+    redirector_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a redirector and all its stream configs (cascade). Does not remove remote files."""
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    name = redirector.name
+    await svc.delete_redirector(redirector)
+
+    audit = AuditService(db)
+    await audit.log(
+        action="REDIRECTOR_DELETE",
+        user_id=current_user.id,
+        resource_type="REDIRECTOR",
+        details={"redirector_id": redirector_id, "name": name},
+        ip_address=request.client.host if request.client else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SSH operations on redirectors
+# ---------------------------------------------------------------------------
+
+@router.post("/{redirector_id}/test-connection", response_model=TestConnectionResult)
+async def test_connection(
+    redirector_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    SSH connect to the redirector and verify nginx stream module presence.
+    Updates the redirector status (online/offline) and last_tested_at.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+
+    try:
+        result = await run_test_connection(ssh)
+    except SSHConnectionError as e:
+        await svc.update_status(redirector, "offline")
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        await svc.update_status(redirector, "offline")
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError, Exception) as e:
+        await svc.update_status(redirector, "offline")
+        raise _ssh_command_error(e)
+
+    new_status = "online" if result["success"] else "offline"
+    await svc.update_status(redirector, new_status)
+
+    audit = AuditService(db)
+    await audit.log(
+        action="REDIRECTOR_TEST",
+        user_id=current_user.id,
+        resource_type="REDIRECTOR",
+        details={
+            "redirector_id": redirector_id,
+            "success": result["success"],
+            "stream_module_present": result.get("stream_module_present"),
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return TestConnectionResult(**result)
+
+
+@router.post("/{redirector_id}/check-nginx-setup")
+async def check_nginx_setup(
+    redirector_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    SSH into the redirector and check for common nginx config issues:
+    default site active (port 80) and stream block presence.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+    try:
+        return await run_check_nginx_setup(ssh)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except Exception as e:
+        raise _ssh_command_error(e)
+
+
+@router.post("/{redirector_id}/fix-nginx-setup")
+async def fix_nginx_setup(
+    redirector_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    SSH into the redirector and fix common nginx config issues:
+    remove sites-enabled/default, add stream block to nginx.conf, reload nginx.
+
+    Requires additional sudoers entry on the redirector:
+        <user> ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix.sh
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+    try:
+        return await run_fix_nginx_setup(ssh, redirector.nginx_stream_dir)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except Exception as e:
+        raise _ssh_command_error(e)
+
+
+@router.post("/{redirector_id}/check-prereqs")
+async def check_prereqs(
+    redirector_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Check that all CyberX prerequisites are met on the redirector."""
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+    try:
+        return await run_check_prereqs(ssh, redirector.nginx_stream_dir)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except Exception as e:
+        raise _ssh_command_error(e)
+
+
+@router.post("/{redirector_id}/fix-prereqs")
+async def fix_prereqs(
+    redirector_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Attempt to automatically satisfy CyberX prerequisites on the redirector.
+    Requires the SSH user to have sudo access (NOPASSWD preferred).
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+    try:
+        return await run_fix_prereqs(ssh, redirector.nginx_stream_dir)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except Exception as e:
+        raise _ssh_command_error(e)
+
+
+@router.post("/{redirector_id}/check-port")
+async def check_port(
+    redirector_id: str,
+    body: dict,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    SSH into the redirector and check whether a port is already in use.
+    Body: {"port": int, "protocol": "tcp"|"udp"|"dns"}
+    Returns: {"in_use": bool, "listeners": [...], "message": str}
+    """
+    port = body.get("port")
+    protocol = body.get("protocol", "tcp")
+    if not isinstance(port, int) or not (1 <= port <= 65535):
+        raise HTTPException(status_code=422, detail="port must be an integer between 1 and 65535.")
+
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+
+    try:
+        result = await run_check_port(ssh, port, protocol)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except Exception as e:
+        raise _ssh_command_error(e)
+
+    return result
+
+
+@router.post("/{redirector_id}/deploy-all", response_model=DeployResult)
+async def deploy_all(
+    redirector_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Sync all stream configs for this redirector:
+    write enabled, delete disabled, remove orphans, reload nginx.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    streams = await svc.list_streams(redirector_id)
+    ssh = _make_ssh_service(svc, redirector)
+
+    try:
+        result = await run_deploy_all(ssh, redirector.nginx_stream_dir, streams)
+    except SSHConnectionError as e:
+        await svc.update_status(redirector, "offline")
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError, Exception) as e:
+        raise _ssh_command_error(e)
+
+    if result["success"]:
+        await svc.update_status(redirector, "online")
+        await svc.update_deployed_at(redirector)
+
+    audit = AuditService(db)
+    await audit.log(
+        action="REDIRECTOR_DEPLOY_ALL",
+        user_id=current_user.id,
+        resource_type="REDIRECTOR",
+        details={
+            "redirector_id": redirector_id,
+            "success": result["success"],
+            "files_written": result["files_written"],
+            "files_deleted": result["files_deleted"],
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return DeployResult(**result)
+
+
+# ---------------------------------------------------------------------------
+# StreamConfig CRUD
+# ---------------------------------------------------------------------------
+
+@router.get("/{redirector_id}/streams", response_model=List[StreamConfigOut])
+async def list_streams(
+    redirector_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all stream configs for a redirector."""
+    svc = RedirectorService(db)
+    await _get_redirector_or_404(redirector_id, svc)
+    streams = await svc.list_streams(redirector_id)
+    return [StreamConfigOut.model_validate(s) for s in streams]
+
+
+@router.post(
+    "/{redirector_id}/streams",
+    response_model=StreamConfigOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_stream(
+    redirector_id: str,
+    payload: StreamConfigCreate,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a stream config for a redirector (does not deploy immediately)."""
+    svc = RedirectorService(db)
+    await _get_redirector_or_404(redirector_id, svc)
+    stream = await svc.create_stream(redirector_id, payload.model_dump())
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_CREATE",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={
+            "stream_id": stream.id,
+            "redirector_id": redirector_id,
+            "name": stream.name,
+            "protocol": stream.protocol,
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return StreamConfigOut.model_validate(stream)
+
+
+@router.get("/{redirector_id}/streams/{stream_id}", response_model=StreamConfigOut)
+async def get_stream(
+    redirector_id: str,
+    stream_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get a single stream config."""
+    svc = RedirectorService(db)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+    return StreamConfigOut.model_validate(stream)
+
+
+@router.put("/{redirector_id}/streams/{stream_id}", response_model=StreamConfigOut)
+async def update_stream(
+    redirector_id: str,
+    stream_id: str,
+    payload: StreamConfigUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a stream config (does not redeploy automatically)."""
+    svc = RedirectorService(db)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+    stream = await svc.update_stream(stream, payload.model_dump(exclude_unset=True))
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_UPDATE",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={"stream_id": stream_id, "redirector_id": redirector_id},
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return StreamConfigOut.model_validate(stream)
+
+
+@router.delete(
+    "/{redirector_id}/streams/{stream_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_stream(
+    redirector_id: str,
+    stream_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a stream config from the database (does not remove remote file)."""
+    svc = RedirectorService(db)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+    name = stream.name
+    await svc.delete_stream(stream)
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_DELETE",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={"stream_id": stream_id, "redirector_id": redirector_id, "name": name},
+        ip_address=request.client.host if request.client else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# SSH operations on individual streams
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/{redirector_id}/streams/{stream_id}/preview",
+    response_model=ConfigPreview,
+)
+async def preview_stream(
+    redirector_id: str,
+    stream_id: str,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the generated nginx config text without performing any SSH operation."""
+    svc = RedirectorService(db)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+    content = generate_stream_config_preview(stream)
+    return ConfigPreview(filename=stream.filename, content=content)
+
+
+@router.post("/{redirector_id}/streams/{stream_id}/enable", response_model=DeployResult)
+async def enable_stream(
+    redirector_id: str,
+    stream_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Mark a stream as enabled, write its config file to the redirector, and reload nginx.
+    Rolls back (deletes the file) if nginx -t fails — stream stays enabled in DB on rollback
+    so the operator can fix the config and retry.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+
+    stream = await svc.update_stream(stream, {"enabled": True})
+    ssh = _make_ssh_service(svc, redirector)
+
+    try:
+        result = await run_deploy_single(ssh, redirector.nginx_stream_dir, stream)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError, Exception) as e:
+        raise _ssh_command_error(e)
+
+    if result["success"]:
+        await svc.update_deployed_at(redirector)
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_ENABLE",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={
+            "stream_id": stream_id,
+            "redirector_id": redirector_id,
+            "success": result["success"],
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return DeployResult(**result)
+
+
+@router.post("/{redirector_id}/streams/{stream_id}/deploy", response_model=DeployResult)
+async def deploy_stream(
+    redirector_id: str,
+    stream_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Write a single stream config file to the redirector and reload nginx.
+    Rolls back (deletes the file) if nginx -t fails.
+    Returns HTTP 200 with success=False if nginx test fails (operator sees output).
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+
+    if not stream.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Stream is disabled. Enable it before deploying.",
+        )
+
+    ssh = _make_ssh_service(svc, redirector)
+
+    try:
+        result = await run_deploy_single(ssh, redirector.nginx_stream_dir, stream)
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError, Exception) as e:
+        raise _ssh_command_error(e)
+
+    if result["success"]:
+        await svc.update_deployed_at(redirector)
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_DEPLOY",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={
+            "stream_id": stream_id,
+            "redirector_id": redirector_id,
+            "success": result["success"],
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return DeployResult(**result)
+
+
+@router.post("/{redirector_id}/streams/{stream_id}/remove", response_model=DeployResult)
+async def remove_stream_file(
+    redirector_id: str,
+    stream_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Remove a stream config file from the redirector and reload nginx.
+    Does not delete the StreamConfig from the database — use DELETE for that.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_redirector_or_404(redirector_id, svc)
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+    ssh = _make_ssh_service(svc, redirector)
+
+    try:
+        result = await run_remove_single(
+            ssh, redirector.nginx_stream_dir, stream_id, stream.name
+        )
+    except SSHConnectionError as e:
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError, Exception) as e:
+        raise _ssh_command_error(e)
+
+    if result["success"]:
+        await svc.update_stream(stream, {"enabled": False})
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_DISABLE",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={
+            "stream_id": stream_id,
+            "redirector_id": redirector_id,
+            "success": result["success"],
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return DeployResult(**result)

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -26,7 +26,7 @@ from app.models.redirector import Redirector, StreamConfig
 from app.schemas.redirector import (
     RedirectorCreate, RedirectorUpdate, RedirectorOut, RedirectorListOut,
     StreamConfigCreate, StreamConfigUpdate, StreamConfigOut,
-    DeployResult, TestConnectionResult, ConfigPreview,
+    DeployResult, TestConnectionResult, ConfigPreview, CheckPortRequest,
 )
 from app.services.redirector_service import RedirectorService
 from app.services.ssh_service import (
@@ -261,7 +261,7 @@ async def test_connection(
     except SSHAuthError as e:
         await svc.update_status(redirector, "offline")
         raise _ssh_auth_error(e)
-    except (NginxReloadError, SSHCommandError, Exception) as e:
+    except (NginxReloadError, SSHCommandError) as e:
         await svc.update_status(redirector, "offline")
         raise _ssh_command_error(e)
 
@@ -303,7 +303,7 @@ async def check_nginx_setup(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except Exception as e:
+    except (SSHCommandError, NginxReloadError) as e:
         raise _ssh_command_error(e)
 
 
@@ -329,7 +329,7 @@ async def fix_nginx_setup(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except Exception as e:
+    except (SSHCommandError, NginxReloadError) as e:
         raise _ssh_command_error(e)
 
 
@@ -349,7 +349,7 @@ async def check_prereqs(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except Exception as e:
+    except (SSHCommandError, NginxReloadError) as e:
         raise _ssh_command_error(e)
 
 
@@ -372,38 +372,32 @@ async def fix_prereqs(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except Exception as e:
+    except (SSHCommandError, NginxReloadError) as e:
         raise _ssh_command_error(e)
 
 
 @router.post("/{redirector_id}/check-port")
 async def check_port(
     redirector_id: str,
-    body: dict,
+    body: CheckPortRequest,
     current_user: User = Depends(get_current_admin_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
     SSH into the redirector and check whether a port is already in use.
-    Body: {"port": int, "protocol": "tcp"|"udp"|"dns"}
     Returns: {"in_use": bool, "listeners": [...], "message": str}
     """
-    port = body.get("port")
-    protocol = body.get("protocol", "tcp")
-    if not isinstance(port, int) or not (1 <= port <= 65535):
-        raise HTTPException(status_code=422, detail="port must be an integer between 1 and 65535.")
-
     svc = RedirectorService(db)
     redirector = await _get_redirector_or_404(redirector_id, svc)
     ssh = _make_ssh_service(svc, redirector)
 
     try:
-        result = await run_check_port(ssh, port, protocol)
+        result = await run_check_port(ssh, body.port, body.protocol)
     except SSHConnectionError as e:
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except Exception as e:
+    except (SSHCommandError, NginxReloadError) as e:
         raise _ssh_command_error(e)
 
     return result
@@ -432,7 +426,7 @@ async def deploy_all(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except (NginxReloadError, SSHCommandError, Exception) as e:
+    except (NginxReloadError, SSHCommandError) as e:
         raise _ssh_command_error(e)
 
     if result["success"]:
@@ -620,7 +614,7 @@ async def enable_stream(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except (NginxReloadError, SSHCommandError, Exception) as e:
+    except (NginxReloadError, SSHCommandError) as e:
         raise _ssh_command_error(e)
 
     if result["success"]:
@@ -673,7 +667,7 @@ async def deploy_stream(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except (NginxReloadError, SSHCommandError, Exception) as e:
+    except (NginxReloadError, SSHCommandError) as e:
         raise _ssh_command_error(e)
 
     if result["success"]:
@@ -720,7 +714,7 @@ async def remove_stream_file(
         raise _ssh_connection_error(e)
     except SSHAuthError as e:
         raise _ssh_auth_error(e)
-    except (NginxReloadError, SSHCommandError, Exception) as e:
+    except (NginxReloadError, SSHCommandError) as e:
         raise _ssh_command_error(e)
 
     if result["success"]:

--- a/backend/app/api/routes/redirectors_pages.py
+++ b/backend/app/api/routes/redirectors_pages.py
@@ -1,0 +1,72 @@
+"""HTML page routes for the Redirector Manager UI.
+
+These routes serve Jinja2 templates. They are separate from the REST API
+routes in redirectors.py and should be included alongside views.py in main.py.
+
+Integration in main.py:
+    from app.api.routes import redirectors as redirectors_api
+    from app.api.routes import redirectors_pages
+    app.include_router(redirectors_api.router)
+    app.include_router(redirectors_pages.router)
+"""
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app.dependencies import get_current_admin_user
+from app.models.user import User
+from app.services.redirector_service import RedirectorService
+from app.dependencies import get_db
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(tags=["Redirector Pages"])
+
+# Template path matches the main app's views.py template resolution
+_templates_path = Path(__file__).parent.parent.parent.parent.parent.parent / "frontend" / "templates"
+templates = Jinja2Templates(directory=str(_templates_path))
+
+
+@router.get("/admin/redirectors", response_class=HTMLResponse)
+async def redirectors_list_page(
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+):
+    """Render the redirectors list page."""
+    return templates.TemplateResponse(
+        "pages/redirectors/list.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "active_page": "redirectors",
+            "now": datetime.now(),
+        },
+    )
+
+
+@router.get("/admin/redirectors/{redirector_id}", response_class=HTMLResponse)
+async def redirector_detail_page(
+    redirector_id: str,
+    request: Request,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Render the redirector detail page with stream configs."""
+    svc = RedirectorService(db)
+    redirector = await svc.get_redirector(redirector_id)
+    if not redirector:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail="Redirector not found.")
+
+    return templates.TemplateResponse(
+        "pages/redirectors/detail.html",
+        {
+            "request": request,
+            "current_user": current_user,
+            "active_page": "redirectors",
+            "redirector": redirector,
+            "now": datetime.now(),
+        },
+    )

--- a/backend/app/api/routes/redirectors_pages.py
+++ b/backend/app/api/routes/redirectors_pages.py
@@ -14,19 +14,15 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
-from fastapi.templating import Jinja2Templates
 
 from app.dependencies import get_current_admin_user
 from app.models.user import User
 from app.services.redirector_service import RedirectorService
 from app.dependencies import get_db
+from app.api.routes.views import templates
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter(tags=["Redirector Pages"])
-
-# Template path matches the main app's views.py template resolution
-_templates_path = Path(__file__).parent.parent.parent.parent.parent.parent / "frontend" / "templates"
-templates = Jinja2Templates(directory=str(_templates_path))
 
 
 @router.get("/admin/redirectors", response_class=HTMLResponse)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,8 @@ from app.api.routes import admin_actions, participant_actions, admin_keycloak, a
 from app.api.routes import admin_tls, participant_tls, admin_roles
 from app.api.routes.agent import agent_router, participant_router as agent_participant_router, admin_router as agent_admin_router
 from app.api.routes import bot as bot_routes, admin_api_keys
+from app.api.routes import redirectors as redirectors_routes
+from app.api.routes import redirectors_pages
 from app.tasks import start_scheduler, stop_scheduler
 from app.utils.encryption import init_encryptor, generate_encryption_key
 from cryptography.fernet import Fernet
@@ -228,6 +230,8 @@ csrf_exempt_urls = [
     "/api/license/queue/release",  # VM-facing queue release (Bearer token auth)
     "/api/agent/*",                # Agent endpoints (Bearer token auth)
     "/api/bot/*",                  # Bot endpoints (Bearer token auth)
+    "/api/redirectors",            # Redirector API (X-API-Key auth)
+    "/api/redirectors/*",          # Redirector API (X-API-Key auth)
 ]
 
 app.add_middleware(
@@ -279,6 +283,8 @@ app.include_router(agent_participant_router)  # Participant agent task managemen
 app.include_router(agent_admin_router)  # Admin agent task management
 app.include_router(bot_routes.router)  # External bot API (Discord verification)
 app.include_router(admin_api_keys.router)  # Admin API key management
+app.include_router(redirectors_routes.router)   # Redirector REST API
+app.include_router(redirectors_pages.router)    # Redirector web UI pages
 
 # Include view routes (HTML pages)
 app.include_router(views.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -230,8 +230,7 @@ csrf_exempt_urls = [
     "/api/license/queue/release",  # VM-facing queue release (Bearer token auth)
     "/api/agent/*",                # Agent endpoints (Bearer token auth)
     "/api/bot/*",                  # Bot endpoints (Bearer token auth)
-    "/api/redirectors",            # Redirector API (X-API-Key auth)
-    "/api/redirectors/*",          # Redirector API (X-API-Key auth)
+    # Redirector API: CSRF bypass handled in middleware when X-API-Key header is present
 ]
 
 app.add_middleware(

--- a/backend/app/middleware/csrf.py
+++ b/backend/app/middleware/csrf.py
@@ -108,11 +108,6 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         """Process request with CSRF protection."""
-        # Skip CSRF check if X-API-Key header is present (stateless API auth)
-        if request.headers.get("X-API-Key"):
-            response = await call_next(request)
-            return response
-
         # Get or create CSRF token, regenerating if expired
         csrf_token = request.cookies.get(self.cookie_name)
         new_token_needed = False

--- a/backend/app/middleware/csrf.py
+++ b/backend/app/middleware/csrf.py
@@ -108,6 +108,11 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         """Process request with CSRF protection."""
+        # Skip CSRF check if X-API-Key header is present (stateless API auth)
+        if request.headers.get("X-API-Key"):
+            response = await call_next(request)
+            return response
+
         # Get or create CSRF token, regenerating if expired
         csrf_token = request.cookies.get(self.cookie_name)
         new_token_needed = False

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -58,4 +58,8 @@ __all__ = [
     "TLSCertificateStatus",
     "AgentTask",
     "ServiceAPIKey",
+    "Redirector",
+    "StreamConfig",
+    "RedirectorStatus",
+    "StreamProtocol",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,9 @@ from app.models.cpe_certificate import CPECertificate, CertificateStatus
 from app.models.tls_certificate import CAChain, CAChainStatus, TLSCertificate, TLSCertificateStatus
 from app.models.agent_task import AgentTask
 from app.models.service_api_key import ServiceAPIKey
+from app.models.redirector import (  # noqa: F401
+    Redirector, StreamConfig, RedirectorStatus, StreamProtocol,
+)
 
 __all__ = [
     "Role",

--- a/backend/app/models/redirector.py
+++ b/backend/app/models/redirector.py
@@ -1,0 +1,143 @@
+"""Redirector and StreamConfig ORM models for nginx stream proxy management."""
+import enum
+import uuid
+
+from sqlalchemy import (
+    Column, String, Boolean, Integer, TIMESTAMP, Text, ForeignKey, Index, JSON,
+    UniqueConstraint,
+)
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class RedirectorStatus(str, enum.Enum):
+    """Connectivity status of a redirector, updated by test-connection and deploy."""
+    UNKNOWN = "unknown"
+    ONLINE = "online"
+    OFFLINE = "offline"
+
+
+class StreamProtocol(str, enum.Enum):
+    """Protocol for a stream config."""
+    TCP = "tcp"
+    UDP = "udp"
+    DNS = "dns"   # UDP on port 53 + proxy_responses 1
+
+
+class Redirector(Base):
+    """
+    A remote nginx redirector server managed via SSH.
+
+    SSH private key and optional passphrase are stored Fernet-encrypted.
+    The nginx_stream_dir must already be included in nginx.conf via:
+        stream { include /etc/nginx/stream.d/*.conf; }
+    This app only writes/deletes files inside stream_dir — never touches nginx.conf.
+    """
+    __tablename__ = "redirectors"
+    __table_args__ = {'extend_existing': True}
+
+    id = Column(String(36), primary_key=True, default=_new_uuid)
+    name = Column(String(255), unique=True, nullable=False, index=True)
+    current_ip = Column(String(45), nullable=False)
+    ssh_port = Column(Integer, nullable=False, default=22)
+    ssh_username = Column(String(255), nullable=False)
+
+    # Fernet-encrypted at rest. Decrypted only in route handler scope, never logged.
+    ssh_private_key = Column(Text, nullable=False)
+    ssh_key_passphrase = Column(Text, nullable=True)   # nullable — passphrase is optional
+
+    # Directory where individual .conf files are written (must exist on redirector)
+    nginx_stream_dir = Column(String(500), nullable=False, default="/etc/nginx/stream.d")
+
+    notes = Column(Text, nullable=True)
+
+    # Updated by test-connection and deploy operations
+    status = Column(String(20), nullable=False, default=RedirectorStatus.UNKNOWN.value)
+    last_deployed_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    last_tested_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    stream_configs = relationship(
+        "StreamConfig",
+        back_populates="redirector",
+        cascade="all, delete-orphan",
+    )
+
+    @property
+    def stream_count(self) -> int:
+        """Number of associated stream configs (requires eager load)."""
+        return len(self.stream_configs) if self.stream_configs is not None else 0
+
+    def __repr__(self):
+        return f"<Redirector(id={self.id}, name={self.name!r}, status={self.status})>"
+
+
+class StreamConfig(Base):
+    """
+    A single nginx stream server block, written to cyberx_<id>.conf on the redirector.
+
+    Each enabled StreamConfig results in one file in the redirector's stream_dir.
+    Disabled StreamConfigs have their file deleted from the remote server.
+    """
+    __tablename__ = "stream_configs"
+    __table_args__ = {'extend_existing': True}
+
+    id = Column(String(36), primary_key=True, default=_new_uuid)
+    redirector_id = Column(
+        String(36),
+        ForeignKey("redirectors.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    name = Column(String(255), nullable=False)
+    protocol = Column(String(10), nullable=False, default=StreamProtocol.TCP.value)
+    listen_port = Column(Integer, nullable=False)
+    cs_ip = Column(String(255), nullable=False)   # CS teamserver IP or hostname
+    cs_port = Column(Integer, nullable=False)
+
+    # Access control: allow/deny by CIDR
+    access_control_enabled = Column(Boolean, nullable=False, default=False)
+    allowed_cidrs = Column(JSON, nullable=True)   # list[str], e.g. ["10.0.0.0/8", "1.2.3.4"]
+
+    # SSL/TLS termination (TCP only; ignored for UDP/DNS)
+    ssl_enabled = Column(Boolean, nullable=False, default=False)
+    ssl_cert_path = Column(String(500), nullable=True)
+    ssl_key_path = Column(String(500), nullable=True)
+    ssl_protocols = Column(String(100), nullable=False, default="TLSv1.2 TLSv1.3")
+    ssl_ciphers = Column(String(200), nullable=False, default="HIGH:!aNULL:!MD5")
+
+    # If False, the .conf file is removed from the remote redirector
+    enabled = Column(Boolean, nullable=False, default=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    redirector = relationship("Redirector", back_populates="stream_configs")
+
+    @property
+    def filename(self) -> str:
+        """Remote filename for this stream config."""
+        return f"cyberx_{self.id}.conf"
+
+    def __repr__(self):
+        return (
+            f"<StreamConfig(id={self.id}, name={self.name!r}, "
+            f"protocol={self.protocol}, port={self.listen_port})>"
+        )

--- a/backend/app/models/redirector.py
+++ b/backend/app/models/redirector.py
@@ -92,7 +92,10 @@ class StreamConfig(Base):
     Disabled StreamConfigs have their file deleted from the remote server.
     """
     __tablename__ = "stream_configs"
-    __table_args__ = {'extend_existing': True}
+    __table_args__ = (
+        UniqueConstraint('redirector_id', 'listen_port', name='uq_stream_configs_redirector_port'),
+        {'extend_existing': True},
+    )
 
     id = Column(String(36), primary_key=True, default=_new_uuid)
     redirector_id = Column(

--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -1,0 +1,172 @@
+"""Pydantic schemas for redirector and stream config management.
+
+Security note: ssh_private_key is ALWAYS returned as "**REDACTED**" in output
+schemas. The key is never serialized in API responses, regardless of what is
+stored in the database.
+"""
+import ipaddress
+from typing import Optional, List
+from datetime import datetime
+from pydantic import BaseModel, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Redirector schemas
+# ---------------------------------------------------------------------------
+
+class RedirectorCreate(BaseModel):
+    name: str = Field(..., max_length=255)
+    current_ip: str = Field(..., max_length=45)
+    ssh_port: int = Field(default=22, ge=1, le=65535)
+    ssh_username: str = Field(..., max_length=255)
+    ssh_private_key: str = Field(..., min_length=1)   # Full PEM content
+    ssh_key_passphrase: Optional[str] = None
+    nginx_stream_dir: str = Field(default="/etc/nginx/stream.d", max_length=500)
+    notes: Optional[str] = None
+
+
+class RedirectorUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    current_ip: Optional[str] = Field(None, max_length=45)
+    ssh_port: Optional[int] = Field(None, ge=1, le=65535)
+    ssh_username: Optional[str] = Field(None, max_length=255)
+    # Empty string or None → keep existing key; non-empty string → update key
+    ssh_private_key: Optional[str] = None
+    ssh_key_passphrase: Optional[str] = None
+    nginx_stream_dir: Optional[str] = Field(None, max_length=500)
+    notes: Optional[str] = None
+
+
+class RedirectorOut(BaseModel):
+    id: str
+    name: str
+    current_ip: str
+    ssh_port: int
+    ssh_username: str
+    ssh_private_key: str = "**REDACTED**"
+    ssh_key_passphrase: Optional[str] = None  # populated as "**REDACTED**" or None
+    nginx_stream_dir: str
+    notes: Optional[str]
+    status: str
+    last_deployed_at: Optional[datetime]
+    last_tested_at: Optional[datetime]
+    stream_count: int = 0
+    created_at: datetime
+    updated_at: Optional[datetime]
+
+    model_config = {"from_attributes": True}
+
+
+class RedirectorListOut(BaseModel):
+    redirectors: List[RedirectorOut]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# StreamConfig schemas
+# ---------------------------------------------------------------------------
+
+class StreamConfigCreate(BaseModel):
+    name: str = Field(..., max_length=255)
+    protocol: str = Field(default="tcp", pattern="^(tcp|udp|dns)$")
+    listen_port: int = Field(..., ge=1, le=65535)
+    cs_ip: str = Field(..., max_length=255)
+    cs_port: int = Field(..., ge=1, le=65535)
+    access_control_enabled: bool = False
+    allowed_cidrs: Optional[List[str]] = None
+
+    @field_validator("allowed_cidrs")
+    @classmethod
+    def validate_cidrs(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is None:
+            return v
+        for cidr in v:
+            try:
+                ipaddress.ip_network(cidr.strip(), strict=False)
+            except ValueError:
+                raise ValueError(f"Invalid CIDR notation: {cidr!r}")
+        return v
+    ssl_enabled: bool = False
+    ssl_cert_path: Optional[str] = Field(None, max_length=500)
+    ssl_key_path: Optional[str] = Field(None, max_length=500)
+    ssl_protocols: str = Field(default="TLSv1.2 TLSv1.3", max_length=100)
+    ssl_ciphers: str = Field(default="HIGH:!aNULL:!MD5", max_length=200)
+    enabled: bool = True
+
+
+class StreamConfigUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    protocol: Optional[str] = Field(None, pattern="^(tcp|udp|dns)$")
+    listen_port: Optional[int] = Field(None, ge=1, le=65535)
+    cs_ip: Optional[str] = Field(None, max_length=255)
+    cs_port: Optional[int] = Field(None, ge=1, le=65535)
+    access_control_enabled: Optional[bool] = None
+    allowed_cidrs: Optional[List[str]] = None
+
+    @field_validator("allowed_cidrs")
+    @classmethod
+    def validate_cidrs(cls, v: Optional[List[str]]) -> Optional[List[str]]:
+        if v is None:
+            return v
+        for cidr in v:
+            try:
+                ipaddress.ip_network(cidr.strip(), strict=False)
+            except ValueError:
+                raise ValueError(f"Invalid CIDR notation: {cidr!r}")
+        return v
+    ssl_enabled: Optional[bool] = None
+    ssl_cert_path: Optional[str] = Field(None, max_length=500)
+    ssl_key_path: Optional[str] = Field(None, max_length=500)
+    ssl_protocols: Optional[str] = Field(None, max_length=100)
+    ssl_ciphers: Optional[str] = Field(None, max_length=200)
+    enabled: Optional[bool] = None
+
+
+class StreamConfigOut(BaseModel):
+    id: str
+    redirector_id: str
+    name: str
+    protocol: str
+    listen_port: int
+    cs_ip: str
+    cs_port: int
+    access_control_enabled: bool
+    allowed_cidrs: Optional[List[str]]
+    ssl_enabled: bool
+    ssl_cert_path: Optional[str]
+    ssl_key_path: Optional[str]
+    ssl_protocols: str
+    ssl_ciphers: str
+    enabled: bool
+    filename: str
+    created_at: datetime
+    updated_at: Optional[datetime]
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# SSH operation result schemas
+# ---------------------------------------------------------------------------
+
+class DeployResult(BaseModel):
+    success: bool
+    nginx_test_output: str = ""
+    nginx_reload_output: str = ""
+    stream_module_present: bool = True
+    files_written: List[str] = []
+    files_deleted: List[str] = []
+    message: str = ""
+
+
+class TestConnectionResult(BaseModel):
+    success: bool
+    status: str          # "online" | "offline"
+    message: str
+    stream_module_present: bool = False
+    rtt_ms: Optional[float] = None
+
+
+class ConfigPreview(BaseModel):
+    filename: str
+    content: str

--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -5,9 +5,22 @@ schemas. The key is never serialized in API responses, regardless of what is
 stored in the database.
 """
 import ipaddress
+import re
 from typing import Optional, List
 from datetime import datetime
 from pydantic import BaseModel, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Shared validation constants
+# ---------------------------------------------------------------------------
+
+_SAFE_PATH_RE = re.compile(r"^/[a-zA-Z0-9_./-]+$")
+_SAFE_USERNAME_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_SAFE_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+_SAFE_CIPHER_RE = re.compile(r"^[a-zA-Z0-9_:!+\-@.]+$")
+_ALLOWED_SSL_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}
+_UNSAFE_NGINX_CHARS = re.compile(r"[;\n\r{}]")
 
 
 # ---------------------------------------------------------------------------
@@ -24,6 +37,26 @@ class RedirectorCreate(BaseModel):
     nginx_stream_dir: str = Field(default="/etc/nginx/stream.d", max_length=500)
     notes: Optional[str] = None
 
+    @field_validator("current_ip")
+    @classmethod
+    def validate_ip(cls, v: str) -> str:
+        ipaddress.ip_address(v)
+        return v
+
+    @field_validator("ssh_username")
+    @classmethod
+    def validate_ssh_username(cls, v: str) -> str:
+        if not _SAFE_USERNAME_RE.match(v):
+            raise ValueError("ssh_username contains invalid characters (allowed: a-z A-Z 0-9 _ . -)")
+        return v
+
+    @field_validator("nginx_stream_dir")
+    @classmethod
+    def validate_stream_dir(cls, v: str) -> str:
+        if not _SAFE_PATH_RE.match(v):
+            raise ValueError("nginx_stream_dir must be an absolute path with safe characters only")
+        return v
+
 
 class RedirectorUpdate(BaseModel):
     name: Optional[str] = Field(None, max_length=255)
@@ -35,6 +68,27 @@ class RedirectorUpdate(BaseModel):
     ssh_key_passphrase: Optional[str] = None
     nginx_stream_dir: Optional[str] = Field(None, max_length=500)
     notes: Optional[str] = None
+
+    @field_validator("current_ip")
+    @classmethod
+    def validate_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            ipaddress.ip_address(v)
+        return v
+
+    @field_validator("ssh_username")
+    @classmethod
+    def validate_ssh_username(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _SAFE_USERNAME_RE.match(v):
+            raise ValueError("ssh_username contains invalid characters (allowed: a-z A-Z 0-9 _ . -)")
+        return v
+
+    @field_validator("nginx_stream_dir")
+    @classmethod
+    def validate_stream_dir(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _SAFE_PATH_RE.match(v):
+            raise ValueError("nginx_stream_dir must be an absolute path with safe characters only")
+        return v
 
 
 class RedirectorOut(BaseModel):
@@ -75,6 +129,25 @@ class StreamConfigCreate(BaseModel):
     access_control_enabled: bool = False
     allowed_cidrs: Optional[List[str]] = None
 
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if _UNSAFE_NGINX_CHARS.search(v):
+            raise ValueError("name must not contain semicolons, newlines, or braces")
+        return v
+
+    @field_validator("cs_ip")
+    @classmethod
+    def validate_cs_ip(cls, v: str) -> str:
+        try:
+            ipaddress.ip_address(v)
+            return v
+        except ValueError:
+            pass
+        if not _SAFE_HOSTNAME_RE.match(v):
+            raise ValueError("cs_ip must be a valid IP address or hostname")
+        return v
+
     @field_validator("allowed_cidrs")
     @classmethod
     def validate_cidrs(cls, v: Optional[List[str]]) -> Optional[List[str]]:
@@ -86,12 +159,35 @@ class StreamConfigCreate(BaseModel):
             except ValueError:
                 raise ValueError(f"Invalid CIDR notation: {cidr!r}")
         return v
+
     ssl_enabled: bool = False
     ssl_cert_path: Optional[str] = Field(None, max_length=500)
     ssl_key_path: Optional[str] = Field(None, max_length=500)
     ssl_protocols: str = Field(default="TLSv1.2 TLSv1.3", max_length=100)
     ssl_ciphers: str = Field(default="HIGH:!aNULL:!MD5", max_length=200)
     enabled: bool = True
+
+    @field_validator("ssl_cert_path", "ssl_key_path")
+    @classmethod
+    def validate_ssl_path(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _SAFE_PATH_RE.match(v):
+            raise ValueError("SSL path must be an absolute path with safe characters only")
+        return v
+
+    @field_validator("ssl_protocols")
+    @classmethod
+    def validate_ssl_protocols(cls, v: str) -> str:
+        for token in v.split():
+            if token not in _ALLOWED_SSL_PROTOCOLS:
+                raise ValueError(f"Unknown SSL protocol: {token!r}")
+        return v
+
+    @field_validator("ssl_ciphers")
+    @classmethod
+    def validate_ssl_ciphers(cls, v: str) -> str:
+        if not _SAFE_CIPHER_RE.match(v):
+            raise ValueError("ssl_ciphers contains invalid characters")
+        return v
 
 
 class StreamConfigUpdate(BaseModel):
@@ -103,6 +199,27 @@ class StreamConfigUpdate(BaseModel):
     access_control_enabled: Optional[bool] = None
     allowed_cidrs: Optional[List[str]] = None
 
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and _UNSAFE_NGINX_CHARS.search(v):
+            raise ValueError("name must not contain semicolons, newlines, or braces")
+        return v
+
+    @field_validator("cs_ip")
+    @classmethod
+    def validate_cs_ip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            ipaddress.ip_address(v)
+            return v
+        except ValueError:
+            pass
+        if not _SAFE_HOSTNAME_RE.match(v):
+            raise ValueError("cs_ip must be a valid IP address or hostname")
+        return v
+
     @field_validator("allowed_cidrs")
     @classmethod
     def validate_cidrs(cls, v: Optional[List[str]]) -> Optional[List[str]]:
@@ -114,12 +231,36 @@ class StreamConfigUpdate(BaseModel):
             except ValueError:
                 raise ValueError(f"Invalid CIDR notation: {cidr!r}")
         return v
+
     ssl_enabled: Optional[bool] = None
     ssl_cert_path: Optional[str] = Field(None, max_length=500)
     ssl_key_path: Optional[str] = Field(None, max_length=500)
     ssl_protocols: Optional[str] = Field(None, max_length=100)
     ssl_ciphers: Optional[str] = Field(None, max_length=200)
     enabled: Optional[bool] = None
+
+    @field_validator("ssl_cert_path", "ssl_key_path")
+    @classmethod
+    def validate_ssl_path(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _SAFE_PATH_RE.match(v):
+            raise ValueError("SSL path must be an absolute path with safe characters only")
+        return v
+
+    @field_validator("ssl_protocols")
+    @classmethod
+    def validate_ssl_protocols(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            for token in v.split():
+                if token not in _ALLOWED_SSL_PROTOCOLS:
+                    raise ValueError(f"Unknown SSL protocol: {token!r}")
+        return v
+
+    @field_validator("ssl_ciphers")
+    @classmethod
+    def validate_ssl_ciphers(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not _SAFE_CIPHER_RE.match(v):
+            raise ValueError("ssl_ciphers contains invalid characters")
+        return v
 
 
 class StreamConfigOut(BaseModel):
@@ -146,8 +287,14 @@ class StreamConfigOut(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# SSH operation result schemas
+# SSH operation request/result schemas
 # ---------------------------------------------------------------------------
+
+class CheckPortRequest(BaseModel):
+    """Typed request body for the check-port endpoint (replaces untyped dict)."""
+    port: int = Field(..., ge=1, le=65535)
+    protocol: str = Field(default="tcp", pattern="^(tcp|udp|dns)$")
+
 
 class DeployResult(BaseModel):
     success: bool

--- a/backend/app/services/nginx_config_service.py
+++ b/backend/app/services/nginx_config_service.py
@@ -16,6 +16,16 @@ if TYPE_CHECKING:
     from app.models.redirector import StreamConfig
 
 
+_UNSAFE_NGINX_CHARS = frozenset("\n\r;{}")
+
+
+def _safe_nginx_value(val: str, field_name: str) -> str:
+    """Defense-in-depth: reject values that could break out of an nginx directive."""
+    if any(c in _UNSAFE_NGINX_CHARS for c in val):
+        raise ValueError(f"Unsafe character in {field_name}: {val!r}")
+    return val
+
+
 def generate_stream_config(stream: "StreamConfig") -> str:
     """
     Generate the content of a single nginx stream .conf file for a StreamConfig.
@@ -33,8 +43,12 @@ def generate_stream_config(stream: "StreamConfig") -> str:
     is_dns = protocol == "dns"
     is_udp = protocol in ("udp", "dns")
 
+    # Defense-in-depth: validate all interpolated values
+    safe_name = _safe_nginx_value(stream.name, "name")
+    safe_cs_ip = _safe_nginx_value(stream.cs_ip, "cs_ip")
+
     lines: list[str] = [
-        f"# CyberX Managed - {stream.name}",
+        f"# CyberX Managed - {safe_name}",
         f"# Generated: {now_utc} - DO NOT EDIT MANUALLY",
         "",
         "server {",
@@ -49,7 +63,7 @@ def generate_stream_config(stream: "StreamConfig") -> str:
         lines.append(f"    listen {stream.listen_port};")
 
     # --- proxy_pass -------------------------------------------------------
-    lines.append(f"    proxy_pass {stream.cs_ip}:{stream.cs_port};")
+    lines.append(f"    proxy_pass {safe_cs_ip}:{stream.cs_port};")
 
     # --- timeouts ---------------------------------------------------------
     if is_udp:
@@ -64,17 +78,22 @@ def generate_stream_config(stream: "StreamConfig") -> str:
 
     # --- SSL block (TCP only) ---------------------------------------------
     if stream.ssl_enabled and not is_udp and stream.ssl_cert_path and stream.ssl_key_path:
-        lines.append(f"    ssl_certificate {stream.ssl_cert_path};")
-        lines.append(f"    ssl_certificate_key {stream.ssl_key_path};")
-        lines.append(f"    ssl_protocols {stream.ssl_protocols};")
-        lines.append(f"    ssl_ciphers {stream.ssl_ciphers};")
+        safe_cert = _safe_nginx_value(stream.ssl_cert_path, "ssl_cert_path")
+        safe_key = _safe_nginx_value(stream.ssl_key_path, "ssl_key_path")
+        safe_protocols = _safe_nginx_value(stream.ssl_protocols, "ssl_protocols")
+        safe_ciphers = _safe_nginx_value(stream.ssl_ciphers, "ssl_ciphers")
+        lines.append(f"    ssl_certificate {safe_cert};")
+        lines.append(f"    ssl_certificate_key {safe_key};")
+        lines.append(f"    ssl_protocols {safe_protocols};")
+        lines.append(f"    ssl_ciphers {safe_ciphers};")
         lines.append("    ssl_session_cache shared:SSL:10m;")
         lines.append("    ssl_session_timeout 10m;")
 
     # --- Access control ---------------------------------------------------
     if stream.access_control_enabled and stream.allowed_cidrs:
         for cidr in stream.allowed_cidrs:
-            lines.append(f"    allow {cidr.strip()};")
+            safe_cidr = _safe_nginx_value(cidr.strip(), "allowed_cidr")
+            lines.append(f"    allow {safe_cidr};")
         lines.append("    deny all;")
 
     lines.append("}")

--- a/backend/app/services/nginx_config_service.py
+++ b/backend/app/services/nginx_config_service.py
@@ -1,0 +1,88 @@
+"""Pure-Python nginx stream config file text generator.
+
+No I/O — only produces text. The SSH service is responsible for writing
+the generated text to the remote redirector.
+
+Each StreamConfig produces a single server {} block written to:
+    <nginx_stream_dir>/cyberx_<stream_id>.conf
+
+The outer  stream { include ...; }  block is assumed to already exist in
+nginx.conf, configured by the operator. This service never touches nginx.conf.
+"""
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models.redirector import StreamConfig
+
+
+def generate_stream_config(stream: "StreamConfig") -> str:
+    """
+    Generate the content of a single nginx stream .conf file for a StreamConfig.
+
+    Returns the complete text for cyberx_<stream_id>.conf.
+    The file contains one server {} block — no outer stream {} wrapper.
+
+    Protocol behaviour:
+        tcp  — plain TCP proxy; optionally with SSL termination
+        udp  — UDP proxy with reuseport
+        dns  — UDP on any port, adds proxy_responses 1 (correct for DNS)
+    """
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    protocol = (stream.protocol or "tcp").lower()
+    is_dns = protocol == "dns"
+    is_udp = protocol in ("udp", "dns")
+
+    lines: list[str] = [
+        f"# CyberX Managed - {stream.name}",
+        f"# Generated: {now_utc} - DO NOT EDIT MANUALLY",
+        "",
+        "server {",
+    ]
+
+    # --- listen directive --------------------------------------------------
+    if is_udp:
+        lines.append(f"    listen {stream.listen_port} udp reuseport;")
+    elif stream.ssl_enabled and stream.ssl_cert_path and stream.ssl_key_path:
+        lines.append(f"    listen {stream.listen_port} ssl;")
+    else:
+        lines.append(f"    listen {stream.listen_port};")
+
+    # --- proxy_pass -------------------------------------------------------
+    lines.append(f"    proxy_pass {stream.cs_ip}:{stream.cs_port};")
+
+    # --- timeouts ---------------------------------------------------------
+    if is_udp:
+        lines.append("    proxy_timeout 20s;")
+    else:
+        lines.append("    proxy_connect_timeout 60s;")
+        lines.append("    proxy_timeout 10m;")
+
+    # --- DNS-specific -----------------------------------------------------
+    if is_dns:
+        lines.append("    proxy_responses 1;")
+
+    # --- SSL block (TCP only) ---------------------------------------------
+    if stream.ssl_enabled and not is_udp and stream.ssl_cert_path and stream.ssl_key_path:
+        lines.append(f"    ssl_certificate {stream.ssl_cert_path};")
+        lines.append(f"    ssl_certificate_key {stream.ssl_key_path};")
+        lines.append(f"    ssl_protocols {stream.ssl_protocols};")
+        lines.append(f"    ssl_ciphers {stream.ssl_ciphers};")
+        lines.append("    ssl_session_cache shared:SSL:10m;")
+        lines.append("    ssl_session_timeout 10m;")
+
+    # --- Access control ---------------------------------------------------
+    if stream.access_control_enabled and stream.allowed_cidrs:
+        for cidr in stream.allowed_cidrs:
+            lines.append(f"    allow {cidr.strip()};")
+        lines.append("    deny all;")
+
+    lines.append("}")
+    lines.append("")   # trailing newline
+
+    return "\n".join(lines)
+
+
+def generate_stream_config_preview(stream: "StreamConfig") -> str:
+    """Alias for generate_stream_config — used by the preview endpoint."""
+    return generate_stream_config(stream)

--- a/backend/app/services/redirector_service.py
+++ b/backend/app/services/redirector_service.py
@@ -1,0 +1,200 @@
+"""CRUD service for Redirector and StreamConfig models.
+
+SSH keys are encrypted with Fernet before any database write and are
+decrypted only on explicit request (get_decrypted_key / get_decrypted_passphrase).
+Callers must treat the decrypted key as a short-lived local variable and
+must not log, cache, or serialize it.
+"""
+import uuid
+from datetime import datetime, timezone
+from typing import Optional, List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.redirector import Redirector, StreamConfig
+from app.utils.encryption import encrypt_field, decrypt_field
+
+
+class RedirectorService:
+    """Async CRUD service for Redirector and StreamConfig."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    # -------------------------------------------------------------------------
+    # Redirectors
+    # -------------------------------------------------------------------------
+
+    async def list_redirectors(self) -> List[Redirector]:
+        """Return all redirectors ordered by name, with stream_configs eager-loaded."""
+        result = await self.session.execute(
+            select(Redirector)
+            .options(selectinload(Redirector.stream_configs))
+            .order_by(Redirector.name)
+        )
+        return list(result.scalars().all())
+
+    async def get_redirector(self, redirector_id: str) -> Optional[Redirector]:
+        """Return a redirector by ID with stream_configs eager-loaded, or None."""
+        result = await self.session.execute(
+            select(Redirector)
+            .options(selectinload(Redirector.stream_configs))
+            .where(Redirector.id == redirector_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_redirector_by_name(self, name: str) -> Optional[Redirector]:
+        result = await self.session.execute(
+            select(Redirector).where(Redirector.name == name)
+        )
+        return result.scalar_one_or_none()
+
+    async def create_redirector(self, data: dict) -> Redirector:
+        redirector = Redirector(
+            id=str(uuid.uuid4()),
+            name=data["name"],
+            current_ip=data["current_ip"],
+            ssh_port=data.get("ssh_port", 22),
+            ssh_username=data["ssh_username"],
+            ssh_private_key=encrypt_field(data["ssh_private_key"]),
+            ssh_key_passphrase=encrypt_field(data.get("ssh_key_passphrase")) if data.get("ssh_key_passphrase") else None,
+            nginx_stream_dir=data.get("nginx_stream_dir", "/etc/nginx/stream.d"),
+            notes=data.get("notes"),
+        )
+        self.session.add(redirector)
+        await self.session.commit()
+        await self.session.refresh(redirector)
+        # Refresh with stream_configs loaded so stream_count property works
+        await self.session.refresh(redirector, attribute_names=["stream_configs"])
+        return redirector
+
+    async def update_redirector(self, redirector: Redirector, data: dict) -> Redirector:
+        """
+        Update a redirector from a dict of changed fields (from model_dump(exclude_unset=True)).
+        SSH key fields: only updated when non-empty string is provided.
+        """
+        simple_fields = ("name", "current_ip", "ssh_port", "ssh_username", "nginx_stream_dir", "notes")
+        for field in simple_fields:
+            if field in data and data[field] is not None:
+                setattr(redirector, field, data[field])
+
+        # Update SSH key only when a non-empty value is provided
+        if data.get("ssh_private_key"):
+            redirector.ssh_private_key = encrypt_field(data["ssh_private_key"])
+
+        # Update passphrase: explicit empty string clears it; non-empty updates it
+        if "ssh_key_passphrase" in data:
+            raw_pass = data["ssh_key_passphrase"]
+            if raw_pass:
+                redirector.ssh_key_passphrase = encrypt_field(raw_pass)
+            else:
+                redirector.ssh_key_passphrase = None
+
+        await self.session.commit()
+        await self.session.refresh(redirector)
+        await self.session.refresh(redirector, attribute_names=["stream_configs"])
+        return redirector
+
+    async def delete_redirector(self, redirector: Redirector) -> None:
+        await self.session.delete(redirector)
+        await self.session.commit()
+
+    def get_decrypted_key(self, redirector: Redirector) -> str:
+        """
+        Decrypt and return the SSH private key PEM.
+
+        SECURITY: Treat the returned string as a short-lived local variable.
+        Do not log, cache, store in response, or pass it outside the current
+        request scope.
+        """
+        return decrypt_field(redirector.ssh_private_key)
+
+    def get_decrypted_passphrase(self, redirector: Redirector) -> Optional[str]:
+        """Decrypt and return the SSH key passphrase, or None if not set."""
+        if not redirector.ssh_key_passphrase:
+            return None
+        return decrypt_field(redirector.ssh_key_passphrase)
+
+    async def update_status(self, redirector: Redirector, status: str) -> None:
+        """Update connectivity status and last_tested_at timestamp."""
+        redirector.status = status
+        redirector.last_tested_at = datetime.now(timezone.utc)
+        await self.session.commit()
+
+    async def update_deployed_at(self, redirector: Redirector) -> None:
+        """Record a successful deploy timestamp."""
+        redirector.last_deployed_at = datetime.now(timezone.utc)
+        await self.session.commit()
+
+    # -------------------------------------------------------------------------
+    # StreamConfigs
+    # -------------------------------------------------------------------------
+
+    async def list_streams(self, redirector_id: str) -> List[StreamConfig]:
+        result = await self.session.execute(
+            select(StreamConfig)
+            .where(StreamConfig.redirector_id == redirector_id)
+            .order_by(StreamConfig.name)
+        )
+        return list(result.scalars().all())
+
+    async def get_stream(
+        self, stream_id: str, redirector_id: str
+    ) -> Optional[StreamConfig]:
+        result = await self.session.execute(
+            select(StreamConfig).where(
+                StreamConfig.id == stream_id,
+                StreamConfig.redirector_id == redirector_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_stream(self, redirector_id: str, data: dict) -> StreamConfig:
+        stream = StreamConfig(
+            id=str(uuid.uuid4()),
+            redirector_id=redirector_id,
+            name=data["name"],
+            protocol=data.get("protocol", "tcp"),
+            listen_port=data["listen_port"],
+            cs_ip=data["cs_ip"],
+            cs_port=data["cs_port"],
+            access_control_enabled=data.get("access_control_enabled", False),
+            allowed_cidrs=data.get("allowed_cidrs"),
+            ssl_enabled=data.get("ssl_enabled", False),
+            ssl_cert_path=data.get("ssl_cert_path"),
+            ssl_key_path=data.get("ssl_key_path"),
+            ssl_protocols=data.get("ssl_protocols", "TLSv1.2 TLSv1.3"),
+            ssl_ciphers=data.get("ssl_ciphers", "HIGH:!aNULL:!MD5"),
+            enabled=data.get("enabled", True),
+        )
+        self.session.add(stream)
+        await self.session.commit()
+        await self.session.refresh(stream)
+        return stream
+
+    async def update_stream(self, stream: StreamConfig, data: dict) -> StreamConfig:
+        """Update stream from a dict of changed fields (exclude_unset=True)."""
+        simple_fields = (
+            "name", "protocol", "listen_port", "cs_ip", "cs_port",
+            "access_control_enabled", "ssl_enabled", "ssl_cert_path",
+            "ssl_key_path", "ssl_protocols", "ssl_ciphers",
+        )
+        for field in simple_fields:
+            if field in data and data[field] is not None:
+                setattr(stream, field, data[field])
+
+        # These can legitimately be falsy ([] or False) — handle separately
+        if "allowed_cidrs" in data:
+            stream.allowed_cidrs = data["allowed_cidrs"]
+        if "enabled" in data and data["enabled"] is not None:
+            stream.enabled = data["enabled"]
+
+        await self.session.commit()
+        await self.session.refresh(stream)
+        return stream
+
+    async def delete_stream(self, stream: StreamConfig) -> None:
+        await self.session.delete(stream)
+        await self.session.commit()

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -584,10 +584,10 @@ class SSHService:
 
         Writes a temp script via SFTP and executes it with sudo.
         Requires sudoers entry:
-            <user> ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix_*.sh
+            <user> ALL=(ALL) NOPASSWD: /bin/bash /var/lib/cyberx/scripts/.cyberx_nginx_fix_*.sh
         """
         safe_dir = shlex.quote(stream_dir)
-        script_path = f"/tmp/.cyberx_nginx_fix_{uuid.uuid4().hex[:8]}.sh"
+        script_path = f"/var/lib/cyberx/scripts/.cyberx_nginx_fix_{uuid.uuid4().hex[:8]}.sh"
         script = (
             "#!/bin/bash\n"
             "set -e\n"
@@ -726,7 +726,7 @@ class SSHService:
         """
         safe_dir = shlex.quote(stream_dir)
         safe_user = shlex.quote(self.username)
-        script_path = f"/tmp/.cyberx_prereq_fix_{uuid.uuid4().hex[:8]}.sh"
+        script_path = f"/var/lib/cyberx/scripts/.cyberx_prereq_fix_{uuid.uuid4().hex[:8]}.sh"
         script = (
             "#!/bin/bash\n"
             "set -e\n"
@@ -738,9 +738,13 @@ class SSHService:
             "fi\n"
             f"# Create stream directory\n"
             f"mkdir -p {safe_dir}\n"
+            "# Create script staging directory (not world-writable, unlike /tmp)\n"
+            "mkdir -p /var/lib/cyberx/scripts\n"
+            f"chown {safe_user}:{safe_user} /var/lib/cyberx/scripts\n"
+            "chmod 750 /var/lib/cyberx/scripts\n"
             "# Write sudoers file for CyberX\n"
             f"cat > /etc/sudoers.d/cyberx <<SUDOERS\n"
-            f"{safe_user} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/bash /tmp/.cyberx_nginx_fix_*.sh, /bin/bash /tmp/.cyberx_prereq_fix_*.sh\n"
+            f"{safe_user} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/bash /var/lib/cyberx/scripts/.cyberx_nginx_fix_*.sh, /bin/bash /var/lib/cyberx/scripts/.cyberx_prereq_fix_*.sh\n"
             "SUDOERS\n"
             "chmod 440 /etc/sudoers.d/cyberx\n"
             "visudo -c -f /etc/sudoers.d/cyberx\n"

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -24,7 +24,9 @@ Sudo requirement on each redirector (set up once by operator):
 import asyncio
 import io
 import logging
+import shlex
 import time
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Tuple
 
@@ -34,6 +36,10 @@ logger = logging.getLogger(__name__)
 
 # Bounded thread pool — all paramiko calls execute here
 _executor = ThreadPoolExecutor(max_workers=10)
+
+# Semaphore prevents queuing more requests than the pool can handle,
+# so a few offline redirectors can't exhaust all workers.
+_ssh_semaphore = asyncio.Semaphore(10)
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +142,8 @@ class SSHService:
         validate them on each connection.
         """
         client = paramiko.SSHClient()
+        # TODO: SECURITY — implement host key pinning (TOFU) by storing
+        # per-redirector fingerprints and verifying on each connection.
         client.set_missing_host_key_policy(paramiko.WarningPolicy())
         try:
             pkey = self._load_key()
@@ -397,10 +405,12 @@ class SSHService:
     def sync_deploy_all(self, stream_dir: str, streams: list) -> dict:
         """
         Sync all StreamConfigs for a redirector:
-          1. Write enabled streams
-          2. Delete disabled streams
-          3. Remove orphaned cyberx_*.conf files not in the current set
-          4. nginx -t → systemctl reload nginx
+          1. Snapshot existing config files (for rollback)
+          2. Write enabled streams
+          3. Delete disabled streams
+          4. Remove orphaned cyberx_*.conf files not in the current set
+          5. nginx -t → systemctl reload nginx
+          6. On nginx -t failure: restore all snapshots (rollback)
 
         Returns a dict compatible with DeployResult schema.
         """
@@ -416,6 +426,20 @@ class SSHService:
 
             known_filenames = {f"cyberx_{s.id}.conf" for s in streams}
 
+            # Snapshot existing files for rollback on nginx -t failure
+            # Key = remote_path, Value = bytes (existing content) or None (file was new)
+            backup: dict[str, Optional[bytes]] = {}
+
+            for stream in streams:
+                filename = f"cyberx_{stream.id}.conf"
+                remote_path = f"{stream_dir}/{filename}"
+                if stream.enabled:
+                    try:
+                        with sftp.open(remote_path, "rb") as f:
+                            backup[remote_path] = f.read()
+                    except FileNotFoundError:
+                        backup[remote_path] = None
+
             # Write enabled streams, delete disabled streams
             for stream in streams:
                 filename = f"cyberx_{stream.id}.conf"
@@ -428,6 +452,12 @@ class SSHService:
                     logger.debug("Wrote %s", remote_path)
                 else:
                     try:
+                        # Snapshot before deleting for rollback
+                        try:
+                            with sftp.open(remote_path, "rb") as f:
+                                backup[remote_path] = f.read()
+                        except FileNotFoundError:
+                            pass
                         sftp.remove(remote_path)
                         files_deleted.append(filename)
                         logger.debug("Removed disabled stream file %s", remote_path)
@@ -443,7 +473,13 @@ class SSHService:
                         and remote_file.endswith(".conf")
                         and remote_file not in known_filenames
                     ):
-                        sftp.remove(f"{stream_dir}/{remote_file}")
+                        orphan_path = f"{stream_dir}/{remote_file}"
+                        try:
+                            with sftp.open(orphan_path, "rb") as f:
+                                backup[orphan_path] = f.read()
+                        except FileNotFoundError:
+                            pass
+                        sftp.remove(orphan_path)
                         files_deleted.append(remote_file)
                         logger.info("Removed orphan file %s", remote_file)
             except Exception as list_err:
@@ -452,6 +488,19 @@ class SSHService:
             try:
                 test_out, reload_out = self._nginx_test_and_reload(client)
             except NginxTestError as e:
+                # Rollback: restore all files to their pre-deploy state
+                rollback_ok = True
+                for path, content in backup.items():
+                    try:
+                        if content is None:
+                            sftp.remove(path)
+                        else:
+                            sftp.putfo(io.BytesIO(content), path)
+                    except Exception as rb_err:
+                        rollback_ok = False
+                        logger.warning("Rollback failed for %s: %s", path, rb_err)
+                if rollback_ok:
+                    logger.info("Rolled back %d file(s) after nginx -t failure", len(backup))
                 return {
                     "success": False,
                     "nginx_test_output": str(e),
@@ -459,7 +508,9 @@ class SSHService:
                     "stream_module_present": True,
                     "files_written": files_written,
                     "files_deleted": files_deleted,
-                    "message": "nginx configuration test failed. Check nginx output.",
+                    "message": "nginx configuration test failed. Files rolled back."
+                    if rollback_ok
+                    else "nginx configuration test failed. Partial rollback — check server manually.",
                 }
 
             return {
@@ -533,15 +584,17 @@ class SSHService:
 
         Writes a temp script via SFTP and executes it with sudo.
         Requires sudoers entry:
-            <user> ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix.sh
+            <user> ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix_*.sh
         """
+        safe_dir = shlex.quote(stream_dir)
+        script_path = f"/tmp/.cyberx_nginx_fix_{uuid.uuid4().hex[:8]}.sh"
         script = (
             "#!/bin/bash\n"
             "set -e\n"
             "rm -f /etc/nginx/sites-enabled/default\n"
-            f"mkdir -p {stream_dir}\n"
+            f"mkdir -p {safe_dir}\n"
             "if ! grep -rq 'stream.d' /etc/nginx/ 2>/dev/null; then\n"
-            f"    printf '\\nstream {{\\n    include {stream_dir}/*.conf;\\n}}\\n'"
+            f"    printf '\\nstream {{\\n    include {safe_dir}/*.conf;\\n}}\\n'"
             " >> /etc/nginx/nginx.conf\n"
             "fi\n"
             "/usr/sbin/nginx -t\n"
@@ -550,13 +603,13 @@ class SSHService:
         client = self._connect()
         try:
             sftp = client.open_sftp()
-            sftp.putfo(io.BytesIO(script.encode()), "/tmp/.cyberx_nginx_fix.sh")
-            sftp.chmod("/tmp/.cyberx_nginx_fix.sh", 0o700)
+            sftp.putfo(io.BytesIO(script.encode()), script_path)
+            sftp.chmod(script_path, 0o700)
 
             _, stderr, code = self._exec(
-                client, "sudo /bin/bash /tmp/.cyberx_nginx_fix.sh 2>&1"
+                client, f"sudo /bin/bash {shlex.quote(script_path)} 2>&1"
             )
-            self._exec(client, "rm -f /tmp/.cyberx_nginx_fix.sh")
+            self._exec(client, f"rm -f {shlex.quote(script_path)}")
 
             if code != 0:
                 return {
@@ -671,6 +724,9 @@ class SSHService:
         Writes a temp script via SFTP and executes it with 'sudo /bin/bash'.
         Requires the SSH user to have NOPASSWD sudo (any command).
         """
+        safe_dir = shlex.quote(stream_dir)
+        safe_user = shlex.quote(self.username)
+        script_path = f"/tmp/.cyberx_prereq_fix_{uuid.uuid4().hex[:8]}.sh"
         script = (
             "#!/bin/bash\n"
             "set -e\n"
@@ -681,10 +737,10 @@ class SSHService:
             "    apt-get install -y nginx-full\n"
             "fi\n"
             f"# Create stream directory\n"
-            f"mkdir -p {stream_dir}\n"
+            f"mkdir -p {safe_dir}\n"
             "# Write sudoers file for CyberX\n"
-            f"cat > /etc/sudoers.d/cyberx <<'SUDOERS'\n"
-            f"{self.username} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/bash /tmp/.cyberx_nginx_fix.sh, /bin/bash /tmp/.cyberx_prereq_fix.sh\n"
+            f"cat > /etc/sudoers.d/cyberx <<SUDOERS\n"
+            f"{safe_user} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/bash /tmp/.cyberx_nginx_fix_*.sh, /bin/bash /tmp/.cyberx_prereq_fix_*.sh\n"
             "SUDOERS\n"
             "chmod 440 /etc/sudoers.d/cyberx\n"
             "visudo -c -f /etc/sudoers.d/cyberx\n"
@@ -692,14 +748,14 @@ class SSHService:
         client = self._connect()
         try:
             sftp = client.open_sftp()
-            sftp.putfo(io.BytesIO(script.encode()), "/tmp/.cyberx_prereq_fix.sh")
-            sftp.chmod("/tmp/.cyberx_prereq_fix.sh", 0o700)
+            sftp.putfo(io.BytesIO(script.encode()), script_path)
+            sftp.chmod(script_path, 0o700)
             sftp.close()
 
             out, stderr, code = self._exec(
-                client, "sudo /bin/bash /tmp/.cyberx_prereq_fix.sh 2>&1"
+                client, f"sudo /bin/bash {shlex.quote(script_path)} 2>&1"
             )
-            self._exec(client, "rm -f /tmp/.cyberx_prereq_fix.sh")
+            self._exec(client, f"rm -f {shlex.quote(script_path)}")
 
             if code != 0:
                 return {
@@ -720,54 +776,46 @@ class SSHService:
 # Async wrappers — use these from FastAPI route handlers
 # ---------------------------------------------------------------------------
 
+async def _run_ssh(fn, *args) -> dict:
+    """Run a synchronous SSH operation in the bounded thread pool with semaphore."""
+    async with _ssh_semaphore:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(_executor, fn, *args)
+
+
 async def run_test_connection(ssh: SSHService) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_executor, ssh.sync_test_connection)
+    return await _run_ssh(ssh.sync_test_connection)
 
 
 async def run_check_prereqs(ssh: SSHService, stream_dir: str) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_executor, ssh.sync_check_prereqs, stream_dir)
+    return await _run_ssh(ssh.sync_check_prereqs, stream_dir)
 
 
 async def run_fix_prereqs(ssh: SSHService, stream_dir: str) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_executor, ssh.sync_fix_prereqs, stream_dir)
+    return await _run_ssh(ssh.sync_fix_prereqs, stream_dir)
 
 
 async def run_check_nginx_setup(ssh: SSHService) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_executor, ssh.sync_check_nginx_setup)
+    return await _run_ssh(ssh.sync_check_nginx_setup)
 
 
 async def run_fix_nginx_setup(ssh: SSHService, stream_dir: str) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_executor, ssh.sync_fix_nginx_setup, stream_dir)
+    return await _run_ssh(ssh.sync_fix_nginx_setup, stream_dir)
 
 
 async def run_check_port(ssh: SSHService, port: int, protocol: str) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_executor, ssh.sync_check_port, port, protocol)
+    return await _run_ssh(ssh.sync_check_port, port, protocol)
 
 
 async def run_deploy_single(ssh: SSHService, stream_dir: str, stream) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(
-        _executor, ssh.sync_deploy_single, stream_dir, stream
-    )
+    return await _run_ssh(ssh.sync_deploy_single, stream_dir, stream)
 
 
 async def run_remove_single(
     ssh: SSHService, stream_dir: str, stream_id: str, stream_name: str
 ) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(
-        _executor, ssh.sync_remove_single, stream_dir, stream_id, stream_name
-    )
+    return await _run_ssh(ssh.sync_remove_single, stream_dir, stream_id, stream_name)
 
 
 async def run_deploy_all(ssh: SSHService, stream_dir: str, streams: list) -> dict:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(
-        _executor, ssh.sync_deploy_all, stream_dir, streams
-    )
+    return await _run_ssh(ssh.sync_deploy_all, stream_dir, streams)

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -1,0 +1,773 @@
+"""SSH/SFTP service for managing nginx stream configs on remote redirectors.
+
+All paramiko operations are synchronous. Public async methods wrap the sync
+implementations in a bounded ThreadPoolExecutor so they don't block the
+FastAPI event loop.
+
+Error taxonomy (maps to HTTP responses in the route layer):
+    SSHConnectionError  → 503 Service Unavailable
+    SSHAuthError        → 422 Unprocessable Entity
+    NginxTestError      → 200 OK  with success=False + nginx stderr
+    NginxReloadError    → 500 Internal Server Error
+    SSHCommandError     → 500 Internal Server Error
+
+NginxTestError returns HTTP 200 (not 500) because the operation completed —
+the operator needs to see the nginx -t output to diagnose and fix the config.
+
+Rollback: on single-stream deploy with NginxTestError, the just-written file
+is deleted via SFTP before returning, leaving the remote in its prior state.
+
+Sudo requirement on each redirector (set up once by operator):
+    # /etc/sudoers.d/cyberx
+    <ssh_user> ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx
+"""
+import asyncio
+import io
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional, Tuple
+
+import paramiko
+
+logger = logging.getLogger(__name__)
+
+# Bounded thread pool — all paramiko calls execute here
+_executor = ThreadPoolExecutor(max_workers=10)
+
+
+# ---------------------------------------------------------------------------
+# Custom exceptions
+# ---------------------------------------------------------------------------
+
+class SSHConnectionError(Exception):
+    """TCP connect or handshake failed."""
+
+
+class SSHAuthError(Exception):
+    """SSH authentication rejected (bad key, wrong user, missing passphrase)."""
+
+
+class NginxTestError(Exception):
+    """nginx -t returned non-zero. Message contains nginx stderr output."""
+
+
+class NginxReloadError(Exception):
+    """nginx -t passed but systemctl reload failed."""
+
+
+class SSHCommandError(Exception):
+    """exec_command returned non-zero for a command that is not otherwise handled."""
+
+
+# ---------------------------------------------------------------------------
+# SSHService (synchronous core — runs inside the executor)
+# ---------------------------------------------------------------------------
+
+class SSHService:
+    """
+    Manages SSH/SFTP operations for a single Redirector.
+
+    Instantiate per-request in the route handler with the decrypted key.
+    Do NOT store the instance across requests — the decrypted key must
+    remain a short-lived local variable.
+    """
+
+    CONNECT_TIMEOUT = 10   # seconds until TCP connect fails
+    AUTH_TIMEOUT = 15      # seconds for key exchange + auth
+    COMMAND_TIMEOUT = 30   # per-command channel timeout
+
+    def __init__(
+        self,
+        hostname: str,
+        port: int,
+        username: str,
+        private_key_pem: str,
+        passphrase: Optional[str] = None,
+    ):
+        self.hostname = hostname
+        self.port = port
+        self.username = username
+        self._private_key_pem = private_key_pem
+        self._passphrase = passphrase
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_key(self) -> paramiko.PKey:
+        """
+        Try RSA → Ed25519 → ECDSA key loading from PEM string.
+
+        Raises SSHAuthError on authentication-related failures.
+        """
+        pem = self._private_key_pem
+        passphrase_bytes: Optional[bytes] = (
+            self._passphrase.encode("utf-8") if self._passphrase else None
+        )
+
+        for key_class in (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey):
+            try:
+                return key_class.from_private_key(
+                    io.StringIO(pem), password=passphrase_bytes
+                )
+            except paramiko.PasswordRequiredException:
+                raise SSHAuthError(
+                    "SSH key is passphrase-protected but no passphrase was provided."
+                )
+            except paramiko.ssh_exception.SSHException:
+                # Wrong key type — try the next one
+                continue
+            except Exception:
+                continue
+
+        raise SSHAuthError(
+            "Could not load SSH private key: unsupported key type or malformed PEM."
+        )
+
+    def _connect(self) -> paramiko.SSHClient:
+        """Establish an authenticated SSH connection. Caller must call client.close().
+
+        Security note: WarningPolicy logs a warning when connecting to an unknown
+        host key instead of silently accepting it (AutoAddPolicy). This is a
+        Trust-On-First-Use (TOFU) model — an adversary performing a MitM attack
+        before the first connection would not be detected. For hardened deployments,
+        a future enhancement will store per-redirector host key fingerprints and
+        validate them on each connection.
+        """
+        client = paramiko.SSHClient()
+        client.set_missing_host_key_policy(paramiko.WarningPolicy())
+        try:
+            pkey = self._load_key()
+            client.connect(
+                hostname=self.hostname,
+                port=self.port,
+                username=self.username,
+                pkey=pkey,
+                timeout=self.CONNECT_TIMEOUT,
+                auth_timeout=self.AUTH_TIMEOUT,
+                look_for_keys=False,
+                allow_agent=False,
+            )
+        except (SSHAuthError, SSHConnectionError):
+            raise
+        except paramiko.AuthenticationException as e:
+            raise SSHAuthError(f"Authentication failed: {e}")
+        except Exception as e:
+            raise SSHConnectionError(
+                f"Could not connect to {self.hostname}:{self.port}: {e}"
+            )
+        return client
+
+    def _exec(
+        self, client: paramiko.SSHClient, command: str
+    ) -> Tuple[str, str, int]:
+        """Execute a shell command. Returns (stdout, stderr, exit_code)."""
+        _, stdout_fh, stderr_fh = client.exec_command(
+            command, timeout=self.COMMAND_TIMEOUT
+        )
+        exit_code = stdout_fh.channel.recv_exit_status()
+        stdout = stdout_fh.read().decode("utf-8", errors="replace")
+        stderr = stderr_fh.read().decode("utf-8", errors="replace")
+        return stdout, stderr, exit_code
+
+    def _ensure_remote_dir(self, sftp: paramiko.SFTPClient, path: str) -> None:
+        """Create the remote directory if it does not exist."""
+        try:
+            sftp.stat(path)
+        except FileNotFoundError:
+            sftp.mkdir(path)
+
+    def _nginx_test_and_reload(
+        self, client: paramiko.SSHClient
+    ) -> Tuple[str, str]:
+        """
+        Run `sudo nginx -t`. On pass, run `sudo systemctl reload nginx`.
+
+        Returns (test_output, reload_output) on full success.
+        Raises NginxTestError if nginx -t fails (test_output = nginx stderr).
+        Raises NginxReloadError if reload fails after a successful test.
+        """
+        # nginx -t writes its output to stderr
+        _, test_stderr, test_code = self._exec(client, "sudo /usr/sbin/nginx -t")
+        test_output = test_stderr.strip()
+
+        if test_code != 0:
+            raise NginxTestError(test_output)
+
+        _, reload_stderr, reload_code = self._exec(
+            client, "sudo /bin/systemctl reload nginx"
+        )
+        reload_output = reload_stderr.strip()
+
+        if reload_code != 0:
+            raise NginxReloadError(f"nginx reload failed: {reload_output}")
+
+        return test_output, reload_output
+
+    # ------------------------------------------------------------------
+    # Public synchronous operations (called via run_in_executor)
+    # ------------------------------------------------------------------
+
+    def sync_test_connection(self) -> dict:
+        """
+        Verify SSH connectivity and confirm nginx stream module is present.
+
+        Returns a dict compatible with TestConnectionResult schema.
+        """
+        t0 = time.monotonic()
+        client = self._connect()
+        try:
+            stdout, _, code = self._exec(client, "echo cyberx_ok")
+            if code != 0 or "cyberx_ok" not in stdout:
+                raise SSHCommandError("Echo connectivity check failed.")
+
+            rtt_ms = round((time.monotonic() - t0) * 1000, 1)
+
+            # nginx --with-stream presence check
+            stream_out, _, _ = self._exec(
+                client, "sudo /usr/sbin/nginx -V 2>&1 | grep -- --with-stream"
+            )
+            stream_module_present = "--with-stream" in stream_out
+
+            return {
+                "success": True,
+                "status": "online",
+                "stream_module_present": stream_module_present,
+                "rtt_ms": rtt_ms,
+                "message": "Connection successful."
+                + ("" if stream_module_present else " WARNING: nginx stream module not detected."),
+            }
+        finally:
+            client.close()
+
+    def sync_check_port(self, port: int, protocol: str) -> dict:
+        """
+        Check whether anything is already listening on the given port.
+
+        Runs `ss -tlunp sport = :<port>` (covers both TCP and UDP) so the
+        operator is warned regardless of which protocol nginx would use.
+
+        Returns {"in_use": bool, "listeners": list[str], "process_names": list[str], "message": str}.
+        """
+        import re
+        command = f"ss -tlunp sport = :{port} 2>/dev/null"
+        client = self._connect()
+        try:
+            stdout, _, _ = self._exec(client, command)
+            lines = [ln for ln in stdout.strip().splitlines() if ln.strip()]
+            # First line is the ss header row; anything beyond it is a match
+            listeners = lines[1:] if len(lines) > 1 else []
+            in_use = bool(listeners)
+
+            # Extract unique process names from users:(("name",...)) in each line
+            process_names: list[str] = []
+            for ln in listeners:
+                for m in re.finditer(r'users:\(\("([^"]+)"', ln):
+                    name = m.group(1)
+                    if name not in process_names:
+                        process_names.append(name)
+
+            nginx_listening = "nginx" in process_names
+            other_processes = [p for p in process_names if p != "nginx"]
+
+            if nginx_listening:
+                status = "healthy"
+                message = f"nginx is listening on port {port}."
+            elif in_use:
+                status = "conflict"
+                proc_str = ", ".join(other_processes) if other_processes else "unknown process"
+                message = (
+                    f"Port {port} is already in use by: {proc_str} — "
+                    "nginx will not be able to bind."
+                )
+            else:
+                status = "not_listening"
+                message = f"Nothing is listening on port {port} — stream may not be deployed."
+
+            return {
+                "in_use": in_use,
+                "status": status,
+                "listeners": listeners,
+                "process_names": process_names,
+                "message": message,
+            }
+        finally:
+            client.close()
+
+    def sync_deploy_single(self, stream_dir: str, stream) -> dict:
+        """
+        Write a single enabled StreamConfig file to the redirector and reload nginx.
+
+        On NginxTestError: deletes the file just written (rollback) before returning.
+        Returns a dict compatible with DeployResult schema.
+        """
+        from app.services.nginx_config_service import generate_stream_config
+
+        filename = f"cyberx_{stream.id}.conf"
+        remote_path = f"{stream_dir}/{filename}"
+        config_text = generate_stream_config(stream)
+
+        client = self._connect()
+        try:
+            sftp = client.open_sftp()
+            self._ensure_remote_dir(sftp, stream_dir)
+            sftp.putfo(io.BytesIO(config_text.encode("utf-8")), remote_path)
+
+            try:
+                test_out, reload_out = self._nginx_test_and_reload(client)
+            except NginxTestError as e:
+                # Rollback: remove the file we just wrote
+                try:
+                    sftp.remove(remote_path)
+                    logger.info("Rolled back %s after nginx -t failure", remote_path)
+                except Exception as rm_err:
+                    logger.warning("Rollback failed for %s: %s", remote_path, rm_err)
+
+                return {
+                    "success": False,
+                    "nginx_test_output": str(e),
+                    "nginx_reload_output": "",
+                    "stream_module_present": True,
+                    "files_written": [],
+                    "files_deleted": [],
+                    "message": "nginx configuration test failed. File rolled back.",
+                }
+
+            return {
+                "success": True,
+                "nginx_test_output": test_out,
+                "nginx_reload_output": reload_out,
+                "stream_module_present": True,
+                "files_written": [filename],
+                "files_deleted": [],
+                "message": f"Stream '{stream.name}' deployed successfully.",
+            }
+        finally:
+            client.close()
+
+    def sync_remove_single(
+        self, stream_dir: str, stream_id: str, stream_name: str
+    ) -> dict:
+        """
+        Delete a single stream config file from the redirector and reload nginx.
+
+        Missing file is not an error (idempotent).
+        Returns a dict compatible with DeployResult schema.
+        """
+        filename = f"cyberx_{stream_id}.conf"
+        remote_path = f"{stream_dir}/{filename}"
+
+        client = self._connect()
+        try:
+            sftp = client.open_sftp()
+            try:
+                sftp.remove(remote_path)
+                files_deleted = [filename]
+                logger.info("Removed %s from redirector", remote_path)
+            except FileNotFoundError:
+                files_deleted = []
+                logger.info("File %s not found on redirector (already removed)", remote_path)
+
+            try:
+                test_out, reload_out = self._nginx_test_and_reload(client)
+            except NginxTestError as e:
+                return {
+                    "success": False,
+                    "nginx_test_output": str(e),
+                    "nginx_reload_output": "",
+                    "stream_module_present": True,
+                    "files_written": [],
+                    "files_deleted": files_deleted,
+                    "message": "nginx configuration test failed after file removal.",
+                }
+
+            return {
+                "success": True,
+                "nginx_test_output": test_out,
+                "nginx_reload_output": reload_out,
+                "stream_module_present": True,
+                "files_written": [],
+                "files_deleted": files_deleted,
+                "message": f"Stream '{stream_name}' removed successfully.",
+            }
+        finally:
+            client.close()
+
+    def sync_deploy_all(self, stream_dir: str, streams: list) -> dict:
+        """
+        Sync all StreamConfigs for a redirector:
+          1. Write enabled streams
+          2. Delete disabled streams
+          3. Remove orphaned cyberx_*.conf files not in the current set
+          4. nginx -t → systemctl reload nginx
+
+        Returns a dict compatible with DeployResult schema.
+        """
+        from app.services.nginx_config_service import generate_stream_config
+
+        files_written: list[str] = []
+        files_deleted: list[str] = []
+
+        client = self._connect()
+        try:
+            sftp = client.open_sftp()
+            self._ensure_remote_dir(sftp, stream_dir)
+
+            known_filenames = {f"cyberx_{s.id}.conf" for s in streams}
+
+            # Write enabled streams, delete disabled streams
+            for stream in streams:
+                filename = f"cyberx_{stream.id}.conf"
+                remote_path = f"{stream_dir}/{filename}"
+
+                if stream.enabled:
+                    config_text = generate_stream_config(stream)
+                    sftp.putfo(io.BytesIO(config_text.encode("utf-8")), remote_path)
+                    files_written.append(filename)
+                    logger.debug("Wrote %s", remote_path)
+                else:
+                    try:
+                        sftp.remove(remote_path)
+                        files_deleted.append(filename)
+                        logger.debug("Removed disabled stream file %s", remote_path)
+                    except FileNotFoundError:
+                        pass
+
+            # Orphan cleanup: remove cyberx_*.conf files that are no longer in the DB
+            try:
+                remote_listing = sftp.listdir(stream_dir)
+                for remote_file in remote_listing:
+                    if (
+                        remote_file.startswith("cyberx_")
+                        and remote_file.endswith(".conf")
+                        and remote_file not in known_filenames
+                    ):
+                        sftp.remove(f"{stream_dir}/{remote_file}")
+                        files_deleted.append(remote_file)
+                        logger.info("Removed orphan file %s", remote_file)
+            except Exception as list_err:
+                logger.warning("Orphan cleanup failed: %s", list_err)
+
+            try:
+                test_out, reload_out = self._nginx_test_and_reload(client)
+            except NginxTestError as e:
+                return {
+                    "success": False,
+                    "nginx_test_output": str(e),
+                    "nginx_reload_output": "",
+                    "stream_module_present": True,
+                    "files_written": files_written,
+                    "files_deleted": files_deleted,
+                    "message": "nginx configuration test failed. Check nginx output.",
+                }
+
+            return {
+                "success": True,
+                "nginx_test_output": test_out,
+                "nginx_reload_output": reload_out,
+                "stream_module_present": True,
+                "files_written": files_written,
+                "files_deleted": files_deleted,
+                "message": (
+                    f"Deployed {len(files_written)} stream(s), "
+                    f"removed {len(files_deleted)} file(s)."
+                ),
+            }
+        finally:
+            client.close()
+
+
+    def sync_check_nginx_setup(self) -> dict:
+        """
+        Check two common nginx setup issues on the redirector:
+          1. Default HTTP site active (port 80 served by nginx, not a stream)
+          2. Stream block with stream.d include absent from nginx config
+
+        Returns {"nginx_conf_ok": bool, "default_site_active": bool,
+                 "stream_block_present": bool, "issues": list[str]}
+        """
+        client = self._connect()
+        try:
+            issues = []
+
+            # Default site: symlink exists → nginx is serving HTTP on port 80
+            _, _, code = self._exec(
+                client, "test -e /etc/nginx/sites-enabled/default"
+            )
+            default_site_active = (code == 0)
+            if default_site_active:
+                issues.append(
+                    "Default HTTP site is active — nginx is listening on port 80 via "
+                    "sites-enabled/default. This blocks any stream config that also needs "
+                    "port 80 and may be unexpected traffic on a redirector."
+                )
+
+            # Stream block: grep for stream.d include in all nginx config files
+            stream_out, _, _ = self._exec(
+                client, "grep -r 'stream.d' /etc/nginx/ 2>/dev/null || true"
+            )
+            stream_block_present = bool(stream_out.strip())
+            if not stream_block_present:
+                issues.append(
+                    "No stream block found in nginx config — stream proxying will not work "
+                    "until a 'stream { include stream.d/*.conf; }' block is added to nginx.conf."
+                )
+
+            return {
+                "nginx_conf_ok": not issues,
+                "default_site_active": default_site_active,
+                "stream_block_present": stream_block_present,
+                "issues": issues,
+            }
+        finally:
+            client.close()
+
+    def sync_fix_nginx_setup(self, stream_dir: str) -> dict:
+        """
+        Fix common nginx setup issues:
+          1. Remove sites-enabled/default symlink (disables default HTTP server)
+          2. Ensure stream.d directory exists
+          3. Append stream block to nginx.conf if absent
+          4. nginx -t → systemctl reload nginx
+
+        Writes a temp script via SFTP and executes it with sudo.
+        Requires sudoers entry:
+            <user> ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix.sh
+        """
+        script = (
+            "#!/bin/bash\n"
+            "set -e\n"
+            "rm -f /etc/nginx/sites-enabled/default\n"
+            f"mkdir -p {stream_dir}\n"
+            "if ! grep -rq 'stream.d' /etc/nginx/ 2>/dev/null; then\n"
+            f"    printf '\\nstream {{\\n    include {stream_dir}/*.conf;\\n}}\\n'"
+            " >> /etc/nginx/nginx.conf\n"
+            "fi\n"
+            "/usr/sbin/nginx -t\n"
+            "systemctl reload nginx\n"
+        )
+        client = self._connect()
+        try:
+            sftp = client.open_sftp()
+            sftp.putfo(io.BytesIO(script.encode()), "/tmp/.cyberx_nginx_fix.sh")
+            sftp.chmod("/tmp/.cyberx_nginx_fix.sh", 0o700)
+
+            _, stderr, code = self._exec(
+                client, "sudo /bin/bash /tmp/.cyberx_nginx_fix.sh 2>&1"
+            )
+            self._exec(client, "rm -f /tmp/.cyberx_nginx_fix.sh")
+
+            if code != 0:
+                return {
+                    "success": False,
+                    "message": f"Fix script failed: {stderr.strip()}",
+                    "output": stderr.strip(),
+                }
+            return {
+                "success": True,
+                "message": "nginx configuration fixed — default site disabled, stream block added, nginx reloaded.",
+                "output": stderr.strip(),
+            }
+        finally:
+            client.close()
+
+
+    def sync_check_prereqs(self, stream_dir: str) -> dict:
+        """
+        Verify all CyberX prerequisites on the redirector:
+          1. nginx installed
+          2. nginx stream module compiled in
+          3. Stream directory exists
+          4. sudo nginx -t works
+          5. sudo systemctl reload nginx is allowed
+        """
+        client = self._connect()
+        try:
+            checks = []
+
+            # 1. nginx installed
+            _, _, code = self._exec(client, "which nginx 2>/dev/null")
+            nginx_ok = code == 0
+            checks.append({
+                "id": "nginx_installed",
+                "label": "nginx installed",
+                "ok": nginx_ok,
+                "detail": "nginx binary found." if nginx_ok
+                          else "nginx not found — install with: apt-get install nginx-full",
+            })
+
+            # 2. nginx stream module
+            if nginx_ok:
+                v_out, _, _ = self._exec(client, "nginx -V 2>&1")
+                stream_mod_ok = "with-stream" in v_out
+            else:
+                stream_mod_ok = False
+            checks.append({
+                "id": "nginx_stream",
+                "label": "nginx stream module",
+                "ok": stream_mod_ok,
+                "detail": "Stream module compiled in." if stream_mod_ok
+                          else "Stream module absent — install nginx-full: apt-get install nginx-full",
+            })
+
+            # 3. Stream directory
+            _, _, code = self._exec(client, f"test -d {stream_dir}")
+            dir_ok = code == 0
+            checks.append({
+                "id": "stream_dir",
+                "label": f"Stream directory ({stream_dir})",
+                "ok": dir_ok,
+                "detail": "Directory exists." if dir_ok
+                          else f"Directory missing — fix will create it.",
+            })
+
+            # 4. sudo nginx -t (runs nginx config test — safe, read-only)
+            out4, _, code = self._exec(
+                client, "sudo -n /usr/sbin/nginx -t 2>&1"
+            )
+            sudo_nginx_ok = code == 0
+            checks.append({
+                "id": "sudo_nginx",
+                "label": "sudo nginx -t allowed",
+                "ok": sudo_nginx_ok,
+                "detail": "sudo nginx -t succeeded." if sudo_nginx_ok
+                          else (
+                              f"sudo nginx -t failed — add sudoers entry: "
+                              f"{self.username} ALL=(ALL) NOPASSWD: /usr/sbin/nginx"
+                          ),
+            })
+
+            # 5. sudo systemctl reload nginx (check via is-active — read-only)
+            _, _, code = self._exec(
+                client, "sudo -n /bin/systemctl is-active nginx 2>/dev/null"
+            )
+            # exit 0 = active, exit 3 = inactive — both mean the sudo rule exists
+            sudo_systemctl_ok = code in (0, 3)
+            checks.append({
+                "id": "sudo_systemctl",
+                "label": "sudo systemctl nginx allowed",
+                "ok": sudo_systemctl_ok,
+                "detail": "sudo systemctl works." if sudo_systemctl_ok
+                          else (
+                              f"sudo systemctl failed — add sudoers entry: "
+                              f"{self.username} ALL=(ALL) NOPASSWD: /bin/systemctl reload nginx"
+                          ),
+            })
+
+            all_ok = all(c["ok"] for c in checks)
+            return {"all_ok": all_ok, "checks": checks}
+        finally:
+            client.close()
+
+    def sync_fix_prereqs(self, stream_dir: str) -> dict:
+        """
+        Attempt to satisfy CyberX prerequisites automatically:
+          1. Install nginx-full (if absent)
+          2. Create stream directory
+          3. Write /etc/sudoers.d/cyberx with required NOPASSWD entries
+          4. Validate sudoers with visudo -c
+
+        Writes a temp script via SFTP and executes it with 'sudo /bin/bash'.
+        Requires the SSH user to have NOPASSWD sudo (any command).
+        """
+        script = (
+            "#!/bin/bash\n"
+            "set -e\n"
+            "# Install nginx-full if nginx binary is missing\n"
+            "if ! command -v nginx &>/dev/null; then\n"
+            "    export DEBIAN_FRONTEND=noninteractive\n"
+            "    apt-get update -qq\n"
+            "    apt-get install -y nginx-full\n"
+            "fi\n"
+            f"# Create stream directory\n"
+            f"mkdir -p {stream_dir}\n"
+            "# Write sudoers file for CyberX\n"
+            f"cat > /etc/sudoers.d/cyberx <<'SUDOERS'\n"
+            f"{self.username} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/bash /tmp/.cyberx_nginx_fix.sh, /bin/bash /tmp/.cyberx_prereq_fix.sh\n"
+            "SUDOERS\n"
+            "chmod 440 /etc/sudoers.d/cyberx\n"
+            "visudo -c -f /etc/sudoers.d/cyberx\n"
+        )
+        client = self._connect()
+        try:
+            sftp = client.open_sftp()
+            sftp.putfo(io.BytesIO(script.encode()), "/tmp/.cyberx_prereq_fix.sh")
+            sftp.chmod("/tmp/.cyberx_prereq_fix.sh", 0o700)
+            sftp.close()
+
+            out, stderr, code = self._exec(
+                client, "sudo /bin/bash /tmp/.cyberx_prereq_fix.sh 2>&1"
+            )
+            self._exec(client, "rm -f /tmp/.cyberx_prereq_fix.sh")
+
+            if code != 0:
+                return {
+                    "success": False,
+                    "message": f"Prereq fix failed: {(out + stderr).strip()}",
+                    "output": (out + stderr).strip(),
+                }
+            return {
+                "success": True,
+                "message": "Prerequisites installed — nginx-full, stream dir, and sudoers configured.",
+                "output": (out + stderr).strip(),
+            }
+        finally:
+            client.close()
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers — use these from FastAPI route handlers
+# ---------------------------------------------------------------------------
+
+async def run_test_connection(ssh: SSHService) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ssh.sync_test_connection)
+
+
+async def run_check_prereqs(ssh: SSHService, stream_dir: str) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ssh.sync_check_prereqs, stream_dir)
+
+
+async def run_fix_prereqs(ssh: SSHService, stream_dir: str) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ssh.sync_fix_prereqs, stream_dir)
+
+
+async def run_check_nginx_setup(ssh: SSHService) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ssh.sync_check_nginx_setup)
+
+
+async def run_fix_nginx_setup(ssh: SSHService, stream_dir: str) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ssh.sync_fix_nginx_setup, stream_dir)
+
+
+async def run_check_port(ssh: SSHService, port: int, protocol: str) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_executor, ssh.sync_check_port, port, protocol)
+
+
+async def run_deploy_single(ssh: SSHService, stream_dir: str, stream) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _executor, ssh.sync_deploy_single, stream_dir, stream
+    )
+
+
+async def run_remove_single(
+    ssh: SSHService, stream_dir: str, stream_id: str, stream_name: str
+) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _executor, ssh.sync_remove_single, stream_dir, stream_id, stream_name
+    )
+
+
+async def run_deploy_all(ssh: SSHService, stream_dir: str, streams: list) -> dict:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _executor, ssh.sync_deploy_all, stream_dir, streams
+    )

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -19,6 +19,7 @@ from app.database import Base
 from app.models import (
     User, VPNCredential, Session, AuditLog, EmailEvent, VPNRequest,
     CloudInitTemplate, Instance, LicenseProduct, LicenseToken, LicenseSlot,
+    Redirector, StreamConfig,
 )
 
 # this is the Alembic Config object, which provides

--- a/backend/migrations/versions/20260323_000000_add_redirector_tables.py
+++ b/backend/migrations/versions/20260323_000000_add_redirector_tables.py
@@ -1,0 +1,84 @@
+"""Add redirectors and stream_configs tables
+
+Revision ID: 20260323_000000
+Revises: f988d0d58b40
+Create Date: 2026-03-23 00:00:00
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '20260323_000000'
+down_revision: Union[str, None] = 'f988d0d58b40'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # redirectors
+    # ------------------------------------------------------------------
+    op.create_table(
+        'redirectors',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('current_ip', sa.String(45), nullable=False),
+        sa.Column('ssh_port', sa.Integer(), nullable=False, server_default='22'),
+        sa.Column('ssh_username', sa.String(255), nullable=False),
+        sa.Column('ssh_private_key', sa.Text(), nullable=False),
+        sa.Column('ssh_key_passphrase', sa.Text(), nullable=True),
+        sa.Column('nginx_stream_dir', sa.String(500), nullable=False,
+                  server_default='/etc/nginx/stream.d'),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('status', sa.String(20), nullable=False, server_default='unknown'),
+        sa.Column('last_deployed_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('last_tested_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index('ix_redirectors_name', 'redirectors', ['name'], unique=True)
+    op.create_index('ix_redirectors_status', 'redirectors', ['status'])
+
+    # ------------------------------------------------------------------
+    # stream_configs
+    # ------------------------------------------------------------------
+    op.create_table(
+        'stream_configs',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column(
+            'redirector_id', sa.String(36),
+            sa.ForeignKey('redirectors.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('protocol', sa.String(10), nullable=False, server_default='tcp'),
+        sa.Column('listen_port', sa.Integer(), nullable=False),
+        sa.Column('cs_ip', sa.String(255), nullable=False),
+        sa.Column('cs_port', sa.Integer(), nullable=False),
+        sa.Column('access_control_enabled', sa.Boolean(), nullable=False,
+                  server_default=sa.false()),
+        sa.Column('allowed_cidrs', sa.JSON(), nullable=True),
+        sa.Column('ssl_enabled', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column('ssl_cert_path', sa.String(500), nullable=True),
+        sa.Column('ssl_key_path', sa.String(500), nullable=True),
+        sa.Column('ssl_protocols', sa.String(100), nullable=False,
+                  server_default='TLSv1.2 TLSv1.3'),
+        sa.Column('ssl_ciphers', sa.String(200), nullable=False,
+                  server_default='HIGH:!aNULL:!MD5'),
+        sa.Column('enabled', sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index('ix_stream_configs_redirector_id', 'stream_configs', ['redirector_id'])
+    op.create_index('ix_stream_configs_enabled', 'stream_configs', ['enabled'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_stream_configs_enabled', table_name='stream_configs')
+    op.drop_index('ix_stream_configs_redirector_id', table_name='stream_configs')
+    op.drop_table('stream_configs')
+
+    op.drop_index('ix_redirectors_status', table_name='redirectors')
+    op.drop_index('ix_redirectors_name', table_name='redirectors')
+    op.drop_table('redirectors')

--- a/backend/migrations/versions/20260323_000000_add_redirector_tables.py
+++ b/backend/migrations/versions/20260323_000000_add_redirector_tables.py
@@ -1,7 +1,7 @@
 """Add redirectors and stream_configs tables
 
 Revision ID: 20260323_000000
-Revises: f988d0d58b40
+Revises: 20260321_000000
 Create Date: 2026-03-23 00:00:00
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = '20260323_000000'
-down_revision: Union[str, None] = 'f988d0d58b40'
+down_revision: Union[str, None] = '20260321_000000'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/migrations/versions/20260323_000001_add_unique_port_constraint.py
+++ b/backend/migrations/versions/20260323_000001_add_unique_port_constraint.py
@@ -1,0 +1,33 @@
+"""Add unique constraint on (redirector_id, listen_port) and CHECK on protocol
+
+Revision ID: 20260323_000001
+Revises: 20260323_000000
+Create Date: 2026-03-23 00:00:01
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '20260323_000001'
+down_revision: Union[str, None] = '20260323_000000'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        'uq_stream_configs_redirector_port',
+        'stream_configs',
+        ['redirector_id', 'listen_port'],
+    )
+    op.create_check_constraint(
+        'ck_stream_protocol',
+        'stream_configs',
+        "protocol IN ('tcp', 'udp', 'dns')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('ck_stream_protocol', 'stream_configs', type_='check')
+    op.drop_constraint('uq_stream_configs_redirector_port', 'stream_configs', type_='unique')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -46,3 +46,6 @@ boto3==1.35.0
 
 # Environment
 python-dotenv==1.0.1
+
+# SSH/SFTP (nginx redirector management)
+paramiko>=3.4.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -48,4 +48,4 @@ boto3==1.35.0
 python-dotenv==1.0.1
 
 # SSH/SFTP (nginx redirector management)
-paramiko>=3.4.0
+paramiko==4.0.0

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -1,0 +1,767 @@
+{% extends "layouts/dashboard.html" %}
+
+{% block title %}{{ redirector.name }} — Redirector{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-4 py-4">
+
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/admin/redirectors">Redirectors</a></li>
+            <li class="breadcrumb-item active">{{ redirector.name }}</li>
+        </ol>
+    </nav>
+
+    <!-- Header Card -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex align-items-start justify-content-between flex-wrap gap-3">
+                <div>
+                    <div class="d-flex align-items-center gap-3 mb-2">
+                        <h2 class="h4 fw-bold mb-0">
+                            <i data-feather="server" class="me-2" style="color:#d32f2f;"></i>
+                            {{ redirector.name }}
+                        </h2>
+                        <span id="statusBadge" class="badge fs-6
+                            {% if redirector.status == 'online' %}bg-success
+                            {% elif redirector.status == 'offline' %}bg-danger
+                            {% else %}bg-secondary{% endif %}">
+                            {{ redirector.status }}
+                        </span>
+                    </div>
+                    <div class="text-muted small">
+                        <code>{{ redirector.ssh_username }}@{{ redirector.current_ip }}:{{ redirector.ssh_port }}</code>
+                        &nbsp;·&nbsp;
+                        Stream dir: <code>{{ redirector.nginx_stream_dir }}</code>
+                        {% if redirector.last_tested_at %}
+                        &nbsp;·&nbsp; Last tested:
+                        <span class="js-dt">{{ redirector.last_tested_at.isoformat() }}</span>
+                        {% endif %}
+                    </div>
+                    {% if redirector.notes %}
+                    <p class="mt-2 mb-0 text-muted small">{{ redirector.notes }}</p>
+                    {% endif %}
+                </div>
+                <div class="d-flex gap-2 flex-wrap">
+                    <button class="btn btn-outline-secondary" onclick="testConnection()">
+                        <i data-feather="wifi" class="me-1"></i>Test Connection
+                    </button>
+                    <button class="btn btn-primary" onclick="deployAll()">
+                        <i data-feather="upload-cloud" class="me-1"></i>Deploy All
+                    </button>
+                    <button class="btn btn-outline-secondary" onclick="openEditRedirectorModal()">
+                        <i data-feather="edit-2" class="me-1"></i>Edit
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Setup Guide (collapsible) -->
+    <div class="accordion mb-4" id="setupGuide">
+        <div class="accordion-item border">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed fw-semibold" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#setupGuideBody">
+                    <i data-feather="info" class="me-2"></i>Prerequisites on this redirector
+                </button>
+            </h2>
+            <div id="setupGuideBody" class="accordion-collapse collapse">
+                <div class="accordion-body small">
+                    <p class="mb-2"><strong>1. nginx.conf must include the stream block:</strong></p>
+                    <pre class="bg-dark text-light rounded p-3 mb-3">stream {
+    include {{ redirector.nginx_stream_dir }}/*.conf;
+}</pre>
+                    <p class="mb-2"><strong>2. Sudo permissions for nginx management:</strong></p>
+                    <pre class="bg-dark text-light rounded p-3 mb-0"># /etc/sudoers.d/cyberx
+{{ redirector.ssh_username }} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx</pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Stream Configs Table -->
+    <div class="card shadow-sm">
+        <div class="card-header d-flex align-items-center justify-content-between py-3">
+            <h5 class="mb-0 fw-semibold"><i data-feather="git-branch" class="me-2"></i>Stream Configs</h5>
+            <button class="btn btn-sm btn-danger" onclick="openAddStreamModal()">
+                <i data-feather="plus" class="me-1"></i>Add Stream
+            </button>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0" id="streamsTable">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>Protocol</th>
+                            <th>Listen</th>
+                            <th>CS Target</th>
+                            <th class="text-center">SSL</th>
+                            <th class="text-center">ACL</th>
+                            <th class="text-center">Enabled</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="streamsBody">
+                        <tr>
+                            <td colspan="8" class="text-center text-muted py-4">
+                                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                                Loading streams...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Edit Redirector Modal
+     ================================================================ -->
+<div class="modal fade" id="editRedirectorModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i data-feather="edit-2" class="me-2"></i>Edit Redirector</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">Name</label>
+                        <input type="text" class="form-control" id="er_name" value="{{ redirector.name }}">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">IP Address</label>
+                        <input type="text" class="form-control" id="er_ip" value="{{ redirector.current_ip }}">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold">SSH Port</label>
+                        <input type="number" class="form-control" id="er_port" value="{{ redirector.ssh_port }}" min="1" max="65535">
+                    </div>
+                    <div class="col-md-8">
+                        <label class="form-label fw-semibold">SSH Username</label>
+                        <input type="text" class="form-control" id="er_user" value="{{ redirector.ssh_username }}">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">SSH Private Key (PEM)</label>
+                        <textarea class="form-control font-monospace" id="er_key" rows="5"
+                            placeholder="Leave blank to keep existing key"></textarea>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">Key Passphrase</label>
+                        <input type="password" class="form-control" id="er_pass"
+                            placeholder="Leave blank to keep existing passphrase">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">nginx Stream Directory</label>
+                        <input type="text" class="form-control" id="er_dir" value="{{ redirector.nginx_stream_dir }}">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">Notes</label>
+                        <textarea class="form-control" id="er_notes" rows="2">{{ redirector.notes or '' }}</textarea>
+                    </div>
+                </div>
+                <div id="editRedirectorError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitEditRedirector()">
+                    <i data-feather="save" class="me-1"></i>Save Changes
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Add / Edit Stream Modal
+     ================================================================ -->
+<div class="modal fade" id="streamModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="streamModalTitle">
+                    <i data-feather="plus-circle" class="me-2"></i>Add Stream Config
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="sm_stream_id">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">Name <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="sm_name" placeholder="HTTPS Beacon">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-semibold">Protocol</label>
+                        <select class="form-select" id="sm_protocol" onchange="updateProtocolHelp()">
+                            <option value="tcp">TCP</option>
+                            <option value="udp">UDP</option>
+                            <option value="dns">DNS (UDP/53)</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-semibold">Listen Port <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control" id="sm_listen_port" min="1" max="65535" placeholder="443">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">CS Teamserver IP <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="sm_cs_ip" placeholder="10.10.0.1">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-semibold">CS Port <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control" id="sm_cs_port" min="1" max="65535" placeholder="443">
+                    </div>
+                    <div class="col-md-3 d-flex align-items-end">
+                        <div class="form-check mb-1">
+                            <input class="form-check-input" type="checkbox" id="sm_enabled" checked>
+                            <label class="form-check-label fw-semibold" for="sm_enabled">Enabled</label>
+                        </div>
+                    </div>
+
+                    <!-- Access Control -->
+                    <div class="col-12">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="sm_acl_enabled"
+                                onchange="toggleCollapse('aclSection', this.checked)">
+                            <label class="form-check-label fw-semibold" for="sm_acl_enabled">
+                                <i data-feather="shield" class="me-1"></i>Enable Access Control
+                            </label>
+                        </div>
+                        <div id="aclSection" class="mt-2 ps-4 d-none">
+                            <label class="form-label small">Allowed CIDRs (comma-separated)</label>
+                            <input type="text" class="form-control" id="sm_cidrs"
+                                placeholder="1.2.3.4, 10.0.0.0/8, 203.0.113.0/24">
+                            <div class="form-text">Generates <code>allow &lt;cidr&gt;;</code> + <code>deny all;</code></div>
+                        </div>
+                    </div>
+
+                    <!-- SSL/TLS (TCP only) -->
+                    <div class="col-12" id="sslToggleRow">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="sm_ssl_enabled"
+                                onchange="toggleCollapse('sslSection', this.checked)">
+                            <label class="form-check-label fw-semibold" for="sm_ssl_enabled">
+                                <i data-feather="lock" class="me-1"></i>Enable SSL/TLS Termination
+                            </label>
+                        </div>
+                        <div id="sslSection" class="mt-2 ps-4 d-none">
+                            <div class="row g-2">
+                                <div class="col-12">
+                                    <label class="form-label small">Certificate Path (on redirector)</label>
+                                    <input type="text" class="form-control" id="sm_ssl_cert"
+                                        placeholder="/etc/ssl/certs/redir.pem">
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label small">Key Path (on redirector)</label>
+                                    <input type="text" class="form-control" id="sm_ssl_key"
+                                        placeholder="/etc/ssl/private/redir.key">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label small">SSL Protocols</label>
+                                    <input type="text" class="form-control" id="sm_ssl_protocols" value="TLSv1.2 TLSv1.3">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label small">SSL Ciphers</label>
+                                    <input type="text" class="form-control" id="sm_ssl_ciphers" value="HIGH:!aNULL:!MD5">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="streamModalError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitStream()">
+                    <i data-feather="save" class="me-1"></i>Save Stream
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Preview Modal
+     ================================================================ -->
+<div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i data-feather="eye" class="me-2"></i>Config Preview
+                    <span id="previewFilename" class="text-muted small ms-2 font-monospace"></span>
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <textarea class="form-control font-monospace bg-dark text-light border-0"
+                    id="previewContent" rows="20" readonly></textarea>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Deploy Result Modal
+     ================================================================ -->
+<div class="modal fade" id="deployResultModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deployResultTitle">Deploy Result</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div id="deployResultStatus" class="mb-3"></div>
+                <div id="deployResultFiles" class="mb-3 small"></div>
+                <div id="deployResultOutput"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Delete Stream Confirmation -->
+<div class="modal fade" id="deleteStreamModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <h5 class="modal-title text-danger"><i data-feather="trash-2" class="me-2"></i>Delete Stream</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Delete stream <strong id="deleteStreamName"></strong>?</p>
+                <p class="text-muted small">This removes it from the database only. Use <em>Remove</em> first to clean up the remote file.</p>
+            </div>
+            <div class="modal-footer border-0">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="confirmDeleteStream()">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// ============================================================
+// Constants
+// ============================================================
+const REDIRECTOR_ID = '{{ redirector.id }}';
+let _deleteStreamId   = null;
+let _deleteStreamName = null;
+
+// Bootstrap modals
+const editRedirModal   = new bootstrap.Modal(document.getElementById('editRedirectorModal'));
+const streamModal      = new bootstrap.Modal(document.getElementById('streamModal'));
+const previewModal     = new bootstrap.Modal(document.getElementById('previewModal'));
+const deployResultModal = new bootstrap.Modal(document.getElementById('deployResultModal'));
+const delStreamModal   = new bootstrap.Modal(document.getElementById('deleteStreamModal'));
+
+// Re-render feather icons after each modal shows
+document.querySelectorAll('.modal').forEach(el => {
+    el.addEventListener('shown.bs.modal', () => feather.replace());
+});
+
+// Format datetime spans
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.js-dt').forEach(el => {
+        el.textContent = formatDateTime(el.textContent);
+    });
+    loadStreams();
+});
+
+// ============================================================
+// Stream table
+// ============================================================
+async function loadStreams() {
+    const resp = await fetch(`/api/redirectors/${REDIRECTOR_ID}/streams`);
+    if (!resp.ok) { renderStreams([]); return; }
+    const streams = await resp.json();
+    renderStreams(streams);
+}
+
+function renderStreams(streams) {
+    const tbody = document.getElementById('streamsBody');
+    if (!streams.length) {
+        tbody.innerHTML = `<tr><td colspan="8" class="text-center text-muted py-5">
+            No stream configs yet. Click <strong>Add Stream</strong> to create one.
+        </td></tr>`;
+        feather.replace();
+        return;
+    }
+    tbody.innerHTML = streams.map(s => `
+        <tr>
+            <td class="fw-semibold">${escHtml(s.name)}</td>
+            <td>${protoBadge(s.protocol)}</td>
+            <td><code>${s.listen_port}</code></td>
+            <td class="small text-muted"><code>${escHtml(s.cs_ip)}:${s.cs_port}</code></td>
+            <td class="text-center">${s.ssl_enabled ? '<i data-feather="lock" class="text-success" title="SSL enabled"></i>' : '<span class="text-muted">—</span>'}</td>
+            <td class="text-center">${s.access_control_enabled ? '<i data-feather="shield" class="text-warning" title="ACL enabled"></i>' : '<span class="text-muted">—</span>'}</td>
+            <td class="text-center">
+                <span class="badge ${s.enabled ? 'bg-success' : 'bg-secondary'}">${s.enabled ? 'Yes' : 'No'}</span>
+            </td>
+            <td class="text-end">
+                <button class="btn btn-sm btn-outline-secondary me-1" title="Preview config"
+                    onclick="previewStream('${s.id}')"><i data-feather="eye"></i></button>
+                <button class="btn btn-sm btn-outline-primary me-1" title="Deploy this stream"
+                    onclick="deployStream('${s.id}', '${escHtml(s.name)}')"><i data-feather="upload"></i></button>
+                <button class="btn btn-sm btn-outline-warning me-1" title="Remove file from redirector"
+                    onclick="removeStream('${s.id}', '${escHtml(s.name)}')"><i data-feather="minus-circle"></i></button>
+                <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
+                    onclick="openEditStreamModal(${JSON.stringify(s)})"><i data-feather="edit-2"></i></button>
+                <button class="btn btn-sm btn-outline-danger" title="Delete from DB"
+                    onclick="openDeleteStreamModal('${s.id}', '${escHtml(s.name)}')"><i data-feather="trash-2"></i></button>
+            </td>
+        </tr>
+    `).join('');
+    feather.replace();
+}
+
+function protoBadge(proto) {
+    const map = { tcp: 'bg-primary', udp: 'bg-info text-dark', dns: 'bg-warning text-dark' };
+    return `<span class="badge ${map[proto] || 'bg-secondary'}">${proto.toUpperCase()}</span>`;
+}
+
+// ============================================================
+// Test Connection
+// ============================================================
+async function testConnection() {
+    showToast('Testing SSH connection...', 'info');
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/test-connection`, { method: 'POST' });
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Connection failed: ${data.detail}`, 'danger');
+            updateStatusBadge('offline');
+            return;
+        }
+        updateStatusBadge(data.status);
+        const rtt = data.rtt_ms ? ` (${data.rtt_ms}ms)` : '';
+        const streamWarn = data.stream_module_present ? '' : ' ⚠️ Stream module not found!';
+        showToast(`${data.message}${rtt}${streamWarn}`, data.success ? 'success' : 'warning');
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+// ============================================================
+// Deploy All
+// ============================================================
+async function deployAll() {
+    showToast('Deploying all streams...', 'info');
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/deploy-all`, { method: 'POST' });
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult('Deploy All', data);
+        if (data.success) loadStreams();
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+// ============================================================
+// Stream operations
+// ============================================================
+async function previewStream(streamId) {
+    try {
+        const resp = await fetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/preview`);
+        const data = await resp.json();
+        document.getElementById('previewFilename').textContent = data.filename;
+        document.getElementById('previewContent').value = data.content;
+        previewModal.show();
+    } catch (err) {
+        showToast(`Preview failed: ${err.message}`, 'danger');
+    }
+}
+
+async function deployStream(streamId, streamName) {
+    if (!confirm(`Deploy stream "${streamName}" to the redirector?`)) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/deploy`,
+            { method: 'POST' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult(`Deploy: ${streamName}`, data);
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+async function removeStream(streamId, streamName) {
+    if (!confirm(`Remove file for stream "${streamName}" from the redirector?\n\nThis reloads nginx. The stream config is kept in the database.`)) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/remove`,
+            { method: 'POST' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Remove failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult(`Remove: ${streamName}`, data);
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+// ============================================================
+// Add/Edit stream modal
+// ============================================================
+function openAddStreamModal() {
+    document.getElementById('sm_stream_id').value = '';
+    document.getElementById('streamModalTitle').innerHTML = '<i data-feather="plus-circle" class="me-2"></i>Add Stream Config';
+    document.getElementById('sm_name').value = '';
+    document.getElementById('sm_protocol').value = 'tcp';
+    document.getElementById('sm_listen_port').value = '';
+    document.getElementById('sm_cs_ip').value = '';
+    document.getElementById('sm_cs_port').value = '';
+    document.getElementById('sm_enabled').checked = true;
+    document.getElementById('sm_acl_enabled').checked = false;
+    document.getElementById('sm_cidrs').value = '';
+    document.getElementById('sm_ssl_enabled').checked = false;
+    document.getElementById('sm_ssl_cert').value = '';
+    document.getElementById('sm_ssl_key').value = '';
+    document.getElementById('sm_ssl_protocols').value = 'TLSv1.2 TLSv1.3';
+    document.getElementById('sm_ssl_ciphers').value = 'HIGH:!aNULL:!MD5';
+    document.getElementById('aclSection').classList.add('d-none');
+    document.getElementById('sslSection').classList.add('d-none');
+    document.getElementById('streamModalError').classList.add('d-none');
+    updateProtocolHelp();
+    streamModal.show();
+}
+
+function openEditStreamModal(s) {
+    document.getElementById('sm_stream_id').value = s.id;
+    document.getElementById('streamModalTitle').innerHTML = '<i data-feather="edit-2" class="me-2"></i>Edit Stream Config';
+    document.getElementById('sm_name').value = s.name;
+    document.getElementById('sm_protocol').value = s.protocol;
+    document.getElementById('sm_listen_port').value = s.listen_port;
+    document.getElementById('sm_cs_ip').value = s.cs_ip;
+    document.getElementById('sm_cs_port').value = s.cs_port;
+    document.getElementById('sm_enabled').checked = s.enabled;
+    document.getElementById('sm_acl_enabled').checked = s.access_control_enabled;
+    document.getElementById('sm_cidrs').value = (s.allowed_cidrs || []).join(', ');
+    document.getElementById('sm_ssl_enabled').checked = s.ssl_enabled;
+    document.getElementById('sm_ssl_cert').value = s.ssl_cert_path || '';
+    document.getElementById('sm_ssl_key').value = s.ssl_key_path || '';
+    document.getElementById('sm_ssl_protocols').value = s.ssl_protocols;
+    document.getElementById('sm_ssl_ciphers').value = s.ssl_ciphers;
+    toggleCollapse('aclSection', s.access_control_enabled);
+    toggleCollapse('sslSection', s.ssl_enabled);
+    document.getElementById('streamModalError').classList.add('d-none');
+    updateProtocolHelp();
+    streamModal.show();
+}
+
+async function submitStream() {
+    const errEl = document.getElementById('streamModalError');
+    errEl.classList.add('d-none');
+    const streamId = document.getElementById('sm_stream_id').value;
+
+    const cidrsRaw = document.getElementById('sm_cidrs').value.trim();
+    const cidrs = cidrsRaw ? cidrsRaw.split(',').map(c => c.trim()).filter(c => c) : null;
+
+    const payload = {
+        name: document.getElementById('sm_name').value.trim(),
+        protocol: document.getElementById('sm_protocol').value,
+        listen_port: parseInt(document.getElementById('sm_listen_port').value, 10),
+        cs_ip: document.getElementById('sm_cs_ip').value.trim(),
+        cs_port: parseInt(document.getElementById('sm_cs_port').value, 10),
+        enabled: document.getElementById('sm_enabled').checked,
+        access_control_enabled: document.getElementById('sm_acl_enabled').checked,
+        allowed_cidrs: cidrs,
+        ssl_enabled: document.getElementById('sm_ssl_enabled').checked,
+        ssl_cert_path: document.getElementById('sm_ssl_cert').value.trim() || null,
+        ssl_key_path: document.getElementById('sm_ssl_key').value.trim() || null,
+        ssl_protocols: document.getElementById('sm_ssl_protocols').value.trim(),
+        ssl_ciphers: document.getElementById('sm_ssl_ciphers').value.trim(),
+    };
+
+    if (!payload.name || !payload.cs_ip || !payload.listen_port || !payload.cs_port) {
+        errEl.textContent = 'Please fill in all required fields.';
+        errEl.classList.remove('d-none');
+        return;
+    }
+
+    const url = streamId
+        ? `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}`
+        : `/api/redirectors/${REDIRECTOR_ID}/streams`;
+    const method = streamId ? 'PUT' : 'POST';
+
+    try {
+        const resp = await csrfFetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Failed to save stream config.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        streamModal.hide();
+        showToast(`Stream <strong>${escHtml(data.name)}</strong> ${streamId ? 'updated' : 'created'}.`, 'success');
+        loadStreams();
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Delete stream
+// ============================================================
+function openDeleteStreamModal(id, name) {
+    _deleteStreamId = id;
+    _deleteStreamName = name;
+    document.getElementById('deleteStreamName').textContent = name;
+    delStreamModal.show();
+}
+
+async function confirmDeleteStream() {
+    if (!_deleteStreamId) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${_deleteStreamId}`,
+            { method: 'DELETE' }
+        );
+        if (!resp.ok && resp.status !== 204) {
+            const d = await resp.json().catch(() => ({}));
+            showToast(d.detail || 'Delete failed.', 'danger');
+            return;
+        }
+        delStreamModal.hide();
+        showToast(`Stream <strong>${escHtml(_deleteStreamName)}</strong> deleted.`, 'success');
+        loadStreams();
+    } catch (err) {
+        showToast(`Delete failed: ${err.message}`, 'danger');
+    }
+    _deleteStreamId = null;
+}
+
+// ============================================================
+// Edit Redirector
+// ============================================================
+function openEditRedirectorModal() { editRedirModal.show(); }
+
+async function submitEditRedirector() {
+    const errEl = document.getElementById('editRedirectorError');
+    errEl.classList.add('d-none');
+    const payload = {};
+    const v = id => document.getElementById(id).value;
+    if (v('er_name').trim())  payload.name = v('er_name').trim();
+    if (v('er_ip').trim())    payload.current_ip = v('er_ip').trim();
+    const port = parseInt(v('er_port'), 10);
+    if (port)                 payload.ssh_port = port;
+    if (v('er_user').trim())  payload.ssh_username = v('er_user').trim();
+    if (v('er_key').trim())   payload.ssh_private_key = v('er_key').trim();
+    if (v('er_pass'))         payload.ssh_key_passphrase = v('er_pass');
+    if (v('er_dir').trim())   payload.nginx_stream_dir = v('er_dir').trim();
+    payload.notes = v('er_notes').trim() || null;
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Update failed.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        editRedirModal.hide();
+        showToast('Redirector updated. Reload page to see changes.', 'success');
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Deploy Result Modal
+// ============================================================
+function showDeployResult(title, data) {
+    document.getElementById('deployResultTitle').textContent = title;
+    const icon = data.success ? '✓' : '✗';
+    const cls  = data.success ? 'text-success' : 'text-danger';
+    document.getElementById('deployResultStatus').innerHTML =
+        `<span class="${cls} fw-bold fs-5">${icon} ${data.success ? 'Success' : 'Failed'}</span>
+         <span class="text-muted small ms-2">${escHtml(data.message)}</span>`;
+
+    let filesHtml = '';
+    if (data.files_written.length)
+        filesHtml += `<div>Written: ${data.files_written.map(f => `<code>${escHtml(f)}</code>`).join(', ')}</div>`;
+    if (data.files_deleted.length)
+        filesHtml += `<div>Removed: ${data.files_deleted.map(f => `<code>${escHtml(f)}</code>`).join(', ')}</div>`;
+    document.getElementById('deployResultFiles').innerHTML = filesHtml;
+
+    const nginxOut = data.nginx_test_output || data.nginx_reload_output;
+    document.getElementById('deployResultOutput').innerHTML = nginxOut
+        ? `<label class="form-label small fw-semibold">nginx output:</label>
+           <pre class="bg-dark text-light rounded p-3 small">${escHtml(nginxOut)}</pre>`
+        : '';
+
+    deployResultModal.show();
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+function updateStatusBadge(status) {
+    const badge = document.getElementById('statusBadge');
+    badge.textContent = status;
+    badge.className = 'badge fs-6 ' + (status === 'online' ? 'bg-success' : status === 'offline' ? 'bg-danger' : 'bg-secondary');
+}
+
+function toggleCollapse(sectionId, show) {
+    document.getElementById(sectionId).classList.toggle('d-none', !show);
+}
+
+function updateProtocolHelp() {
+    const proto = document.getElementById('sm_protocol').value;
+    // Hide SSL for UDP/DNS streams
+    const sslRow = document.getElementById('sslToggleRow');
+    if (proto === 'udp' || proto === 'dns') {
+        sslRow.classList.add('d-none');
+        document.getElementById('sm_ssl_enabled').checked = false;
+        document.getElementById('sslSection').classList.add('d-none');
+    } else {
+        sslRow.classList.remove('d-none');
+    }
+    // Auto-fill port for DNS
+    if (proto === 'dns' && !document.getElementById('sm_listen_port').value) {
+        document.getElementById('sm_listen_port').value = '53';
+    }
+}
+
+function escHtml(str) {
+    if (!str) return '';
+    return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+                      .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+}
+</script>
+{% endblock %}

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -391,7 +391,20 @@ async function loadStreams() {
     renderStreams(streams);
 }
 
+// Map of stream objects by ID — used by event-delegated edit button
+const _streamMap = new Map();
+
+// Event delegation for stream edit buttons — avoids inline JSON.stringify XSS
+document.addEventListener('click', e => {
+    const btn = e.target.closest('[data-edit-stream-id]');
+    if (btn) {
+        const s = _streamMap.get(btn.dataset.editStreamId);
+        if (s) openEditStreamModal(s);
+    }
+});
+
 function renderStreams(streams) {
+    streams.forEach(s => _streamMap.set(s.id, s));
     const tbody = document.getElementById('streamsBody');
     if (!streams.length) {
         tbody.innerHTML = `<tr><td colspan="8" class="text-center text-muted py-5">
@@ -419,7 +432,7 @@ function renderStreams(streams) {
                 <button class="btn btn-sm btn-outline-warning me-1" title="Remove file from redirector"
                     onclick="removeStream('${s.id}', '${escHtml(s.name)}')"><i data-feather="minus-circle"></i></button>
                 <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
-                    onclick="openEditStreamModal(${JSON.stringify(s)})"><i data-feather="edit-2"></i></button>
+                    data-edit-stream-id="${escHtml(s.id)}"><i data-feather="edit-2"></i></button>
                 <button class="btn btn-sm btn-outline-danger" title="Delete from DB"
                     onclick="openDeleteStreamModal('${s.id}', '${escHtml(s.name)}')"><i data-feather="trash-2"></i></button>
             </td>
@@ -442,7 +455,7 @@ async function testConnection() {
         const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/test-connection`, { method: 'POST' });
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Connection failed: ${data.detail}`, 'danger');
+            showToast(`Connection failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             updateStatusBadge('offline');
             return;
         }
@@ -464,7 +477,7 @@ async function deployAll() {
         const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/deploy-all`, { method: 'POST' });
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            showToast(`Deploy failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult('Deploy All', data);
@@ -498,7 +511,7 @@ async function deployStream(streamId, streamName) {
         );
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            showToast(`Deploy failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult(`Deploy: ${streamName}`, data);
@@ -516,7 +529,7 @@ async function removeStream(streamId, streamName) {
         );
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Remove failed: ${data.detail}`, 'danger');
+            showToast(`Remove failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult(`Remove: ${streamName}`, data);

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -1,0 +1,448 @@
+{% extends "layouts/dashboard.html" %}
+
+{% block title %}Redirectors{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-4 py-4">
+
+    <!-- Page Header -->
+    <div class="d-flex align-items-center justify-content-between mb-4">
+        <div>
+            <h1 class="h3 mb-0 fw-bold">
+                <i data-feather="server" class="me-2" style="color:#d32f2f;"></i>Redirectors
+            </h1>
+            <p class="text-muted small mb-0 mt-1">
+                Manage nginx stream proxy configurations on remote redirector servers via SSH.
+            </p>
+        </div>
+        <button class="btn btn-danger" onclick="openAddModal()">
+            <i data-feather="plus" class="me-1"></i> Add Redirector
+        </button>
+    </div>
+
+    <!-- Redirectors Table -->
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0" id="redirectorsTable">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>IP Address</th>
+                            <th>SSH User:Port</th>
+                            <th>Status</th>
+                            <th>Streams</th>
+                            <th>Last Deployed</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="redirectorsBody">
+                        <tr id="loadingRow">
+                            <td colspan="7" class="text-center text-muted py-4">
+                                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                                Loading redirectors...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Add Redirector Modal
+     ================================================================ -->
+<div class="modal fade" id="addRedirectorModal" tabindex="-1" aria-labelledby="addRedirectorModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addRedirectorModalLabel">
+                    <i data-feather="plus-circle" class="me-2"></i>Add Redirector
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addRedirectorForm">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">Name <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="add_name" placeholder="e.g. prod-redirector-01" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="add_ip" placeholder="203.0.113.10" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label fw-semibold">SSH Port</label>
+                            <input type="number" class="form-control" id="add_ssh_port" value="22" min="1" max="65535">
+                        </div>
+                        <div class="col-md-8">
+                            <label class="form-label fw-semibold">SSH Username <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="add_ssh_username" placeholder="debian" required>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">
+                                SSH Private Key (PEM) <span class="text-danger">*</span>
+                            </label>
+                            <textarea class="form-control font-monospace" id="add_ssh_key" rows="6"
+                                placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;...&#10;-----END OPENSSH PRIVATE KEY-----" required></textarea>
+                            <div class="form-text">Paste the full PEM private key. Stored encrypted at rest.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Key Passphrase <span class="text-muted small">(optional)</span></label>
+                            <input type="password" class="form-control" id="add_passphrase" placeholder="Leave blank if key has no passphrase">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">nginx Stream Directory</label>
+                            <input type="text" class="form-control" id="add_stream_dir" value="/etc/nginx/stream.d">
+                            <div class="form-text">Directory where <code>cyberx_*.conf</code> files are written. Must be included in nginx.conf.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Notes <span class="text-muted small">(optional)</span></label>
+                            <textarea class="form-control" id="add_notes" rows="2" placeholder="Optional notes about this redirector"></textarea>
+                        </div>
+                    </div>
+                </form>
+                <div id="addRedirectorError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitAddRedirector()">
+                    <i data-feather="save" class="me-1"></i>Save Redirector
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Edit Redirector Modal
+     ================================================================ -->
+<div class="modal fade" id="editRedirectorModal" tabindex="-1" aria-labelledby="editRedirectorModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="editRedirectorModalLabel">
+                    <i data-feather="edit-2" class="me-2"></i>Edit Redirector
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="edit_redirector_id">
+                <form id="editRedirectorForm">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">Name</label>
+                            <input type="text" class="form-control" id="edit_name" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">IP Address</label>
+                            <input type="text" class="form-control" id="edit_ip" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label fw-semibold">SSH Port</label>
+                            <input type="number" class="form-control" id="edit_ssh_port" min="1" max="65535">
+                        </div>
+                        <div class="col-md-8">
+                            <label class="form-label fw-semibold">SSH Username</label>
+                            <input type="text" class="form-control" id="edit_ssh_username">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">SSH Private Key (PEM)</label>
+                            <textarea class="form-control font-monospace" id="edit_ssh_key" rows="6"
+                                placeholder="Leave blank to keep existing key"></textarea>
+                            <div class="form-text">Leave blank to keep the current key. Paste new PEM to replace it.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Key Passphrase</label>
+                            <input type="password" class="form-control" id="edit_passphrase"
+                                placeholder="Leave blank to keep existing passphrase">
+                            <div class="form-text">Leave blank to keep existing. Send a space to clear the passphrase.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">nginx Stream Directory</label>
+                            <input type="text" class="form-control" id="edit_stream_dir">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Notes</label>
+                            <textarea class="form-control" id="edit_notes" rows="2"></textarea>
+                        </div>
+                    </div>
+                </form>
+                <div id="editRedirectorError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitEditRedirector()">
+                    <i data-feather="save" class="me-1"></i>Save Changes
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Delete Confirmation Modal
+     ================================================================ -->
+<div class="modal fade" id="deleteRedirectorModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <h5 class="modal-title text-danger">
+                    <i data-feather="trash-2" class="me-2"></i>Delete Redirector
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to delete <strong id="deleteRedirectorName"></strong>?</p>
+                <p class="text-muted small mb-0">
+                    This removes the redirector and all stream configs from the database.
+                    Remote nginx config files are <strong>not</strong> automatically removed.
+                    Run "Remove" on each stream before deleting if needed.
+                </p>
+            </div>
+            <div class="modal-footer border-0">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="confirmDeleteRedirector()">
+                    <i data-feather="trash-2" class="me-1"></i>Delete
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// ============================================================
+// State
+// ============================================================
+let _redirectors = [];
+let _deleteTargetId = null;
+
+const addModal  = new bootstrap.Modal(document.getElementById('addRedirectorModal'));
+const editModal = new bootstrap.Modal(document.getElementById('editRedirectorModal'));
+const delModal  = new bootstrap.Modal(document.getElementById('deleteRedirectorModal'));
+
+// ============================================================
+// Bootstrap: re-render feather icons after modal shows
+// ============================================================
+document.querySelectorAll('.modal').forEach(el => {
+    el.addEventListener('shown.bs.modal', () => feather.replace());
+});
+
+// ============================================================
+// Load redirectors on page load
+// ============================================================
+document.addEventListener('DOMContentLoaded', loadRedirectors);
+
+async function loadRedirectors() {
+    try {
+        const resp = await fetch('/api/redirectors/');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        _redirectors = data.redirectors || [];
+        renderTable(_redirectors);
+    } catch (err) {
+        document.getElementById('redirectorsBody').innerHTML =
+            `<tr><td colspan="7" class="text-center text-danger py-4">Failed to load redirectors: ${err.message}</td></tr>`;
+    }
+}
+
+function renderTable(redirectors) {
+    const tbody = document.getElementById('redirectorsBody');
+    if (!redirectors.length) {
+        tbody.innerHTML = `<tr><td colspan="7" class="text-center text-muted py-5">
+            No redirectors yet. Click <strong>Add Redirector</strong> to get started.
+        </td></tr>`;
+        feather.replace();
+        return;
+    }
+    tbody.innerHTML = redirectors.map(r => `
+        <tr>
+            <td>
+                <a href="/admin/redirectors/${r.id}" class="fw-semibold text-decoration-none">
+                    ${escHtml(r.name)}
+                </a>
+            </td>
+            <td><code>${escHtml(r.current_ip)}</code></td>
+            <td class="text-muted small">${escHtml(r.ssh_username)}@${r.current_ip}:${r.ssh_port}</td>
+            <td>${statusBadge(r.status)}</td>
+            <td><span class="badge bg-secondary rounded-pill">${r.stream_count}</span></td>
+            <td class="text-muted small">${r.last_deployed_at ? formatDateTime(r.last_deployed_at) : '—'}</td>
+            <td class="text-end">
+                <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
+                    onclick="openEditModal(${JSON.stringify(r)})">
+                    <i data-feather="edit-2"></i>
+                </button>
+                <button class="btn btn-sm btn-outline-danger" title="Delete"
+                    onclick="openDeleteModal('${r.id}', '${escHtml(r.name)}')">
+                    <i data-feather="trash-2"></i>
+                </button>
+            </td>
+        </tr>
+    `).join('');
+    feather.replace();
+}
+
+function statusBadge(status) {
+    const map = {
+        online:  'bg-success',
+        offline: 'bg-danger',
+        unknown: 'bg-secondary',
+    };
+    const cls = map[status] || 'bg-secondary';
+    return `<span class="badge ${cls}">${status}</span>`;
+}
+
+// ============================================================
+// Add Modal
+// ============================================================
+function openAddModal() {
+    document.getElementById('addRedirectorForm').reset();
+    document.getElementById('addRedirectorError').classList.add('d-none');
+    addModal.show();
+}
+
+async function submitAddRedirector() {
+    const errEl = document.getElementById('addRedirectorError');
+    errEl.classList.add('d-none');
+
+    const payload = {
+        name:             document.getElementById('add_name').value.trim(),
+        current_ip:       document.getElementById('add_ip').value.trim(),
+        ssh_port:         parseInt(document.getElementById('add_ssh_port').value, 10),
+        ssh_username:     document.getElementById('add_ssh_username').value.trim(),
+        ssh_private_key:  document.getElementById('add_ssh_key').value.trim(),
+        ssh_key_passphrase: document.getElementById('add_passphrase').value || null,
+        nginx_stream_dir: document.getElementById('add_stream_dir').value.trim(),
+        notes:            document.getElementById('add_notes').value.trim() || null,
+    };
+
+    if (!payload.name || !payload.current_ip || !payload.ssh_username || !payload.ssh_private_key) {
+        errEl.textContent = 'Please fill in all required fields.';
+        errEl.classList.remove('d-none');
+        return;
+    }
+
+    try {
+        const resp = await csrfFetch('/api/redirectors/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Failed to create redirector.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        addModal.hide();
+        showToast(`Redirector <strong>${escHtml(data.name)}</strong> created.`, 'success');
+        loadRedirectors();
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Edit Modal
+// ============================================================
+function openEditModal(r) {
+    document.getElementById('edit_redirector_id').value = r.id;
+    document.getElementById('edit_name').value         = r.name;
+    document.getElementById('edit_ip').value           = r.current_ip;
+    document.getElementById('edit_ssh_port').value     = r.ssh_port;
+    document.getElementById('edit_ssh_username').value = r.ssh_username;
+    document.getElementById('edit_ssh_key').value      = '';   // always blank
+    document.getElementById('edit_passphrase').value   = '';
+    document.getElementById('edit_stream_dir').value   = r.nginx_stream_dir;
+    document.getElementById('edit_notes').value        = r.notes || '';
+    document.getElementById('editRedirectorError').classList.add('d-none');
+    editModal.show();
+}
+
+async function submitEditRedirector() {
+    const id    = document.getElementById('edit_redirector_id').value;
+    const errEl = document.getElementById('editRedirectorError');
+    errEl.classList.add('d-none');
+
+    const payload = {};
+    const name    = document.getElementById('edit_name').value.trim();
+    const ip      = document.getElementById('edit_ip').value.trim();
+    const port    = parseInt(document.getElementById('edit_ssh_port').value, 10);
+    const user    = document.getElementById('edit_ssh_username').value.trim();
+    const key     = document.getElementById('edit_ssh_key').value.trim();
+    const pass    = document.getElementById('edit_passphrase').value;
+    const dir     = document.getElementById('edit_stream_dir').value.trim();
+    const notes   = document.getElementById('edit_notes').value.trim();
+
+    if (name)  payload.name = name;
+    if (ip)    payload.current_ip = ip;
+    if (port)  payload.ssh_port = port;
+    if (user)  payload.ssh_username = user;
+    if (key)   payload.ssh_private_key = key;
+    if (pass)  payload.ssh_key_passphrase = pass;
+    if (dir)   payload.nginx_stream_dir = dir;
+    payload.notes = notes || null;
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Failed to update redirector.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        editModal.hide();
+        showToast(`Redirector <strong>${escHtml(data.name)}</strong> updated.`, 'success');
+        loadRedirectors();
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Delete
+// ============================================================
+function openDeleteModal(id, name) {
+    _deleteTargetId = id;
+    document.getElementById('deleteRedirectorName').textContent = name;
+    delModal.show();
+}
+
+async function confirmDeleteRedirector() {
+    if (!_deleteTargetId) return;
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${_deleteTargetId}`, { method: 'DELETE' });
+        if (!resp.ok && resp.status !== 204) {
+            const data = await resp.json().catch(() => ({}));
+            showToast(data.detail || 'Delete failed.', 'danger');
+            return;
+        }
+        delModal.hide();
+        showToast('Redirector deleted.', 'success');
+        loadRedirectors();
+    } catch (err) {
+        showToast(`Delete failed: ${err.message}`, 'danger');
+    }
+    _deleteTargetId = null;
+}
+
+// ============================================================
+// Utility
+// ============================================================
+function escHtml(str) {
+    if (!str) return '';
+    return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+              .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+}
+</script>
+{% endblock %}

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -250,6 +250,9 @@ async function loadRedirectors() {
     }
 }
 
+// Map of redirector objects by ID — used by event-delegated edit button
+const _redirectorMap = new Map();
+
 function renderTable(redirectors) {
     const tbody = document.getElementById('redirectorsBody');
     if (!redirectors.length) {
@@ -259,6 +262,7 @@ function renderTable(redirectors) {
         feather.replace();
         return;
     }
+    redirectors.forEach(r => _redirectorMap.set(r.id, r));
     tbody.innerHTML = redirectors.map(r => `
         <tr>
             <td>
@@ -273,7 +277,7 @@ function renderTable(redirectors) {
             <td class="text-muted small">${r.last_deployed_at ? formatDateTime(r.last_deployed_at) : '—'}</td>
             <td class="text-end">
                 <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
-                    onclick="openEditModal(${JSON.stringify(r)})">
+                    data-edit-id="${escHtml(r.id)}">
                     <i data-feather="edit-2"></i>
                 </button>
                 <button class="btn btn-sm btn-outline-danger" title="Delete"
@@ -285,6 +289,15 @@ function renderTable(redirectors) {
     `).join('');
     feather.replace();
 }
+
+// Event delegation for edit buttons — avoids inline JSON.stringify XSS
+document.addEventListener('click', e => {
+    const btn = e.target.closest('[data-edit-id]');
+    if (btn) {
+        const r = _redirectorMap.get(btn.dataset.editId);
+        if (r) openEditModal(r);
+    }
+});
 
 function statusBadge(status) {
     const map = {

--- a/redirector_app/.env.example
+++ b/redirector_app/.env.example
@@ -1,0 +1,57 @@
+# ============================================================================
+# CyberX Redirector Manager — Environment Configuration
+# Copy this file to .env and fill in all required values.
+# NEVER commit .env to version control.
+# ============================================================================
+
+# ── SSH Key Encryption (REQUIRED) ──────────────────────────────────────────
+# Fernet symmetric encryption key for SSH private keys stored in the database.
+# Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+FERNET_KEY=
+
+# ── API Authentication (REQUIRED) ──────────────────────────────────────────
+# Secret key for X-API-Key header authentication (automation / API clients).
+# Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+API_KEY=
+
+# ── Web UI Admin Credentials (REQUIRED for web UI) ─────────────────────────
+# Username for the web UI login page.
+ADMIN_USERNAME=admin
+
+# Bcrypt hash of the admin password.
+# Generate: python -c "import bcrypt; print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt(12)).decode())"
+ADMIN_PASSWORD_HASH=
+
+# Email address shown in the sidebar footer (cosmetic only).
+ADMIN_EMAIL=admin@localhost
+
+# ── JWT Session Secret (REQUIRED for web UI) ───────────────────────────────
+# HS256 signing secret for JWT session cookies.
+# Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+SECRET_KEY=
+
+# Optional: separate CSRF signing secret. Defaults to SECRET_KEY if unset.
+# Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+CSRF_SECRET_KEY=
+
+# JWT session lifetime in minutes (default: 480 = 8 hours)
+SESSION_EXPIRY_MINUTES=480
+
+# ── Database ───────────────────────────────────────────────────────────────
+# SQLAlchemy async database URL.
+# SQLite (default, for dev/standalone):
+DATABASE_URL=sqlite+aiosqlite:///./data/redirectors.db
+# PostgreSQL (for production):
+# DATABASE_URL=postgresql+asyncpg://user:password@host:5432/dbname
+
+# ── Application ────────────────────────────────────────────────────────────
+# Set to "production" to enable Secure cookie flag on the session cookie.
+# In development (without HTTPS), leave this unset or set to "development".
+APP_ENV=development
+
+# Comma-separated allowed CORS origins. Leave empty to disable CORS (recommended).
+# Example: CORS_ORIGINS=https://yourdomain.com
+CORS_ORIGINS=
+
+# Application version shown in the dashboard footer (optional).
+APP_VERSION=1.0.0

--- a/redirector_app/alembic/env.py
+++ b/redirector_app/alembic/env.py
@@ -1,0 +1,57 @@
+"""Alembic environment for the standalone redirector app."""
+import asyncio
+import os
+from logging.config import fileConfig
+
+from sqlalchemy.ext.asyncio import create_async_engine
+from alembic import context
+
+from dotenv import load_dotenv
+load_dotenv()
+
+config = context.config
+if config.config_file_name:
+    fileConfig(config.config_file_name)
+
+# Import models so their metadata is registered
+from redirector_app.models import Base  # noqa: E402
+target_metadata = Base.metadata
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "sqlite+aiosqlite:///./redirectors.db"
+)
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=True,   # required for SQLite ALTER TABLE support
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection):
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        render_as_batch=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = create_async_engine(DATABASE_URL)
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/redirector_app/alembic/versions/001_redirector_tables.py
+++ b/redirector_app/alembic/versions/001_redirector_tables.py
@@ -1,0 +1,88 @@
+"""Create redirectors and stream_configs tables (SQLite-compatible)
+
+Revision ID: 001
+Revises:
+Create Date: 2026-03-21 00:00:00
+
+SQLite notes:
+  - Uses JSON (not JSONB) for allowed_cidrs
+  - Uses String(36) (not UUID type) for primary/foreign keys
+  - Boolean server defaults written as integer literals (0/1)
+  - No ENUM types (stored as VARCHAR)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # redirectors
+    # ------------------------------------------------------------------
+    op.create_table(
+        'redirectors',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('current_ip', sa.String(45), nullable=False),
+        sa.Column('ssh_port', sa.Integer(), nullable=False, server_default='22'),
+        sa.Column('ssh_username', sa.String(255), nullable=False),
+        sa.Column('ssh_private_key', sa.Text(), nullable=False),
+        sa.Column('ssh_key_passphrase', sa.Text(), nullable=True),
+        sa.Column('nginx_stream_dir', sa.String(500), nullable=False,
+                  server_default='/etc/nginx/stream.d'),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('status', sa.String(20), nullable=False, server_default='unknown'),
+        sa.Column('last_deployed_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('last_tested_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index('ix_redirectors_name', 'redirectors', ['name'], unique=True)
+    op.create_index('ix_redirectors_status', 'redirectors', ['status'])
+
+    # ------------------------------------------------------------------
+    # stream_configs
+    # ------------------------------------------------------------------
+    op.create_table(
+        'stream_configs',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column(
+            'redirector_id', sa.String(36),
+            sa.ForeignKey('redirectors.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('name', sa.String(255), nullable=False),
+        sa.Column('protocol', sa.String(10), nullable=False, server_default='tcp'),
+        sa.Column('listen_port', sa.Integer(), nullable=False),
+        sa.Column('cs_ip', sa.String(255), nullable=False),
+        sa.Column('cs_port', sa.Integer(), nullable=False),
+        sa.Column('access_control_enabled', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('allowed_cidrs', sa.JSON(), nullable=True),
+        sa.Column('ssl_enabled', sa.Boolean(), nullable=False, server_default='0'),
+        sa.Column('ssl_cert_path', sa.String(500), nullable=True),
+        sa.Column('ssl_key_path', sa.String(500), nullable=True),
+        sa.Column('ssl_protocols', sa.String(100), nullable=False,
+                  server_default='TLSv1.2 TLSv1.3'),
+        sa.Column('ssl_ciphers', sa.String(200), nullable=False,
+                  server_default='HIGH:!aNULL:!MD5'),
+        sa.Column('enabled', sa.Boolean(), nullable=False, server_default='1'),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index('ix_stream_configs_redirector_id', 'stream_configs', ['redirector_id'])
+    op.create_index('ix_stream_configs_enabled', 'stream_configs', ['enabled'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_stream_configs_enabled', table_name='stream_configs')
+    op.drop_index('ix_stream_configs_redirector_id', table_name='stream_configs')
+    op.drop_table('stream_configs')
+
+    op.drop_index('ix_redirectors_status', table_name='redirectors')
+    op.drop_index('ix_redirectors_name', table_name='redirectors')
+    op.drop_table('redirectors')

--- a/redirector_app/database.py
+++ b/redirector_app/database.py
@@ -1,0 +1,51 @@
+"""Async SQLAlchemy engine and session factory for the standalone app.
+
+Defaults to SQLite via aiosqlite. Override with DATABASE_URL env var for PostgreSQL.
+
+Usage:
+    DATABASE_URL=sqlite+aiosqlite:///./redirectors.db     (default)
+    DATABASE_URL=postgresql+asyncpg://user:pass@host/db   (production)
+"""
+import os
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "sqlite+aiosqlite:///./redirectors.db"
+)
+
+# SQLite needs check_same_thread=False; asyncpg needs no special args
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_async_engine(
+    DATABASE_URL,
+    echo=False,
+    connect_args=connect_args,
+)
+
+AsyncSessionLocal = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+    autocommit=False,
+    autoflush=False,
+)
+
+Base = declarative_base()
+
+
+async def get_db() -> AsyncSession:
+    """FastAPI dependency: yields an async database session."""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.close()
+
+
+async def create_tables() -> None:
+    """Create all tables (idempotent). Called at application startup."""
+    # Import models so their metadata is registered with Base
+    from redirector_app import models  # noqa: F401
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/redirector_app/dependencies.py
+++ b/redirector_app/dependencies.py
@@ -12,6 +12,7 @@ Environment variables:
     API_KEY     Secret key for X-API-Key header auth (REQUIRED)
     SECRET_KEY  HS256 JWT signing secret (REQUIRED for web UI)
 """
+import hmac
 import os
 from fastapi import Depends, HTTPException, Request, Security, status
 from fastapi.security import APIKeyHeader
@@ -56,7 +57,7 @@ async def get_current_admin_user(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="API_KEY environment variable is not configured.",
             )
-        if api_key == _API_KEY:
+        if hmac.compare_digest(api_key, _API_KEY):
             return _FakeAdminUser()
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/redirector_app/dependencies.py
+++ b/redirector_app/dependencies.py
@@ -1,0 +1,87 @@
+"""Authentication dependencies for the standalone redirector app.
+
+Supports two auth modes so existing API consumers and the web UI can both work:
+
+  1. X-API-Key header — for automation / API-only clients (backward compatible).
+  2. JWT session cookie — for the web browser UI (set at login via /api/web/login).
+
+Both modes return a compatible user object so route signatures in
+backend/app/api/routes/redirectors.py do not need modification.
+
+Environment variables:
+    API_KEY     Secret key for X-API-Key header auth (REQUIRED)
+    SECRET_KEY  HS256 JWT signing secret (REQUIRED for web UI)
+"""
+import os
+from fastapi import Depends, HTTPException, Request, Security, status
+from fastapi.security import APIKeyHeader
+
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+_API_KEY = os.environ.get("API_KEY", "")
+
+
+class _FakeAdminUser:
+    """Minimal stand-in for the cyberx User model used in audit log calls."""
+
+    def __init__(
+        self,
+        email: str = "api-key-user@standalone",
+        first_name: str = "API",
+        last_name: str = "Key",
+    ):
+        self.id = 0
+        self.email = email
+        self.first_name = first_name
+        self.last_name = last_name
+
+
+async def get_current_admin_user(
+    request: Request,
+    api_key: str = Security(_api_key_header),
+) -> _FakeAdminUser:
+    """
+    Authenticate the request via X-API-Key header or JWT session cookie.
+
+    Priority:
+      1. X-API-Key header (API automation clients)
+      2. 'session' HTTP-only cookie (web UI after login)
+
+    Raises HTTP 401 if neither succeeds.
+    """
+    # --- Mode 1: X-API-Key header ---
+    if api_key:
+        if not _API_KEY:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="API_KEY environment variable is not configured.",
+            )
+        if api_key == _API_KEY:
+            return _FakeAdminUser()
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid X-API-Key.",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
+
+    # --- Mode 2: JWT session cookie ---
+    session_token = request.cookies.get("session")
+    if session_token:
+        try:
+            from redirector_app.web.auth import decode_session_token, build_web_admin_user
+            username = decode_session_token(session_token)
+            if username:
+                user = build_web_admin_user(username)
+                return _FakeAdminUser(
+                    email=user.email,
+                    first_name=user.first_name,
+                    last_name=user.last_name,
+                )
+        except Exception:
+            pass
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Authentication required. Provide X-API-Key header or log in via the web UI.",
+        headers={"WWW-Authenticate": "ApiKey"},
+    )

--- a/redirector_app/encryption.py
+++ b/redirector_app/encryption.py
@@ -1,0 +1,34 @@
+"""Minimal Fernet field encryption for the standalone app.
+
+Mirrors app.utils.encryption from cyberx-event-mgmt but is self-contained.
+Initialize once at startup with init_encryptor(key).
+"""
+import os
+from typing import Optional
+from cryptography.fernet import Fernet, InvalidToken
+
+_fernet: Optional[Fernet] = None
+
+
+def init_encryptor(key: str) -> None:
+    global _fernet
+    _fernet = Fernet(key.encode("utf-8") if isinstance(key, str) else key)
+
+
+def encrypt_field(plaintext: Optional[str]) -> Optional[str]:
+    if plaintext is None:
+        return None
+    if _fernet is None:
+        raise RuntimeError("Encryptor not initialized. Call init_encryptor() first.")
+    return _fernet.encrypt(plaintext.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_field(encrypted: Optional[str]) -> Optional[str]:
+    if encrypted is None:
+        return None
+    if _fernet is None:
+        raise RuntimeError("Encryptor not initialized. Call init_encryptor() first.")
+    try:
+        return _fernet.decrypt(encrypted.encode("utf-8")).decode("utf-8")
+    except InvalidToken:
+        raise ValueError("Decryption failed: invalid token or wrong key.")

--- a/redirector_app/main.py
+++ b/redirector_app/main.py
@@ -134,7 +134,8 @@ app.add_middleware(
         "/docs",
         "/redoc",
         "/openapi.json",
-        "/api/redirectors/*",   # X-API-Key consumers
+        "/api/web/login",       # Login exempt — no CSRF cookie on first visit
+        # X-API-Key bypass handled in middleware dispatch, not via exemption
     ],
     cookie_secure=_is_production,
 )

--- a/redirector_app/main.py
+++ b/redirector_app/main.py
@@ -1,0 +1,211 @@
+"""Standalone FastAPI application for the Redirector Manager.
+
+Runs independently of cyberx-event-mgmt. Includes a full browser UI with
+cyberpunk-themed login, redirector management dashboard, and error log viewer.
+
+Authentication:
+  - Web UI: bcrypt + JWT session cookie (set at POST /api/web/login)
+  - API automation: X-API-Key header (backward compatible)
+
+TLS: handled by nginx reverse proxy (see nginx/nginx.conf).
+     For local dev without nginx, run with --ssl-keyfile/--ssl-certfile.
+
+Setup:
+    cp redirector_app/.env.example redirector_app/.env
+    # Edit .env — fill in all required secrets (see .env.example for commands)
+    pip install -r redirector_app/requirements.txt
+    PYTHONPATH=backend uvicorn redirector_app.main:app --host 0.0.0.0 --port 8080
+
+Environment variables (see redirector_app/.env.example for full list):
+    FERNET_KEY              SSH key encryption (REQUIRED)
+    API_KEY                 X-API-Key header secret (REQUIRED)
+    ADMIN_USERNAME          Web UI login username (default: admin)
+    ADMIN_PASSWORD_HASH     bcrypt hash of web UI password (REQUIRED)
+    SECRET_KEY              JWT signing secret (REQUIRED)
+    CSRF_SECRET_KEY         CSRF token signing secret (default: SECRET_KEY)
+    SESSION_EXPIRY_MINUTES  JWT lifetime in minutes (default: 480)
+    DATABASE_URL            SQLAlchemy async URL (default: SQLite)
+    APP_ENV                 "production" enables Secure cookie flag
+    CORS_ORIGINS            Comma-separated allowed origins (default: empty)
+"""
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+load_dotenv()
+
+# ---------------------------------------------------------------------------
+# Startup secret validation — fail fast before any handler is registered
+# ---------------------------------------------------------------------------
+_REQUIRED_VARS = ("FERNET_KEY", "SECRET_KEY", "API_KEY", "ADMIN_PASSWORD_HASH")
+for _var in _REQUIRED_VARS:
+    if not os.environ.get(_var, "").strip():
+        raise RuntimeError(
+            f"Required environment variable {_var!r} is not set. "
+            "See redirector_app/.env.example for setup instructions."
+        )
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Security headers middleware (defense-in-depth; nginx also sets these)
+# ---------------------------------------------------------------------------
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        return response
+
+
+# ---------------------------------------------------------------------------
+# Application lifespan
+# ---------------------------------------------------------------------------
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # 1. Install memory log handler first — captures startup messages
+    from redirector_app.web.log_buffer import install_memory_handler
+    install_memory_handler()
+
+    # 2. Initialize field encryption
+    fernet_key = os.environ["FERNET_KEY"]
+    from redirector_app.encryption import init_encryptor
+    init_encryptor(fernet_key)
+    logger.info("Field encryption initialized.")
+
+    # 3. Create DB tables (idempotent)
+    from redirector_app.database import create_tables
+    await create_tables()
+    logger.info("Database tables ready.")
+
+    logger.info("CyberX Redirector Manager standalone app started.")
+    yield
+    logger.info("CyberX Redirector Manager standalone app shutting down.")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="CyberX Redirector Manager",
+    description=(
+        "Manage nginx stream proxy configurations on remote redirector servers "
+        "via SSH. Authenticate via the web UI or X-API-Key header."
+    ),
+    version="1.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    lifespan=lifespan,
+)
+
+# Security headers (defense-in-depth alongside nginx)
+app.add_middleware(SecurityHeadersMiddleware)
+
+# CSRF protection — exempt API key endpoints and read-only paths
+_csrf_secret = os.environ.get("CSRF_SECRET_KEY", "").strip() or os.environ["SECRET_KEY"]
+_is_production = os.environ.get("APP_ENV", "").lower() == "production"
+
+from redirector_app.web.middleware import CSRFMiddleware
+app.add_middleware(
+    CSRFMiddleware,
+    secret_key=_csrf_secret,
+    exempt_urls=[
+        "/health",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+        "/api/redirectors/*",   # X-API-Key consumers
+    ],
+    cookie_secure=_is_production,
+)
+
+# CORS — restrict to explicitly configured origins
+_cors_origins_raw = os.environ.get("CORS_ORIGINS", "").strip()
+_cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()] if _cors_origins_raw else []
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins,
+    allow_credentials=False,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["X-API-Key", "X-CSRF-Token", "Content-Type"],
+)
+
+# ---------------------------------------------------------------------------
+# Static files
+# ---------------------------------------------------------------------------
+
+_static_dir = Path(__file__).parent / "web" / "static"
+if _static_dir.exists():
+    app.mount("/static", StaticFiles(directory=str(_static_dir)), name="static")
+
+# ---------------------------------------------------------------------------
+# Dependency overrides — standalone versions replace cyberx-event-mgmt ones
+# ---------------------------------------------------------------------------
+
+from app.api.routes import redirectors as redirectors_api
+from app.dependencies import get_current_admin_user as _main_get_admin
+from app.dependencies import get_db as _main_get_db
+from redirector_app.dependencies import get_current_admin_user as _sa_get_admin
+from redirector_app.database import get_db as _sa_get_db
+
+import app.utils.encryption as _main_enc
+import redirector_app.encryption as _sa_enc
+_main_enc.encrypt_field = _sa_enc.encrypt_field
+_main_enc.decrypt_field = _sa_enc.decrypt_field
+
+app.dependency_overrides[_main_get_admin] = _sa_get_admin
+app.dependency_overrides[_main_get_db]    = _sa_get_db
+
+# ---------------------------------------------------------------------------
+# Routers
+# ---------------------------------------------------------------------------
+
+# REST API (X-API-Key + session cookie auth via dependency override above)
+app.include_router(redirectors_api.router)
+
+# Web UI (HTML pages + login/logout)
+from redirector_app.web import pages as web_pages
+app.include_router(web_pages.router)
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+@app.get("/health", tags=["System"])
+async def health_check():
+    return {"status": "healthy", "app": "cyberx-redirector-manager"}
+
+
+# ---------------------------------------------------------------------------
+# Global exception handler
+# ---------------------------------------------------------------------------
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+    )

--- a/redirector_app/main.py
+++ b/redirector_app/main.py
@@ -61,6 +61,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+_is_production = os.environ.get("APP_ENV", "").lower() == "production"
+
 
 # ---------------------------------------------------------------------------
 # Security headers middleware (defense-in-depth; nginx also sets these)
@@ -113,8 +115,8 @@ app = FastAPI(
         "via SSH. Authenticate via the web UI or X-API-Key header."
     ),
     version="1.0.0",
-    docs_url="/docs",
-    redoc_url="/redoc",
+    docs_url=None if _is_production else "/docs",
+    redoc_url=None if _is_production else "/redoc",
     lifespan=lifespan,
 )
 
@@ -123,7 +125,14 @@ app.add_middleware(SecurityHeadersMiddleware)
 
 # CSRF protection — exempt API key endpoints and read-only paths
 _csrf_secret = os.environ.get("CSRF_SECRET_KEY", "").strip() or os.environ["SECRET_KEY"]
-_is_production = os.environ.get("APP_ENV", "").lower() == "production"
+
+
+def _validate_api_key(key: str) -> bool:
+    """Return True only if the key matches the configured API_KEY (timing-safe)."""
+    import hmac
+    configured_key = os.environ.get("API_KEY", "")
+    return bool(configured_key) and hmac.compare_digest(key, configured_key)
+
 
 from redirector_app.web.middleware import CSRFMiddleware
 app.add_middleware(
@@ -135,9 +144,9 @@ app.add_middleware(
         "/redoc",
         "/openapi.json",
         "/api/web/login",       # Login exempt — no CSRF cookie on first visit
-        # X-API-Key bypass handled in middleware dispatch, not via exemption
     ],
     cookie_secure=_is_production,
+    api_key_validator=_validate_api_key,
 )
 
 # CORS — restrict to explicitly configured origins

--- a/redirector_app/models.py
+++ b/redirector_app/models.py
@@ -1,0 +1,12 @@
+"""Re-export shim — canonical model definitions live in backend/app/models/redirector.py.
+
+Both this module and backend/app/models/redirector.py previously defined Redirector and
+StreamConfig, causing a SQLAlchemy registry collision (both imported the same Base via
+backend/app/database.py → redirector_app/database.py). This shim eliminates the duplicate.
+"""
+from app.models.redirector import (  # noqa: F401
+    Redirector,
+    StreamConfig,
+    RedirectorStatus,
+    StreamProtocol,
+)

--- a/redirector_app/requirements.txt
+++ b/redirector_app/requirements.txt
@@ -18,7 +18,7 @@ alembic==1.14.0
 cryptography==44.0.0
 
 # SSH/SFTP
-paramiko>=3.4.0
+paramiko==4.0.0
 
 # Validation
 pydantic==2.10.5

--- a/redirector_app/requirements.txt
+++ b/redirector_app/requirements.txt
@@ -1,0 +1,37 @@
+# Standalone Redirector Manager requirements
+# Run: pip install -r requirements.txt
+
+# FastAPI and server
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+python-multipart==0.0.20
+jinja2>=3.1.4
+
+# Database
+sqlalchemy==2.0.36
+greenlet>=3.1.0         # required by SQLAlchemy async engine
+aiosqlite==0.20.0       # SQLite async driver
+asyncpg==0.30.0         # PostgreSQL async driver (optional — for production)
+alembic==1.14.0
+
+# Encryption (SSH key storage)
+cryptography==44.0.0
+
+# SSH/SFTP
+paramiko>=3.4.0
+
+# Validation
+pydantic==2.10.5
+pydantic-settings==2.7.1
+email-validator==2.2.0
+
+# Web UI auth
+bcrypt==4.2.0
+python-jose[cryptography]==3.3.0
+itsdangerous==2.2.0
+
+# Static files serving
+aiofiles==24.1.0
+
+# Environment
+python-dotenv==1.0.1

--- a/redirector_app/web/__init__.py
+++ b/redirector_app/web/__init__.py
@@ -1,0 +1,13 @@
+"""Standalone web UI sub-package for the Redirector Manager.
+
+Contains everything specific to the browser-facing web interface:
+  auth.py       — bcrypt password verification + JWT cookie session management
+  log_buffer.py — in-memory rotating log handler for the error log viewer
+  middleware.py — CSRF protection middleware
+  pages.py      — HTML route handlers (login, dashboard, redirectors, logs)
+  templates/    — Self-contained Jinja2 templates (no dependency on cyberx-event-mgmt)
+  static/       — Static assets (logo, etc.)
+
+This sub-package is standalone-mode only. It is NOT included in the
+cyberx-event-mgmt integration, which uses its own auth and layout system.
+"""

--- a/redirector_app/web/auth.py
+++ b/redirector_app/web/auth.py
@@ -1,0 +1,127 @@
+"""Session-based authentication for the standalone web UI.
+
+Provides bcrypt password verification and HS256 JWT sessions stored in
+HTTP-only cookies. This mirrors the cyberx-event-mgmt auth pattern but uses
+a single admin credential from environment variables instead of a database
+user table — keeping standalone deployment simple and self-contained.
+
+Environment variables:
+    ADMIN_USERNAME          Admin login username (default: "admin")
+    ADMIN_PASSWORD_HASH     bcrypt hash of the admin password (REQUIRED for web UI)
+    ADMIN_EMAIL             Email shown in sidebar footer (default: "admin@localhost")
+    SECRET_KEY              HS256 JWT signing secret (REQUIRED)
+    SESSION_EXPIRY_MINUTES  JWT lifetime in minutes (default: 480 = 8 hours)
+    APP_ENV                 Set to "production" to enable Secure cookie flag
+"""
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import bcrypt
+from jose import JWTError, jwt
+
+
+# ---------------------------------------------------------------------------
+# Admin credential dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WebAdminUser:
+    """Minimal user object passed to Jinja2 templates for the web UI."""
+    username: str
+    email: str
+    first_name: str
+    last_name: str = ""
+
+    @property
+    def display_name(self) -> str:
+        return self.first_name or self.username
+
+
+# ---------------------------------------------------------------------------
+# Password verification
+# ---------------------------------------------------------------------------
+
+def verify_password(plain: str, hashed: str) -> bool:
+    """Return True if plain-text password matches the bcrypt hash."""
+    try:
+        return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    except Exception:
+        return False
+
+
+def get_admin_credentials() -> tuple[str, str]:
+    """Return (username, password_hash) from environment. Raises RuntimeError if unset."""
+    username = os.environ.get("ADMIN_USERNAME", "admin").strip()
+    password_hash = os.environ.get("ADMIN_PASSWORD_HASH", "").strip()
+    if not password_hash:
+        raise RuntimeError(
+            "ADMIN_PASSWORD_HASH environment variable is not set. "
+            "Generate one with: python -c \"import bcrypt; "
+            "print(bcrypt.hashpw(b'yourpassword', bcrypt.gensalt(12)).decode())\""
+        )
+    return username, password_hash
+
+
+# ---------------------------------------------------------------------------
+# JWT session tokens
+# ---------------------------------------------------------------------------
+
+_ALGORITHM = "HS256"
+
+
+def _secret_key() -> str:
+    key = os.environ.get("SECRET_KEY", "").strip()
+    if not key:
+        raise RuntimeError("SECRET_KEY environment variable is not set.")
+    return key
+
+
+def _session_expiry_minutes() -> int:
+    try:
+        return int(os.environ.get("SESSION_EXPIRY_MINUTES", "480"))
+    except (ValueError, TypeError):
+        return 480
+
+
+def create_session_token(username: str) -> str:
+    """Create a signed HS256 JWT for the given admin username."""
+    expire = datetime.now(timezone.utc) + timedelta(minutes=_session_expiry_minutes())
+    payload = {
+        "sub": username,
+        "exp": expire,
+        "iat": datetime.now(timezone.utc),
+    }
+    return jwt.encode(payload, _secret_key(), algorithm=_ALGORITHM)
+
+
+def decode_session_token(token: str) -> Optional[str]:
+    """
+    Decode and validate a session JWT.
+
+    Returns the username (sub claim) on success, or None if the token is
+    missing, expired, tampered with, or otherwise invalid.
+    """
+    try:
+        payload = jwt.decode(token, _secret_key(), algorithms=[_ALGORITHM])
+        username: Optional[str] = payload.get("sub")
+        return username if username else None
+    except JWTError:
+        return None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building the WebAdminUser from env
+# ---------------------------------------------------------------------------
+
+def build_web_admin_user(username: str) -> WebAdminUser:
+    """Build a WebAdminUser dataclass from env vars for template context."""
+    email = os.environ.get("ADMIN_EMAIL", "admin@localhost").strip()
+    return WebAdminUser(
+        username=username,
+        email=email,
+        first_name=username.capitalize(),
+    )

--- a/redirector_app/web/log_buffer.py
+++ b/redirector_app/web/log_buffer.py
@@ -1,0 +1,76 @@
+"""In-memory rotating log buffer for the web UI error log viewer.
+
+Captures all Python log records into a bounded deque so operators can
+inspect recent application logs directly from the browser without needing
+SSH access or file system access to the container.
+
+Usage:
+    Call install_memory_handler() once at application startup (before the
+    lifespan yields) to attach the handler to the root logger.
+
+    Call get_recent_logs(n) from route handlers to retrieve the last n
+    log entries (newest first) as JSON-serializable dicts.
+"""
+import collections
+import logging
+import threading
+from typing import List
+
+# Thread-safe bounded buffer: newest entries are at index 0 (appendleft)
+_MAX_ENTRIES = 500
+_log_buffer: collections.deque = collections.deque(maxlen=_MAX_ENTRIES)
+_buffer_lock = threading.Lock()
+
+
+class MemoryLogHandler(logging.Handler):
+    """A logging.Handler that appends formatted records to the in-memory deque."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            entry = {
+                "ts": self.formatter.formatTime(record, "%Y-%m-%d %H:%M:%S")
+                if self.formatter
+                else record.asctime,
+                "level": record.levelname,
+                "name": record.name,
+                "msg": self.format(record) if self.formatter else record.getMessage(),
+            }
+            with _buffer_lock:
+                _log_buffer.appendleft(entry)
+        except Exception:
+            # Never let the log handler itself crash the application
+            self.handleError(record)
+
+
+def install_memory_handler() -> None:
+    """
+    Attach a MemoryLogHandler to the root logger.
+
+    Must be called before any other startup code so that startup log messages
+    are captured in the buffer and visible in the web UI log viewer.
+    """
+    handler = MemoryLogHandler()
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
+
+    root_logger = logging.getLogger()
+    # Avoid duplicate handlers if called more than once (e.g., during reload)
+    existing_types = {type(h) for h in root_logger.handlers}
+    if MemoryLogHandler not in existing_types:
+        root_logger.addHandler(handler)
+
+
+def get_recent_logs(n: int = 200) -> List[dict]:
+    """
+    Return the most recent n log entries, newest first.
+
+    Args:
+        n: Maximum number of entries to return (capped at _MAX_ENTRIES).
+    """
+    n = min(max(1, n), _MAX_ENTRIES)
+    with _buffer_lock:
+        return list(_log_buffer)[:n]

--- a/redirector_app/web/middleware.py
+++ b/redirector_app/web/middleware.py
@@ -81,6 +81,11 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         response.headers.append("Set-Cookie", cookie_value)
 
     async def dispatch(self, request: Request, call_next):
+        # Skip CSRF check if X-API-Key header is present (stateless API auth)
+        if request.headers.get("X-API-Key"):
+            response = await call_next(request)
+            return response
+
         csrf_token = request.cookies.get(self.cookie_name)
         new_token_needed = False
 

--- a/redirector_app/web/middleware.py
+++ b/redirector_app/web/middleware.py
@@ -1,0 +1,126 @@
+"""Custom CSRF protection middleware compatible with FastAPI/Starlette.
+
+Copied from cyberx-event-mgmt/backend/app/middleware/csrf.py and adapted for
+the standalone redirector manager. The X-API-Key API routes are added to
+exempt_urls so API consumers do not need a CSRF token.
+"""
+from typing import List
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response, JSONResponse
+import secrets
+from itsdangerous import URLSafeTimedSerializer, BadSignature
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """
+    CSRF protection middleware for FastAPI/Starlette.
+
+    Sets a signed CSRF token cookie and validates it on state-changing requests.
+    """
+
+    def __init__(
+        self,
+        app,
+        secret_key: str,
+        exempt_urls: List[str] = None,
+        cookie_name: str = "csrf_token",
+        header_name: str = "X-CSRF-Token",
+        cookie_secure: bool = True,
+        cookie_samesite: str = "lax",
+        cookie_httponly: bool = False,
+        cookie_path: str = "/",
+        token_max_age: int = 3600,  # 1 hour
+    ):
+        super().__init__(app)
+        self.secret_key = secret_key
+        self.exempt_urls = exempt_urls or []
+        self.cookie_name = cookie_name
+        self.header_name = header_name
+        self.cookie_secure = cookie_secure
+        self.cookie_samesite = cookie_samesite
+        self.cookie_httponly = cookie_httponly
+        self.cookie_path = cookie_path
+        self.token_max_age = token_max_age
+        self.serializer = URLSafeTimedSerializer(secret_key)
+
+    def _generate_token(self) -> str:
+        random_value = secrets.token_urlsafe(32)
+        return self.serializer.dumps(random_value)
+
+    def _validate_token(self, token: str) -> bool:
+        try:
+            self.serializer.loads(token, max_age=self.token_max_age)
+            return True
+        except (BadSignature, Exception):
+            return False
+
+    def _is_exempt(self, path: str) -> bool:
+        for exempt_pattern in self.exempt_urls:
+            if exempt_pattern.endswith("/*"):
+                prefix = exempt_pattern[:-2]
+                if path.startswith(prefix):
+                    return True
+            elif path == exempt_pattern:
+                return True
+        return False
+
+    def _requires_csrf_check(self, method: str) -> bool:
+        return method.upper() in ["POST", "PUT", "DELETE", "PATCH"]
+
+    def _set_csrf_cookie(self, response: Response, token: str, needed: bool):
+        if not needed:
+            return
+        cookie_value = f"{self.cookie_name}={token}; Path={self.cookie_path}"
+        if self.cookie_secure:
+            cookie_value += "; Secure"
+        if self.cookie_samesite:
+            cookie_value += f"; SameSite={self.cookie_samesite}"
+        if self.cookie_httponly:
+            cookie_value += "; HttpOnly"
+        response.headers.append("Set-Cookie", cookie_value)
+
+    async def dispatch(self, request: Request, call_next):
+        csrf_token = request.cookies.get(self.cookie_name)
+        new_token_needed = False
+
+        if not csrf_token:
+            csrf_token = self._generate_token()
+            new_token_needed = True
+        elif not self._validate_token(csrf_token):
+            csrf_token = self._generate_token()
+            new_token_needed = True
+
+        if (
+            self._requires_csrf_check(request.method)
+            and not self._is_exempt(request.url.path)
+        ):
+            token_from_header = request.headers.get(self.header_name)
+
+            if not token_from_header:
+                resp = JSONResponse(
+                    status_code=403,
+                    content={"detail": "CSRF token missing"},
+                )
+                self._set_csrf_cookie(resp, csrf_token, new_token_needed)
+                return resp
+
+            if not self._validate_token(token_from_header):
+                resp = JSONResponse(
+                    status_code=403,
+                    content={"detail": "CSRF token invalid or expired"},
+                )
+                self._set_csrf_cookie(resp, csrf_token, new_token_needed)
+                return resp
+
+            if token_from_header != csrf_token:
+                resp = JSONResponse(
+                    status_code=403,
+                    content={"detail": "CSRF token mismatch"},
+                )
+                self._set_csrf_cookie(resp, csrf_token, new_token_needed)
+                return resp
+
+        response = await call_next(request)
+        self._set_csrf_cookie(response, csrf_token, new_token_needed)
+        return response

--- a/redirector_app/web/middleware.py
+++ b/redirector_app/web/middleware.py
@@ -31,6 +31,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         cookie_httponly: bool = False,
         cookie_path: str = "/",
         token_max_age: int = 3600,  # 1 hour
+        api_key_validator=None,
     ):
         super().__init__(app)
         self.secret_key = secret_key
@@ -43,6 +44,7 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         self.cookie_path = cookie_path
         self.token_max_age = token_max_age
         self.serializer = URLSafeTimedSerializer(secret_key)
+        self.api_key_validator = api_key_validator
 
     def _generate_token(self) -> str:
         random_value = secrets.token_urlsafe(32)
@@ -81,10 +83,12 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         response.headers.append("Set-Cookie", cookie_value)
 
     async def dispatch(self, request: Request, call_next):
-        # Skip CSRF check if X-API-Key header is present (stateless API auth)
-        if request.headers.get("X-API-Key"):
-            response = await call_next(request)
-            return response
+        # Skip CSRF only if X-API-Key is present AND valid (prevents bypass with garbage key)
+        if self.api_key_validator:
+            api_key = request.headers.get("X-API-Key")
+            if api_key and self.api_key_validator(api_key):
+                response = await call_next(request)
+                return response
 
         csrf_token = request.cookies.get(self.cookie_name)
         new_token_needed = False

--- a/redirector_app/web/pages.py
+++ b/redirector_app/web/pages.py
@@ -1,0 +1,258 @@
+"""HTML page routes and web UI API endpoints for the standalone Redirector Manager.
+
+Routes:
+    GET  /login               Render login page (no auth)
+    POST /api/web/login       Authenticate and set JWT session cookie
+    POST /api/web/logout      Clear session cookie
+    GET  /                    Redirect to /redirectors
+    GET  /redirectors         Redirector list page
+    GET  /redirectors/{id}    Redirector detail page
+    GET  /logs                Error log viewer page
+    GET  /api/internal/logs   JSON log buffer (auth-gated, ?n= query param)
+"""
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from redirector_app.database import get_db
+from redirector_app.web.auth import (
+    WebAdminUser,
+    build_web_admin_user,
+    create_session_token,
+    decode_session_token,
+    get_admin_credentials,
+    verify_password,
+)
+from redirector_app.web.log_buffer import get_recent_logs
+
+router = APIRouter(tags=["Web UI"])
+
+_templates_dir = Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_templates_dir))
+
+_is_production = os.environ.get("APP_ENV", "").lower() == "production"
+
+# ---------------------------------------------------------------------------
+# In-memory login rate limiter: max 5 attempts per 15 minutes per IP
+# ---------------------------------------------------------------------------
+_login_attempts: dict[str, list[datetime]] = defaultdict(list)
+_RATE_LIMIT_ATTEMPTS = 5
+_RATE_LIMIT_WINDOW = timedelta(minutes=15)
+
+
+def _check_login_rate_limit(ip: str) -> bool:
+    """Return True if the IP has exceeded the login rate limit."""
+    now = datetime.utcnow()
+    window_start = now - _RATE_LIMIT_WINDOW
+    attempts = [t for t in _login_attempts[ip] if t > window_start]
+    _login_attempts[ip] = attempts
+    return len(attempts) >= _RATE_LIMIT_ATTEMPTS
+
+
+def _record_login_attempt(ip: str) -> None:
+    _login_attempts[ip].append(datetime.utcnow())
+
+
+# ---------------------------------------------------------------------------
+# Auth dependency for web UI pages (redirects to /login on failure)
+# ---------------------------------------------------------------------------
+
+def _get_session_user(request: Request) -> Optional[WebAdminUser]:
+    """Extract WebAdminUser from session cookie, or None."""
+    token = request.cookies.get("session")
+    if not token:
+        return None
+    username = decode_session_token(token)
+    if not username:
+        return None
+    return build_web_admin_user(username)
+
+
+def _require_web_auth(request: Request) -> WebAdminUser:
+    """Dependency: return WebAdminUser or raise 307 redirect to /login."""
+    user = _get_session_user(request)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+            headers={"Location": "/login"},
+        )
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Template context helper
+# ---------------------------------------------------------------------------
+
+def _ctx(request: Request, current_user: WebAdminUser, active_page: str = "", **extra):
+    return {
+        "request": request,
+        "current_user": current_user,
+        "active_page": active_page,
+        "now": datetime.now(),
+        "app_version": os.environ.get("APP_VERSION", "1.0.0"),
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Login / Logout
+# ---------------------------------------------------------------------------
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    """Render the cyberpunk login page. Redirect to /redirectors if already logged in."""
+    user = _get_session_user(request)
+    if user:
+        return RedirectResponse("/redirectors", status_code=302)
+    ctx = {
+        "request": request,
+        "now": datetime.now(),
+    }
+    return templates.TemplateResponse("pages/auth/login.html", ctx)
+
+
+@router.post("/api/web/login")
+async def api_login(request: Request):
+    """
+    Authenticate with username + password. Sets a secure HTTP-only JWT cookie on success.
+
+    Rate-limited: 5 attempts per 15 minutes per IP.
+    Returns 200 JSON on success, 401 JSON on failure, 429 JSON on rate limit.
+    """
+    ip = request.client.host if request.client else "unknown"
+
+    if _check_login_rate_limit(ip):
+        return JSONResponse(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            content={"detail": "Too many login attempts. Please wait 15 minutes and try again."},
+        )
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"detail": "Invalid JSON body."},
+        )
+
+    username = (body.get("username") or "").strip()
+    password = body.get("password") or ""
+
+    if not username or not password:
+        _record_login_attempt(ip)
+        return JSONResponse(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content={"detail": "Username and password are required."},
+        )
+
+    try:
+        admin_username, admin_password_hash = get_admin_credentials()
+    except RuntimeError as e:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": str(e)},
+        )
+
+    if username != admin_username or not verify_password(password, admin_password_hash):
+        _record_login_attempt(ip)
+        return JSONResponse(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content={"detail": "Invalid credentials."},
+        )
+
+    token = create_session_token(username)
+    response = JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={"status": "ok", "redirect": "/redirectors"},
+    )
+    response.set_cookie(
+        key="session",
+        value=token,
+        httponly=True,
+        secure=_is_production,
+        samesite="lax",
+        max_age=int(os.environ.get("SESSION_EXPIRY_MINUTES", "480")) * 60,
+    )
+    return response
+
+
+@router.post("/api/web/logout")
+async def api_logout(
+    request: Request,
+    current_user: WebAdminUser = Depends(_require_web_auth),
+):
+    """Clear the session cookie."""
+    response = JSONResponse(status_code=200, content={"status": "ok"})
+    response.delete_cookie("session")
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Dashboard pages
+# ---------------------------------------------------------------------------
+
+@router.get("/", response_class=HTMLResponse)
+async def root_redirect(current_user: WebAdminUser = Depends(_require_web_auth)):
+    return RedirectResponse("/redirectors", status_code=302)
+
+
+@router.get("/redirectors", response_class=HTMLResponse)
+async def redirectors_list(
+    request: Request,
+    current_user: WebAdminUser = Depends(_require_web_auth),
+):
+    return templates.TemplateResponse(
+        "pages/redirectors/list.html",
+        _ctx(request, current_user, active_page="redirectors"),
+    )
+
+
+@router.get("/redirectors/{redirector_id}", response_class=HTMLResponse)
+async def redirector_detail(
+    redirector_id: str,
+    request: Request,
+    current_user: WebAdminUser = Depends(_require_web_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    from app.services.redirector_service import RedirectorService
+    svc = RedirectorService(db)
+    redirector = await svc.get_redirector(redirector_id)
+    if not redirector:
+        raise HTTPException(status_code=404, detail="Redirector not found.")
+    return templates.TemplateResponse(
+        "pages/redirectors/detail.html",
+        _ctx(request, current_user, active_page="redirectors", redirector=redirector),
+    )
+
+
+@router.get("/logs", response_class=HTMLResponse)
+async def logs_page(
+    request: Request,
+    current_user: WebAdminUser = Depends(_require_web_auth),
+):
+    return templates.TemplateResponse(
+        "pages/logs.html",
+        _ctx(request, current_user, active_page="logs"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal log API
+# ---------------------------------------------------------------------------
+
+@router.get("/api/internal/logs")
+async def api_logs(
+    request: Request,
+    n: int = Query(default=200, ge=1, le=500),
+    current_user: WebAdminUser = Depends(_require_web_auth),
+):
+    """Return the most recent n log entries as JSON. Newest first."""
+    logs = get_recent_logs(n)
+    return JSONResponse({"logs": logs, "total": len(logs)})

--- a/redirector_app/web/static/img/cyberx-star-logo.svg
+++ b/redirector_app/web/static/img/cyberx-star-logo.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="120.2645mm"
+   height="119.82453mm"
+   viewBox="0 0 120.2645 119.82453"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (c497b03c, 2020-09-10)"
+   sodipodi:docname="cyberx-red-team.svg"
+   inkscape:export-filename="/Users/wes/projects/cyberx/branding/cybex-red-team-logo-nobg-280x280.png"
+   inkscape:export-xdpi="59.139999"
+   inkscape:export-ydpi="59.139999">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="255.84375"
+     inkscape:cy="252.75123"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="2048"
+     inkscape:window-height="1158"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-38.141341,-81.292903)">
+    <path
+       id="path10"
+       style="fill:#ff0000;stroke:#ff0000;stroke-width:0.999999"
+       d="m 399.77344,307.86523 15.76562,29.7168 a 200.31496,200.31496 0 0 1 122.23633,84.47852 l 33.64063,3.88476 A 226.77165,226.77165 0 0 0 399.77344,307.86523 Z m -70.93164,2.25586 A 226.77165,226.77165 0 0 0 165.60352,437.66602 l 32.20898,-5.64844 a 200.31496,200.31496 0 0 1 117.11719,-91.49805 z m 266.14258,184.68946 -24.20118,25.01172 a 200.31496,200.31496 0 0 1 0.42578,13.03515 200.31496,200.31496 0 0 1 -41.26953,121.78125 l 6.75977,33.49414 a 226.77165,226.77165 0 0 0 61.5,-155.27539 226.77165,226.77165 0 0 0 -3.21484,-38.04687 z m -449.05469,14.04297 a 226.77165,226.77165 0 0 0 -1.27344,24.0039 226.77165,226.77165 0 0 0 69.95703,163.8125 l 4.65625,-32.90625 a 200.31496,200.31496 0 0 1 -48.69141,-130.90625 200.31496,200.31496 0 0 1 0.006,-1.3418 z m 298.48047,210.33984 a 200.31496,200.31496 0 0 1 -73.51563,13.97852 200.31496,200.31496 0 0 1 -62.4707,-9.99024 l -29.5918,16.67969 a 226.77165,226.77165 0 0 0 92.5957,19.76758 226.77165,226.77165 0 0 0 104.01563,-25.26368 z"
+       transform="scale(0.26458333)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     transform="translate(-38.141341,-81.292903)" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 3"
+     transform="translate(-38.141341,-81.292903)">
+    <path
+       sodipodi:type="star"
+       style="fill:#ff0000;stroke:#ff0000;stroke-width:0.264583"
+       id="path18"
+       sodipodi:sides="5"
+       sodipodi:cx="99.747917"
+       sodipodi:cy="142.34583"
+       sodipodi:r1="59.437595"
+       sodipodi:r2="21.991911"
+       sodipodi:arg1="1.0471976"
+       sodipodi:arg2="1.6755161"
+       inkscape:flatsided="false"
+       inkscape:rounded="3.46945e-18"
+       inkscape:randomized="0"
+       d="m 129.46671,193.82029 -32.017574,-29.60303 -37.472735,22.2993 18.260181,-39.59836 -32.787609,-28.74783 43.302989,5.1299 17.208878,-40.066435 8.50254,42.768815 43.42328,3.98541 -38.04813,21.30268 z"
+       inkscape:transform-center-x="0.71557854"
+       inkscape:transform-center-y="-6.8707532"
+       transform="rotate(-7.6773182,95.010913,153.91103)" />
+  </g>
+</svg>

--- a/redirector_app/web/templates/layouts/auth.html
+++ b/redirector_app/web/templates/layouts/auth.html
@@ -1,0 +1,222 @@
+{% extends "layouts/base.html" %}
+
+{% block body_class %}cyber-auth{% endblock %}
+
+{% block body %}
+<div id="layoutAuthentication">
+    <!-- Background effects -->
+    <div class="cyber-grid"></div>
+    <div class="cyber-glow cyber-glow-1"></div>
+    <div class="cyber-glow cyber-glow-2"></div>
+    <div class="cyber-glow cyber-glow-3"></div>
+    <div class="scan-line"></div>
+
+    <div id="layoutAuthentication_content">
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+    <div id="layoutAuthentication_footer">
+        <footer class="py-4 mt-auto" style="background: rgba(0,0,0,0.4);">
+            <div class="container-fluid px-4">
+                <div class="d-flex align-items-center justify-content-between small" style="color: rgba(255,255,255,0.3);">
+                    <div>Copyright &copy; CyberX Red Team {{ now.year if now else '2026' }}</div>
+                </div>
+            </div>
+        </footer>
+    </div>
+</div>
+
+<style>
+    body.cyber-auth {
+        background: #080810 !important;
+        overflow-x: hidden;
+    }
+
+    #layoutAuthentication {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+        position: relative;
+        overflow: hidden;
+        background: transparent !important;
+    }
+
+    #layoutAuthentication_content {
+        min-height: calc(100vh - 60px);
+        display: flex;
+        align-items: center;
+        position: relative;
+        z-index: 2;
+        background: transparent !important;
+    }
+
+    #layoutAuthentication_content main { width: 100%; }
+
+    #layoutAuthentication_footer {
+        min-height: 60px;
+        position: relative;
+        z-index: 2;
+        background: transparent !important;
+    }
+
+    /* ── Animated Grid Background ── */
+    .cyber-grid {
+        position: fixed;
+        top: 0; left: 0;
+        width: 200%; height: 200%;
+        z-index: 0;
+        pointer-events: none;
+        background-image:
+            linear-gradient(rgba(255, 23, 68, 0.15) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255, 23, 68, 0.15) 1px, transparent 1px),
+            linear-gradient(rgba(0, 207, 213, 0.07) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(0, 207, 213, 0.07) 1px, transparent 1px);
+        background-size: 80px 80px, 80px 80px, 20px 20px, 20px 20px;
+        animation: gridShift 20s linear infinite;
+    }
+
+    @keyframes gridShift {
+        0% { transform: translate(0, 0); }
+        100% { transform: translate(-80px, -80px); }
+    }
+
+    /* ── Ambient Glow Spots ── */
+    .cyber-glow { position: fixed; border-radius: 50%; z-index: 1; pointer-events: none; }
+
+    .cyber-glow-1 {
+        width: 600px; height: 600px;
+        top: -150px; right: -100px;
+        background: radial-gradient(circle, rgba(255, 23, 68, 0.12) 0%, transparent 70%);
+        animation: glowPulse1 6s ease-in-out infinite;
+    }
+
+    .cyber-glow-2 {
+        width: 500px; height: 500px;
+        bottom: -100px; left: -100px;
+        background: radial-gradient(circle, rgba(0, 207, 213, 0.08) 0%, transparent 70%);
+        animation: glowPulse2 8s ease-in-out infinite;
+    }
+
+    .cyber-glow-3 {
+        width: 400px; height: 400px;
+        top: 40%; left: 50%;
+        transform: translate(-50%, -50%);
+        background: radial-gradient(circle, rgba(255, 23, 68, 0.06) 0%, transparent 70%);
+        animation: glowPulse3 10s ease-in-out infinite;
+    }
+
+    @keyframes glowPulse1 {
+        0%, 100% { opacity: 0.6; transform: scale(1); }
+        50% { opacity: 1; transform: scale(1.1); }
+    }
+    @keyframes glowPulse2 {
+        0%, 100% { opacity: 0.5; transform: scale(1); }
+        50% { opacity: 0.9; transform: scale(1.15); }
+    }
+    @keyframes glowPulse3 {
+        0%, 100% { opacity: 0.4; }
+        50% { opacity: 0.8; }
+    }
+
+    /* ── Scanning Line ── */
+    .scan-line {
+        position: fixed;
+        top: -4px; left: 0;
+        width: 100%; height: 3px;
+        background: linear-gradient(90deg, transparent 5%, rgba(255, 23, 68, 0.6) 30%, rgba(255, 23, 68, 0.8) 50%, rgba(255, 23, 68, 0.6) 70%, transparent 95%);
+        box-shadow: 0 0 30px rgba(255, 23, 68, 0.5), 0 0 80px rgba(255, 23, 68, 0.2);
+        z-index: 1;
+        pointer-events: none;
+        animation: scanDown 8s ease-in-out infinite;
+    }
+
+    @keyframes scanDown {
+        0% { top: -4px; opacity: 0; }
+        5% { opacity: 1; }
+        95% { opacity: 1; }
+        100% { top: 100vh; opacity: 0; }
+    }
+
+    /* ── Glassmorphism Card ── */
+    .cyber-card {
+        background: rgba(12, 12, 22, 0.88) !important;
+        backdrop-filter: blur(24px);
+        -webkit-backdrop-filter: blur(24px);
+        border: 1px solid rgba(255, 23, 68, 0.25) !important;
+        border-radius: 12px !important;
+        box-shadow:
+            0 0 40px rgba(255, 23, 68, 0.12),
+            0 0 80px rgba(255, 23, 68, 0.05),
+            0 8px 32px rgba(0, 0, 0, 0.6),
+            inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
+
+    .cyber-card .card-footer {
+        background: rgba(0, 0, 0, 0.3) !important;
+        border-top: 1px solid rgba(255, 255, 255, 0.05) !important;
+        border-radius: 0 0 12px 12px !important;
+    }
+
+    /* ── Logo Glow ── */
+    .cyber-logo {
+        filter: drop-shadow(0 0 12px rgba(255, 23, 68, 0.6));
+        animation: logoPulse 3s ease-in-out infinite;
+    }
+
+    @keyframes logoPulse {
+        0%, 100% { filter: drop-shadow(0 0 12px rgba(255, 23, 68, 0.6)); }
+        50% { filter: drop-shadow(0 0 24px rgba(255, 23, 68, 0.9)) drop-shadow(0 0 48px rgba(255, 23, 68, 0.3)); }
+    }
+
+    /* ── Typography ── */
+    .cyber-title { color: #f0f0f0; font-weight: 300; letter-spacing: 2px; text-shadow: 0 0 20px rgba(255, 23, 68, 0.3); }
+    .cyber-subtitle { color: rgba(255, 23, 68, 0.7); font-size: 0.7rem; letter-spacing: 4px; text-transform: uppercase; text-shadow: 0 0 10px rgba(255, 23, 68, 0.3); }
+
+    /* ── Form Inputs ── */
+    .cyber-card .form-control { background: rgba(255, 255, 255, 0.05); border: 1px solid rgba(255, 255, 255, 0.12); color: #e0e0e0; border-radius: 8px; transition: all 0.3s ease; }
+    .cyber-card .form-control::placeholder { color: rgba(255, 255, 255, 0.25); }
+    .cyber-card .form-control:focus { background: rgba(255, 255, 255, 0.08); border-color: #ff1744; color: #f0f0f0; box-shadow: 0 0 0 0.2rem rgba(255, 23, 68, 0.15), 0 0 12px rgba(255, 23, 68, 0.3); }
+    .cyber-card label { color: rgba(255, 255, 255, 0.5); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 1px; }
+
+    /* ── Button ── */
+    .btn-cyber {
+        background: linear-gradient(135deg, #d32f2f, #ff1744);
+        color: #fff; border: none; border-radius: 8px;
+        padding: 0.5rem 1.5rem;
+        text-transform: uppercase; letter-spacing: 1.5px; font-size: 0.85rem; font-weight: 500;
+        transition: all 0.3s ease;
+        box-shadow: 0 0 15px rgba(255, 23, 68, 0.3);
+    }
+    .btn-cyber:hover { color: #fff; box-shadow: 0 0 25px rgba(255, 23, 68, 0.6), 0 0 50px rgba(255, 23, 68, 0.3); transform: translateY(-1px); }
+    .btn-cyber:active { transform: translateY(0); }
+
+    /* ── Links ── */
+    .cyber-card a { color: rgba(255, 23, 68, 0.7); text-decoration: none; transition: color 0.2s; }
+    .cyber-card a:hover { color: #ff1744; text-shadow: 0 0 8px rgba(255, 23, 68, 0.3); }
+    .cyber-card a.btn-cyber, .cyber-card a.btn-cyber:hover { color: #fff; }
+
+    /* ── Alerts ── */
+    .cyber-card .alert-danger { background: rgba(255, 23, 68, 0.1); border: 1px solid rgba(255, 23, 68, 0.3); color: #ff6e7f; }
+    .cyber-card .alert-danger .btn-close { filter: invert(1) brightness(0.8); }
+    .cyber-card .alert-success { background: rgba(0, 172, 105, 0.1); border: 1px solid rgba(0, 172, 105, 0.3); color: #69f0ae; }
+    .cyber-card .alert-success .btn-close { filter: invert(1) brightness(0.8); }
+
+    /* ── Footer Text ── */
+    .cyber-card .card-footer .text-muted { color: rgba(255, 255, 255, 0.25) !important; }
+
+    /* ── Nuclear override: force transparent backgrounds ── */
+    body.cyber-auth #layoutAuthentication,
+    body.cyber-auth #layoutAuthentication > *:not(.cyber-grid):not(.cyber-glow):not(.scan-line),
+    body.cyber-auth #layoutAuthentication_content,
+    body.cyber-auth #layoutAuthentication_content > *,
+    body.cyber-auth #layoutAuthentication_footer {
+        background-color: transparent !important;
+    }
+
+    body.cyber-auth #layoutAuthentication .card.cyber-card {
+        background: rgba(12, 12, 22, 0.88) !important;
+        color: #e0e0e0 !important;
+    }
+</style>
+{% endblock %}

--- a/redirector_app/web/templates/layouts/base.html
+++ b/redirector_app/web/templates/layouts/base.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="CyberX Redirector Manager">
+    <meta name="author" content="CyberX Red Team">
+    <title>{% block title %}CyberX{% endblock %} - Redirector Manager</title>
+
+    <!-- Bootstrap 5.3.2 -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <!-- Font Awesome 6.5.1 -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer">
+
+    <style>
+        /* ── CSS Variables ── */
+        :root {
+            --primary-color: #0061f2;
+            --secondary-color: #6900c7;
+            --success-color: #00ac69;
+            --danger-color: #e81500;
+            --warning-color: #f4a100;
+            --info-color: #00cfd5;
+            --bg-primary: #ffffff;
+            --bg-secondary: #f8f9fa;
+            --bg-card: #ffffff;
+            --text-primary: #212529;
+            --text-secondary: #6c757d;
+            --text-muted: #adb5bd;
+            --border-color: #dee2e6;
+            --shadow: rgba(0, 0, 0, 0.1);
+            --navbar-bg: #ffffff;
+            --sidebar-bg: #212529;
+            --sidebar-text: rgba(255, 255, 255, 0.5);
+            --sidebar-text-active: #ffffff;
+            --hover-bg: rgba(0, 0, 0, 0.05);
+            --input-bg: #ffffff;
+            --input-border: #dee2e6;
+            --table-stripe: rgba(0, 0, 0, 0.05);
+            --modal-bg: #ffffff;
+        }
+
+        [data-theme="dark"] {
+            --primary-color: #00cfd5;
+            --secondary-color: #6900c7;
+            --bg-primary: #0a0e27;
+            --bg-secondary: #1a1f3a;
+            --bg-card: #151a2e;
+            --text-primary: #e6edf3;
+            --text-secondary: #8b949e;
+            --text-muted: #6e7681;
+            --border-color: #2a2f4a;
+            --shadow: rgba(0, 0, 0, 0.3);
+            --navbar-bg: #0d1117;
+            --sidebar-bg: #0d1117;
+            --sidebar-text: #8b949e;
+            --sidebar-text-active: #e6edf3;
+            --hover-bg: rgba(0, 207, 213, 0.1);
+            --input-bg: #151a2e;
+            --input-border: #2a2f4a;
+            --table-stripe: rgba(255, 255, 255, 0.05);
+            --modal-bg: #151a2e;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            background-color: var(--bg-secondary);
+            color: var(--text-primary);
+        }
+
+        .bg-gradient-primary-to-secondary {
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
+        }
+
+        .nav-fixed { padding-top: 56px; }
+
+        .navbar.fixed-top { z-index: 1040; }
+
+        /* ── Sidenav ── */
+        .sidenav {
+            display: flex;
+            flex-direction: column;
+            height: calc(100vh - 56px);
+            flex-wrap: nowrap;
+            position: fixed;
+            top: 56px;
+            width: 225px;
+            left: 0;
+            background-color: var(--sidebar-bg);
+            z-index: 1038;
+            transition: transform 0.15s ease-in-out;
+        }
+
+        .sidenav .sidenav-menu { flex-grow: 1; overflow-y: auto; }
+
+        .sidenav .nav-link {
+            color: var(--sidebar-text);
+            padding: 0.75rem 1rem;
+            display: flex;
+            align-items: center;
+        }
+
+        .sidenav .nav-link:hover { color: var(--sidebar-text-active); }
+        .sidenav .nav-link.active { color: var(--sidebar-text-active); }
+
+        .sidenav .nav-link svg,
+        .sidenav .nav-link [data-feather] {
+            margin-right: 0.5rem;
+            width: 18px; height: 18px;
+            stroke: currentColor;
+            stroke-width: 2;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+            fill: none;
+        }
+
+        /* ── Feather icon sizes ── */
+        .feather { width: 16px; height: 16px; stroke: currentColor; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; fill: none; vertical-align: text-bottom; }
+        .feather-sm { width: 14px; height: 14px; }
+        .feather-lg { width: 24px; height: 24px; }
+        .feather-xl { width: 32px; height: 32px; }
+        .feather-xxl { width: 48px; height: 48px; }
+
+        .card-header svg, .card-header [data-feather] { width: 16px; height: 16px; vertical-align: text-bottom; }
+        .btn svg, .btn [data-feather] { width: 16px; height: 16px; vertical-align: text-bottom; }
+        .page-header-icon svg, .page-header-icon [data-feather] { width: 24px; height: 24px; margin-right: 0.5rem; vertical-align: middle; }
+
+        /* ── Sidenav Light Theme ── */
+        .sidenav-light { background-color: #f8f9fa; border-right: 1px solid #dee2e6; }
+        .sidenav-light .nav-link { color: #495057; }
+        .sidenav-light .nav-link:hover { color: var(--primary-color); background-color: rgba(0, 97, 242, 0.05); }
+        .sidenav-light .nav-link.active { color: var(--primary-color); font-weight: 600; background-color: rgba(0, 97, 242, 0.1); }
+        .sidenav-light .nav-link svg { stroke: currentColor; }
+        .sidenav-light .sidenav-menu-heading { color: #6c757d; text-transform: uppercase; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; }
+        .sidenav-light .sidenav-footer { background-color: #fff; }
+
+        /* ── Layout ── */
+        #layoutSidenav { display: flex; }
+
+        #layoutSidenav #layoutSidenav_content {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+            flex-grow: 1;
+            min-height: calc(100vh - 56px);
+            margin-left: 225px;
+        }
+
+        /* ── Page Header ── */
+        .page-header { padding: 2rem 0; position: relative; z-index: 1; }
+        .page-header-dark { color: #fff; }
+        .page-header-title { display: flex; align-items: center; }
+        .page-header-subtitle { opacity: 0.8; }
+        .pb-10 { padding-bottom: 8rem !important; }
+        .mt-n10 { margin-top: -6rem !important; position: relative; z-index: 2; }
+
+        /* ── Cards ── */
+        .card { box-shadow: 0 0.15rem 1.75rem 0 rgba(33, 40, 50, 0.15); border: none; }
+        .card-header { background-color: rgba(33, 40, 50, 0.03); border-bottom: 1px solid rgba(33, 40, 50, 0.125); display: flex; align-items: center; }
+        .footer { padding: 1rem 0; background-color: #fff; }
+
+        /* ── Stats cards ── */
+        .stats-card { transition: transform 0.15s ease-in-out; }
+        .stats-card:hover { transform: translateY(-3px); }
+        .text-white-50 { color: rgba(255, 255, 255, 0.5) !important; }
+        .text-white-75 { color: rgba(255, 255, 255, 0.75) !important; }
+
+        /* ── Responsive ── */
+        @media (max-width: 992px) {
+            .sidenav { transform: translateX(-225px); }
+            .sidenav.show { transform: translateX(0); }
+            #layoutSidenav #layoutSidenav_content { margin-left: 0; }
+        }
+
+        @media print {
+            .sidenav, .navbar { display: none !important; }
+            #layoutSidenav #layoutSidenav_content { margin-left: 0 !important; }
+        }
+
+        /* ── Theme-aware component overrides ── */
+        .navbar-light { background-color: var(--navbar-bg) !important; border-bottom: 1px solid var(--border-color); }
+        .navbar-light .navbar-brand { color: #d32f2f !important; }
+        .navbar-light .navbar-nav .nav-link { color: var(--text-secondary); }
+        .navbar-light .navbar-nav .nav-link:hover { color: var(--text-primary); }
+
+        .card { background-color: var(--bg-card); border-color: var(--border-color); color: var(--text-primary); }
+        .card-header { background-color: var(--bg-secondary); border-bottom-color: var(--border-color); color: var(--text-primary); }
+        .card-footer { background-color: var(--bg-secondary); border-top-color: var(--border-color); }
+
+        .table { color: var(--text-primary); border-color: var(--border-color); }
+        .table thead th { border-bottom-color: var(--border-color); color: var(--text-primary); }
+        .table tbody tr { border-bottom-color: var(--border-color); }
+        .table-striped > tbody > tr:nth-of-type(odd) > * { background-color: var(--table-stripe); }
+        .table-hover > tbody > tr:hover > * { background-color: var(--hover-bg); }
+
+        .form-control, .form-select { background-color: var(--input-bg); border-color: var(--input-border); color: var(--text-primary); }
+        .form-control:focus, .form-select:focus { background-color: var(--input-bg); border-color: var(--primary-color); color: var(--text-primary); }
+        .form-control::placeholder { color: var(--text-muted); }
+        .form-label { color: var(--text-primary); }
+        .form-text { color: var(--text-muted); }
+
+        .modal-content { background-color: var(--modal-bg); border-color: var(--border-color); color: var(--text-primary); }
+        .modal-header { border-bottom-color: var(--border-color); }
+        .modal-footer { border-top-color: var(--border-color); }
+        .modal-title { color: var(--text-primary); }
+
+        .dropdown-menu { background-color: var(--bg-card); border-color: var(--border-color); }
+        .dropdown-item { color: var(--text-primary); }
+        .dropdown-item:hover, .dropdown-item:focus { background-color: var(--hover-bg); color: var(--text-primary); }
+        .dropdown-divider { border-top-color: var(--border-color); }
+
+        .badge { color: #fff; }
+        .text-muted { color: var(--text-muted) !important; }
+        .border { border-color: var(--border-color) !important; }
+        .bg-white { background-color: var(--bg-card) !important; }
+        .bg-light { background-color: var(--bg-secondary) !important; }
+
+        code { background-color: var(--bg-secondary); color: var(--primary-color); }
+        pre { background-color: var(--bg-secondary); border-color: var(--border-color); color: var(--text-primary); }
+        hr { border-color: var(--border-color); opacity: 1; }
+        main { background-color: var(--bg-secondary); }
+        #layoutSidenav_content { background-color: var(--bg-secondary); }
+
+        .footer { background-color: var(--bg-card); border-top: 1px solid var(--border-color); color: var(--text-secondary); }
+        .sidenav-footer { background-color: var(--sidebar-bg); border-top-color: var(--border-color) !important; color: var(--sidebar-text); }
+        .sidenav-footer .fw-bold { color: var(--sidebar-text-active); }
+
+        /* Colored stat cards */
+        .card.bg-primary, .card.bg-primary .card-body { background-color: #0061f2 !important; color: #ffffff !important; }
+        .card.bg-success, .card.bg-success .card-body { background-color: #00ac69 !important; color: #ffffff !important; }
+        .card.bg-info, .card.bg-info .card-body { background-color: #00cfd5 !important; color: #ffffff !important; }
+        .card.bg-warning, .card.bg-warning .card-body { background-color: #f4a100 !important; color: #ffffff !important; }
+        .card.bg-danger, .card.bg-danger .card-body { background-color: #e81500 !important; color: #ffffff !important; }
+        .card.bg-primary .card-footer, .card.bg-success .card-footer, .card.bg-info .card-footer, .card.bg-danger .card-footer, .card.bg-warning .card-footer { background-color: rgba(0,0,0,0.1) !important; border-color: rgba(0,0,0,0.125) !important; color: rgba(255,255,255,0.8) !important; }
+
+        /* Dark mode overrides */
+        [data-theme="dark"] .card { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; }
+        [data-theme="dark"] .card-header, [data-theme="dark"] .card-footer { background-color: var(--bg-secondary) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; }
+        [data-theme="dark"] .card-body { background-color: var(--bg-card) !important; color: var(--text-primary) !important; }
+        [data-theme="dark"] .table { color: var(--text-primary) !important; background-color: transparent !important; }
+        [data-theme="dark"] .table thead th { background-color: var(--bg-secondary) !important; color: var(--text-primary) !important; border-color: var(--border-color) !important; }
+        [data-theme="dark"] .table tbody tr { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; }
+        [data-theme="dark"] .table tbody tr:hover { background-color: var(--hover-bg) !important; }
+        [data-theme="dark"] .table td, [data-theme="dark"] .table th { border-color: var(--border-color) !important; color: var(--text-primary) !important; }
+        [data-theme="dark"] .form-control, [data-theme="dark"] .form-select { background-color: var(--input-bg) !important; border-color: var(--input-border) !important; color: var(--text-primary) !important; }
+        [data-theme="dark"] .form-control:focus, [data-theme="dark"] .form-select:focus { background-color: var(--input-bg) !important; border-color: var(--primary-color) !important; color: var(--text-primary) !important; box-shadow: 0 0 0 0.25rem rgba(0,207,213,0.25) !important; }
+        [data-theme="dark"] .form-label { color: var(--text-primary) !important; }
+        [data-theme="dark"] .modal-content { background-color: var(--modal-bg); border-color: var(--border-color); color: var(--text-primary); }
+        [data-theme="dark"] .modal-header, [data-theme="dark"] .modal-footer { border-color: var(--border-color); }
+        [data-theme="dark"] .dropdown-menu { background-color: var(--bg-card); border-color: var(--border-color); }
+        [data-theme="dark"] .dropdown-item { color: var(--text-primary); }
+        [data-theme="dark"] .dropdown-item:hover, [data-theme="dark"] .dropdown-item:focus { background-color: var(--hover-bg); color: var(--text-primary); }
+        [data-theme="dark"] .dropdown-divider { border-color: var(--border-color); }
+        [data-theme="dark"] .navbar.navbar-light { background-color: var(--navbar-bg) !important; }
+        [data-theme="dark"] .navbar.navbar-light .nav-link, [data-theme="dark"] .navbar.navbar-light .navbar-text { color: var(--text-primary) !important; }
+        [data-theme="dark"] .sidenav, [data-theme="dark"] .sidenav-light { background-color: var(--sidebar-bg) !important; }
+        [data-theme="dark"] .sidenav .nav-link, [data-theme="dark"] .sidenav-light .nav-link { color: var(--sidebar-text) !important; }
+        [data-theme="dark"] .sidenav .nav-link:hover, [data-theme="dark"] .sidenav-light .nav-link:hover { color: var(--sidebar-text-active) !important; background-color: var(--hover-bg) !important; }
+        [data-theme="dark"] .sidenav .nav-link.active, [data-theme="dark"] .sidenav-light .nav-link.active { color: var(--sidebar-text-active) !important; background-color: var(--hover-bg) !important; }
+        [data-theme="dark"] .sidenav-menu-heading, [data-theme="dark"] .sidenav-light .sidenav-menu-heading { color: var(--text-muted) !important; }
+        [data-theme="dark"] .sidenav-footer, [data-theme="dark"] .sidenav-light .sidenav-footer { background-color: var(--sidebar-bg) !important; border-top-color: var(--border-color) !important; }
+        [data-theme="dark"] .text-muted { color: var(--text-muted) !important; }
+        [data-theme="dark"] .btn-close { filter: invert(1) grayscale(100%) brightness(200%); }
+        [data-theme="dark"] .btn-outline-secondary { border-color: var(--border-color) !important; color: var(--text-secondary) !important; }
+        [data-theme="dark"] .btn-outline-secondary:hover { background-color: var(--bg-secondary) !important; color: var(--text-primary) !important; }
+        [data-theme="dark"] .btn-outline-danger { border-color: var(--danger-color) !important; color: var(--danger-color) !important; }
+        [data-theme="dark"] .btn-outline-danger:hover { background-color: var(--danger-color) !important; color: #fff !important; }
+        [data-theme="dark"] .border { border-color: var(--border-color) !important; }
+        [data-theme="dark"] .border-bottom { border-color: var(--border-color) !important; }
+        [data-theme="dark"] hr { border-color: var(--border-color); }
+    </style>
+
+    {% block extra_css %}{% endblock %}
+</head>
+<body class="{% block body_class %}{% endblock %}">
+    {% block body %}{% endblock %}
+
+    <!-- Bootstrap JS Bundle -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+
+    <!-- Feather Icons -->
+    <script src="https://unpkg.com/feather-icons@4.29.1/dist/feather.min.js"></script>
+    <script>
+        if (typeof feather === 'undefined') {
+            var s = document.createElement('script');
+            s.src = 'https://cdn.jsdelivr.net/npm/feather-icons@4.29.1/dist/feather.min.js';
+            document.head.appendChild(s);
+        }
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(function() {
+                if (typeof feather !== 'undefined') feather.replace();
+            }, 50);
+        });
+
+        function refreshFeatherIcons() {
+            if (typeof feather !== 'undefined') feather.replace();
+        }
+
+        // ── DateTime Formatting ──
+        window.formatDateTime = function(dateStr, options = {}) {
+            if (!dateStr) return '-';
+            const date = new Date(dateStr);
+            const timezone = localStorage.getItem('timezonePreference') || 'utc';
+            const timeFormat = localStorage.getItem('timeFormat') || '24';
+            const fmt = {
+                year: 'numeric', month: '2-digit', day: '2-digit',
+                hour: '2-digit', minute: '2-digit',
+                second: options.hideSeconds ? undefined : '2-digit',
+                hour12: options.hour12 !== undefined ? options.hour12 : (timeFormat === '12')
+            };
+            if (timezone === 'utc') fmt.timeZone = 'UTC';
+            return date.toLocaleString('en-US', fmt);
+        };
+    </script>
+
+    <!-- CSRF Protection (inlined from cyberx-event-mgmt/frontend/static/js/csrf.js) -->
+    <script>
+        function getCSRFToken() {
+            const cookies = document.cookie.split(';');
+            for (let cookie of cookies) {
+                const [name, value] = cookie.trim().split('=');
+                if (name === 'csrf_token') return value;
+            }
+            return null;
+        }
+
+        async function csrfFetch(url, options = {}) {
+            const defaultOptions = { credentials: 'include', headers: {} };
+            const mergedOptions = { ...defaultOptions, ...options };
+            if (!mergedOptions.headers) mergedOptions.headers = {};
+
+            const method = (mergedOptions.method || 'GET').toUpperCase();
+            const requiresCSRF = ['POST', 'PUT', 'DELETE', 'PATCH'].includes(method);
+
+            let csrfToken = null;
+            if (requiresCSRF) {
+                csrfToken = getCSRFToken();
+                if (csrfToken) {
+                    mergedOptions.headers['X-CSRF-Token'] = csrfToken;
+                } else {
+                    console.warn('CSRF token not found in cookies. Request may be rejected.');
+                }
+            }
+
+            if (mergedOptions.body && typeof mergedOptions.body === 'object'
+                && !(mergedOptions.body instanceof FormData)
+                && !(mergedOptions.body instanceof Blob)
+                && !(mergedOptions.body instanceof URLSearchParams)) {
+                mergedOptions.body = JSON.stringify(mergedOptions.body);
+                if (!mergedOptions.headers['Content-Type']) {
+                    mergedOptions.headers['Content-Type'] = 'application/json';
+                }
+            }
+
+            const response = await fetch(url, mergedOptions);
+
+            if (response.status === 401) {
+                window.location.href = '/login';
+                return response;
+            }
+
+            if (requiresCSRF && response.status === 403) {
+                try {
+                    const errorBody = await response.clone().json();
+                    if (errorBody.detail && errorBody.detail.toLowerCase().includes('csrf')) {
+                        const freshToken = getCSRFToken();
+                        if (freshToken && freshToken !== csrfToken) {
+                            mergedOptions.headers['X-CSRF-Token'] = freshToken;
+                            return fetch(url, mergedOptions);
+                        }
+                    }
+                } catch (_) {}
+            }
+
+            return response;
+        }
+    </script>
+
+    <!-- Theme Management -->
+    <script>
+        (function() {
+            function applyTheme(theme) {
+                document.documentElement.setAttribute('data-theme', theme);
+                localStorage.setItem('theme', theme);
+                updateThemeUI(theme);
+            }
+
+            function updateThemeUI(theme) {
+                const themeIcon = document.getElementById('themeIcon');
+                const themeLabel = document.getElementById('themeLabel');
+                if (themeIcon && themeLabel) {
+                    if (theme === 'dark') {
+                        themeIcon.setAttribute('data-feather', 'sun');
+                        themeLabel.textContent = 'Light Mode';
+                    } else {
+                        themeIcon.setAttribute('data-feather', 'moon');
+                        themeLabel.textContent = 'Dark Mode';
+                    }
+                    if (typeof feather !== 'undefined') feather.replace();
+                }
+            }
+
+            window.toggleTheme = function() {
+                const current = document.documentElement.getAttribute('data-theme') || 'light';
+                applyTheme(current === 'light' ? 'dark' : 'light');
+            };
+
+            function initTheme() {
+                const isAuthPage = document.getElementById('layoutAuthentication') !== null;
+                if (!isAuthPage) {
+                    const theme = localStorage.getItem('theme') || 'light';
+                    applyTheme(theme);
+                }
+            }
+
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', initTheme);
+            } else {
+                initTheme();
+            }
+        })();
+    </script>
+
+    <!-- Toast notifications -->
+    <script>
+        window.showToast = function(message, type) {
+            type = type || 'info';
+            const colorMap = { success: 'success', danger: 'danger', warning: 'warning', info: 'info' };
+            const bsColor = colorMap[type] || 'info';
+            const div = document.createElement('div');
+            div.className = `alert alert-${bsColor} alert-dismissible fade show`;
+            div.style.cssText = 'position:fixed;top:70px;left:50%;transform:translateX(-50%);z-index:9999;min-width:320px;max-width:600px;box-shadow:0 4px 12px rgba(0,0,0,0.15);';
+            div.innerHTML = message + '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>';
+            document.body.appendChild(div);
+            setTimeout(function() {
+                div.classList.remove('show');
+                setTimeout(function() { div.remove(); }, 300);
+            }, 5000);
+        };
+    </script>
+
+    <!-- Logout -->
+    <script>
+        async function logout() {
+            try {
+                await csrfFetch('/api/web/logout', { method: 'POST' });
+            } catch (_) {}
+            window.location.href = '/login';
+        }
+    </script>
+
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/redirector_app/web/templates/layouts/dashboard.html
+++ b/redirector_app/web/templates/layouts/dashboard.html
@@ -1,0 +1,92 @@
+{% extends "layouts/base.html" %}
+
+{% block body_class %}nav-fixed{% endblock %}
+
+{% block body %}
+<!-- Top Navigation -->
+<nav class="navbar navbar-expand-lg navbar-light fixed-top shadow-sm" style="background-color: var(--navbar-bg, #ffffff);">
+    <div class="container-fluid px-4">
+        <a class="navbar-brand fw-bold" href="/redirectors" style="color: #d32f2f;">
+            <img src="/static/img/cyberx-star-logo.svg" alt="CyberX" style="width: 28px; height: 28px; vertical-align: middle;" class="me-2">CyberX Redirector Manager
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="https://github.com/CyberX-Red-Team/nginx-redir-mgmt/issues" target="_blank" rel="noopener noreferrer" title="Report an issue">
+                        <i data-feather="alert-circle" class="me-1"></i>
+                        <span class="d-none d-md-inline">Report Issue</span>
+                    </a>
+                </li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                        <i data-feather="user" class="me-1"></i>
+                        {{ current_user.first_name }}
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <button class="dropdown-item" id="themeToggle" onclick="toggleTheme()" type="button">
+                                <i data-feather="moon" class="me-2" id="themeIcon"></i>
+                                <span id="themeLabel">Dark Mode</span>
+                            </button>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" href="#" onclick="logout()"><i data-feather="log-out" class="me-2"></i>Logout</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<div id="layoutSidenav">
+    <!-- Sidebar -->
+    <div id="layoutSidenav_nav">
+        <nav class="sidenav sidenav-light">
+            <div class="sidenav-menu">
+                <div class="nav pt-3">
+                    <div class="sidenav-menu-heading px-3 py-2">Infrastructure</div>
+                    <a class="nav-link {% if active_page == 'redirectors' %}active{% endif %}" href="/redirectors">
+                        <i data-feather="server"></i>
+                        <span>Redirectors</span>
+                    </a>
+
+                    <div class="sidenav-menu-heading px-3 py-2 mt-2">System</div>
+                    <a class="nav-link {% if active_page == 'logs' %}active{% endif %}" href="/logs">
+                        <i data-feather="terminal"></i>
+                        <span>Error Logs</span>
+                    </a>
+                </div>
+            </div>
+
+            <!-- Sidebar Footer -->
+            <div class="sidenav-footer p-3 border-top">
+                <div class="sidenav-footer-content">
+                    <div class="sidenav-footer-subtitle fw-bold text-truncate small">
+                        <i data-feather="user" class="me-1" style="width:14px;height:14px;"></i>
+                        {{ current_user.email }}
+                    </div>
+                </div>
+            </div>
+        </nav>
+    </div>
+
+    <!-- Main Content -->
+    <div id="layoutSidenav_content">
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+        <footer class="footer mt-auto py-3">
+            <div class="container-fluid px-4">
+                <div class="d-flex align-items-center justify-content-between small">
+                    <div class="text-muted">Copyright &copy; CyberX Red Team {{ now.year if now else '2026' }}</div>
+                    <div class="text-muted">v{{ app_version | default('1.0.0') }}</div>
+                </div>
+            </div>
+        </footer>
+    </div>
+</div>
+{% endblock %}

--- a/redirector_app/web/templates/pages/auth/login.html
+++ b/redirector_app/web/templates/pages/auth/login.html
@@ -1,0 +1,89 @@
+{% extends "layouts/auth.html" %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-lg-5">
+            <div class="card cyber-card border-0 mt-5">
+                <div class="card-body">
+                    <div class="text-center pt-4 pb-2">
+                        <img src="/static/img/cyberx-star-logo.svg" alt="CyberX" style="width: 56px; height: 56px;" class="mb-3 cyber-logo">
+                        <h3 class="cyber-title">CyberX</h3>
+                        <div class="cyber-subtitle mt-1">Redirector Manager</div>
+                    </div>
+
+                    <div id="loginError" class="alert alert-danger alert-dismissible fade show mt-3 d-none" role="alert">
+                        <span id="loginErrorMsg"></span>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                    </div>
+
+                    <form id="loginForm" class="mt-4">
+                        <div class="mb-3">
+                            <label class="small mb-1" for="username">Username</label>
+                            <input class="form-control" id="username" name="username" type="text"
+                                   placeholder="Enter username" required autofocus autocomplete="username" />
+                        </div>
+                        <div class="mb-3">
+                            <label class="small mb-1" for="password">Password</label>
+                            <input class="form-control" id="password" name="password" type="password"
+                                   placeholder="Enter password" required autocomplete="current-password" />
+                        </div>
+                        <div class="d-flex align-items-center justify-content-end mt-4 mb-0">
+                            <button type="submit" class="btn btn-cyber" id="loginBtn">Login</button>
+                        </div>
+                    </form>
+                </div>
+                <div class="card-footer text-center py-3">
+                    <div class="small text-muted">
+                        CyberX Redirector Manager
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.getElementById('loginForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+
+    const btn = document.getElementById('loginBtn');
+    const errEl = document.getElementById('loginError');
+    const errMsg = document.getElementById('loginErrorMsg');
+
+    errEl.classList.add('d-none');
+    btn.disabled = true;
+    btn.textContent = 'Authenticating...';
+
+    const username = document.getElementById('username').value.trim();
+    const password = document.getElementById('password').value;
+
+    try {
+        const response = await csrfFetch('/api/web/login', {
+            method: 'POST',
+            body: JSON.stringify({ username, password }),
+            headers: { 'Content-Type': 'application/json' }
+        });
+
+        if (response.ok) {
+            window.location.href = '/redirectors';
+        } else {
+            const data = await response.json().catch(() => ({}));
+            errMsg.textContent = data.detail || 'Login failed. Please check your credentials.';
+            errEl.classList.remove('d-none');
+            btn.disabled = false;
+            btn.textContent = 'Login';
+        }
+    } catch (error) {
+        errMsg.textContent = 'An error occurred. Please try again.';
+        errEl.classList.remove('d-none');
+        btn.disabled = false;
+        btn.textContent = 'Login';
+    }
+});
+</script>
+{% endblock %}

--- a/redirector_app/web/templates/pages/logs.html
+++ b/redirector_app/web/templates/pages/logs.html
@@ -1,0 +1,186 @@
+{% extends "layouts/dashboard.html" %}
+
+{% block title %}Error Logs{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-4 py-4">
+
+    <!-- Page Header -->
+    <div class="d-flex align-items-center justify-content-between mb-4">
+        <div>
+            <h1 class="h3 mb-0 fw-bold">
+                <i data-feather="terminal" class="me-2" style="color:#d32f2f;"></i>Error Logs
+            </h1>
+            <p class="text-muted small mb-0 mt-1">
+                Recent application log entries (last 500, newest first). Refreshes automatically every 5 seconds.
+            </p>
+        </div>
+        <div class="d-flex align-items-center gap-2">
+            <!-- Level filter -->
+            <select class="form-select form-select-sm" id="levelFilter" style="width:auto;" onchange="applyFilter()">
+                <option value="">All Levels</option>
+                <option value="DEBUG">DEBUG</option>
+                <option value="INFO">INFO</option>
+                <option value="WARNING">WARNING</option>
+                <option value="ERROR">ERROR</option>
+                <option value="CRITICAL">CRITICAL</option>
+            </select>
+
+            <!-- Auto-refresh toggle -->
+            <div class="form-check form-switch mb-0 ms-2">
+                <input class="form-check-input" type="checkbox" id="autoRefresh" checked onchange="toggleAutoRefresh()">
+                <label class="form-check-label small" for="autoRefresh">Auto-refresh</label>
+            </div>
+
+            <!-- Download button -->
+            <button class="btn btn-sm btn-outline-secondary" onclick="downloadLogs()" title="Download visible logs as .txt">
+                <i data-feather="download" class="me-1"></i> Download
+            </button>
+
+            <!-- Manual refresh -->
+            <button class="btn btn-sm btn-outline-secondary" onclick="loadLogs()" title="Refresh now">
+                <i data-feather="refresh-cw"></i>
+            </button>
+        </div>
+    </div>
+
+    <!-- Log Table -->
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive" style="max-height: 75vh; overflow-y: auto;">
+                <table class="table table-hover table-sm mb-0 font-monospace" id="logsTable" style="font-size: 0.8rem;">
+                    <thead class="table-light sticky-top">
+                        <tr>
+                            <th style="width:160px;">Timestamp</th>
+                            <th style="width:80px;">Level</th>
+                            <th style="width:180px;">Logger</th>
+                            <th>Message</th>
+                        </tr>
+                    </thead>
+                    <tbody id="logsBody">
+                        <tr id="loadingRow">
+                            <td colspan="4" class="text-center text-muted py-4">
+                                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                                Loading logs...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-between align-items-center small text-muted">
+            <span id="logCount">—</span>
+            <span id="lastUpdated">—</span>
+        </div>
+    </div>
+
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+let _allLogs = [];
+let _autoRefreshInterval = null;
+
+// ── Load logs from API ──
+async function loadLogs() {
+    try {
+        const resp = await fetch('/api/internal/logs?n=500');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        _allLogs = data.logs || [];
+        applyFilter();
+        document.getElementById('lastUpdated').textContent =
+            'Updated: ' + new Date().toLocaleTimeString();
+    } catch (err) {
+        document.getElementById('logsBody').innerHTML =
+            `<tr><td colspan="4" class="text-center text-danger py-3">Failed to load logs: ${escHtml(err.message)}</td></tr>`;
+    }
+}
+
+// ── Apply level filter and render ──
+function applyFilter() {
+    const level = document.getElementById('levelFilter').value;
+    const filtered = level ? _allLogs.filter(e => e.level === level) : _allLogs;
+    renderLogs(filtered);
+    document.getElementById('logCount').textContent =
+        `Showing ${filtered.length} of ${_allLogs.length} entries`;
+}
+
+// ── Render log rows ──
+function renderLogs(logs) {
+    const tbody = document.getElementById('logsBody');
+    if (!logs.length) {
+        tbody.innerHTML = `<tr><td colspan="4" class="text-center text-muted py-4">No log entries to display.</td></tr>`;
+        return;
+    }
+    tbody.innerHTML = logs.map(e => {
+        const levelClass = levelColor(e.level);
+        return `<tr>
+            <td class="text-muted text-nowrap">${escHtml(e.ts || '')}</td>
+            <td><span class="badge ${levelBadge(e.level)} rounded-1">${escHtml(e.level || '')}</span></td>
+            <td class="text-muted text-truncate" style="max-width:180px;" title="${escHtml(e.name || '')}">${escHtml(e.name || '')}</td>
+            <td class="${levelClass}">${escHtml(e.msg || '')}</td>
+        </tr>`;
+    }).join('');
+}
+
+function levelColor(level) {
+    switch (level) {
+        case 'ERROR':
+        case 'CRITICAL': return 'text-danger';
+        case 'WARNING':  return 'text-warning';
+        default: return '';
+    }
+}
+
+function levelBadge(level) {
+    switch (level) {
+        case 'ERROR':    return 'bg-danger';
+        case 'CRITICAL': return 'bg-danger';
+        case 'WARNING':  return 'bg-warning text-dark';
+        case 'INFO':     return 'bg-info text-dark';
+        case 'DEBUG':    return 'bg-secondary';
+        default: return 'bg-secondary';
+    }
+}
+
+// ── Auto-refresh toggle ──
+function toggleAutoRefresh() {
+    const enabled = document.getElementById('autoRefresh').checked;
+    if (enabled) {
+        _autoRefreshInterval = setInterval(loadLogs, 5000);
+    } else {
+        clearInterval(_autoRefreshInterval);
+        _autoRefreshInterval = null;
+    }
+}
+
+// ── Download visible logs ──
+function downloadLogs() {
+    const level = document.getElementById('levelFilter').value;
+    const filtered = level ? _allLogs.filter(e => e.level === level) : _allLogs;
+    const lines = filtered.map(e => `${e.ts || ''} [${e.level || ''}] ${e.name || ''}: ${e.msg || ''}`).join('\n');
+    const blob = new Blob([lines], { type: 'text/plain' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `cyberx-redir-logs-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.txt`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+}
+
+// ── Utility ──
+function escHtml(str) {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+}
+
+// ── Init ──
+document.addEventListener('DOMContentLoaded', function() {
+    loadLogs();
+    // Start auto-refresh
+    _autoRefreshInterval = setInterval(loadLogs, 5000);
+});
+</script>
+{% endblock %}

--- a/redirector_app/web/templates/pages/redirectors/detail.html
+++ b/redirector_app/web/templates/pages/redirectors/detail.html
@@ -547,7 +547,7 @@ async function testConnection() {
         updateStatusBadge(data.status);
         const rtt = data.rtt_ms ? ` (${data.rtt_ms}ms)` : '';
         const streamWarn = data.stream_module_present ? '' : ' ⚠️ Stream module not found!';
-        showToast(`${data.message}${rtt}${streamWarn}`, data.success ? 'success' : 'warning');
+        showToast(`${escHtml(data.message || '')}${rtt}${streamWarn}`, data.success ? 'success' : 'warning');
     } catch (err) {
         showToast(`Request failed: ${err.message}`, 'danger');
     }
@@ -798,7 +798,7 @@ async function confirmDeleteStream() {
         );
         if (!resp.ok && resp.status !== 204) {
             const d = await resp.json().catch(() => ({}));
-            showToast(d.detail || 'Delete failed.', 'danger');
+            showToast(escHtml(d.detail || 'Delete failed.'), 'danger');
             return;
         }
         delStreamModal.hide();

--- a/redirector_app/web/templates/pages/redirectors/detail.html
+++ b/redirector_app/web/templates/pages/redirectors/detail.html
@@ -540,7 +540,7 @@ async function testConnection() {
         const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/test-connection`, { method: 'POST' });
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Connection failed: ${data.detail}`, 'danger');
+            showToast(`Connection failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             updateStatusBadge('offline');
             return;
         }
@@ -562,7 +562,7 @@ async function deployAll() {
         const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/deploy-all`, { method: 'POST' });
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            showToast(`Deploy failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult('Deploy All', data);
@@ -596,7 +596,7 @@ async function deployStream(streamId, streamName) {
         );
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            showToast(`Deploy failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult(`Deploy: ${streamName}`, data);
@@ -614,7 +614,7 @@ async function removeStream(streamId, streamName) {
         );
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Disable failed: ${data.detail}`, 'danger');
+            showToast(`Disable failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult(`Disable: ${streamName}`, data);
@@ -633,7 +633,7 @@ async function enableStream(streamId, streamName) {
         );
         const data = await resp.json();
         if (!resp.ok) {
-            showToast(`Enable failed: ${data.detail}`, 'danger');
+            showToast(`Enable failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
             return;
         }
         showDeployResult(`Enable: ${streamName}`, data);

--- a/redirector_app/web/templates/pages/redirectors/detail.html
+++ b/redirector_app/web/templates/pages/redirectors/detail.html
@@ -1,0 +1,1152 @@
+{% extends "layouts/dashboard.html" %}
+
+{% block title %}{{ redirector.name }} — Redirector{% endblock %}
+
+{% block extra_css %}
+<style>
+tr.stream-conflict > td { background-color: rgba(220,53,69,0.15) !important; }
+tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !important; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-4 py-4">
+
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/redirectors">Redirectors</a></li>
+            <li class="breadcrumb-item active">{{ redirector.name }}</li>
+        </ol>
+    </nav>
+
+    <!-- Header Card -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex align-items-start justify-content-between flex-wrap gap-3">
+                <div>
+                    <div class="d-flex align-items-center gap-3 mb-2">
+                        <h2 class="h4 fw-bold mb-0">
+                            <i data-feather="server" class="me-2" style="color:#d32f2f;"></i>
+                            {{ redirector.name }}
+                        </h2>
+                        <span id="statusBadge" class="badge fs-6
+                            {% if redirector.status == 'online' %}bg-success
+                            {% elif redirector.status == 'offline' %}bg-danger
+                            {% else %}bg-secondary{% endif %}">
+                            {{ redirector.status }}
+                        </span>
+                    </div>
+                    <div class="text-muted small">
+                        <code>{{ redirector.ssh_username }}@{{ redirector.current_ip }}:{{ redirector.ssh_port }}</code>
+                        &nbsp;·&nbsp;
+                        Stream dir: <code>{{ redirector.nginx_stream_dir }}</code>
+                        {% if redirector.last_tested_at %}
+                        &nbsp;·&nbsp; Last tested:
+                        <span class="js-dt">{{ redirector.last_tested_at.isoformat() }}</span>
+                        {% endif %}
+                    </div>
+                    {% if redirector.notes %}
+                    <p class="mt-2 mb-0 text-muted small">{{ redirector.notes }}</p>
+                    {% endif %}
+                </div>
+                <div class="d-flex gap-2 flex-wrap">
+                    <button class="btn btn-outline-secondary" onclick="testConnection()">
+                        <i data-feather="wifi" class="me-1"></i>Test Connection
+                    </button>
+                    <button class="btn btn-primary" onclick="deployAll()">
+                        <i data-feather="upload-cloud" class="me-1"></i>Deploy All
+                    </button>
+                    <button class="btn btn-outline-secondary" onclick="openEditRedirectorModal()">
+                        <i data-feather="edit-2" class="me-1"></i>Edit
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Prerequisites (collapsible) -->
+    <div class="accordion mb-4" id="setupGuide">
+        <div class="accordion-item border">
+            <h2 class="accordion-header">
+                <button class="accordion-button collapsed fw-semibold" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#setupGuideBody">
+                    <i data-feather="check-square" class="me-2"></i>Prerequisites
+                    <span id="prereqBadge" class="badge bg-secondary ms-2 d-none">?</span>
+                </button>
+            </h2>
+            <div id="setupGuideBody" class="accordion-collapse collapse">
+                <div class="accordion-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <span class="small text-muted">Required on <code>{{ redirector.current_ip }}</code> for CyberX to operate.</span>
+                        <div class="d-flex gap-2">
+                            <button class="btn btn-sm btn-outline-secondary" onclick="checkPrereqs()">
+                                <i data-feather="refresh-cw" class="me-1"></i>Re-check
+                            </button>
+                            <button class="btn btn-sm btn-warning d-none" id="fixPrereqsBtn" onclick="fixPrereqs()">
+                                <i data-feather="tool" class="me-1"></i>Auto-fix
+                            </button>
+                        </div>
+                    </div>
+                    <div id="prereqResults">
+                        <!-- populated by checkPrereqs() -->
+                        <div class="text-muted small fst-italic">Click "Re-check" or expand to run live check.</div>
+                    </div>
+                    <div id="fixPrereqStatus" class="mt-2 small d-none"></div>
+                    <hr class="my-3">
+                    <p class="small mb-2 fw-semibold">Manual setup reference:</p>
+                    <div class="small text-muted mb-1">sudoers (<code>/etc/sudoers.d/cyberx</code>):</div>
+                    <pre class="bg-dark text-light rounded p-2 mb-2 small">{{ redirector.ssh_username }} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/bash /tmp/.cyberx_nginx_fix.sh, /bin/bash /tmp/.cyberx_prereq_fix.sh</pre>
+                    <div class="small text-muted mb-1">nginx.conf stream block:</div>
+                    <pre class="bg-dark text-light rounded p-2 mb-0 small">stream {
+    include {{ redirector.nginx_stream_dir }}/*.conf;
+}</pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- nginx Setup Warning Banner (shown when setup issues detected) -->
+    <div id="nginxSetupBanner" class="alert alert-warning d-none mb-4" role="alert">
+        <div class="d-flex align-items-start gap-3">
+            <i data-feather="alert-triangle" style="flex-shrink:0;margin-top:2px;width:20px;height:20px;"></i>
+            <div class="flex-grow-1">
+                <strong>nginx Configuration Issues Detected</strong>
+                <ul id="nginxSetupIssues" class="mb-2 mt-1 ps-3 small"></ul>
+                <div class="d-flex align-items-center gap-2 flex-wrap">
+                    <button class="btn btn-sm btn-warning" id="fixNginxBtn" onclick="fixNginxSetup()">
+                        <i data-feather="tool" class="me-1"></i>Fix nginx.conf
+                    </button>
+                    <span id="fixNginxStatus" class="small d-none"></span>
+                </div>
+                <p class="mb-0 mt-2 small text-muted">
+                    The fix will: remove <code>sites-enabled/default</code>, add a stream block to
+                    <code>nginx.conf</code>, and reload nginx. Requires this sudoers entry:
+                    <code>{{ redirector.ssh_username }} ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix.sh</code>
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Stream Configs Table -->
+    <div class="card shadow-sm">
+        <div class="card-header d-flex align-items-center justify-content-between py-3">
+            <h5 class="mb-0 fw-semibold"><i data-feather="git-branch" class="me-2"></i>Stream Configs</h5>
+            <button class="btn btn-sm btn-danger" onclick="openAddStreamModal()">
+                <i data-feather="plus" class="me-1"></i>Add Stream
+            </button>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0" id="streamsTable">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>Protocol</th>
+                            <th>Listen</th>
+                            <th>Redirect To</th>
+                            <th class="text-center">SSL</th>
+                            <th class="text-center">ACL</th>
+                            <th class="text-center">Enabled</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="streamsBody">
+                        <tr>
+                            <td colspan="8" class="text-center text-muted py-4">
+                                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                                Loading streams...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Edit Redirector Modal
+     ================================================================ -->
+<div class="modal fade" id="editRedirectorModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title"><i data-feather="edit-2" class="me-2"></i>Edit Redirector</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">Name</label>
+                        <input type="text" class="form-control" id="er_name" value="{{ redirector.name }}">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">IP Address</label>
+                        <input type="text" class="form-control" id="er_ip" value="{{ redirector.current_ip }}">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold">SSH Port</label>
+                        <input type="number" class="form-control" id="er_port" value="{{ redirector.ssh_port }}" min="1" max="65535">
+                    </div>
+                    <div class="col-md-8">
+                        <label class="form-label fw-semibold">SSH Username</label>
+                        <input type="text" class="form-control" id="er_user" value="{{ redirector.ssh_username }}">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">SSH Private Key (PEM)</label>
+                        <textarea class="form-control font-monospace" id="er_key" rows="5"
+                            placeholder="Leave blank to keep existing key"></textarea>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">Key Passphrase</label>
+                        <input type="password" class="form-control" id="er_pass"
+                            placeholder="Leave blank to keep existing passphrase">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">nginx Stream Directory</label>
+                        <input type="text" class="form-control" id="er_dir" value="{{ redirector.nginx_stream_dir }}">
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label fw-semibold">Notes</label>
+                        <textarea class="form-control" id="er_notes" rows="2">{{ redirector.notes or '' }}</textarea>
+                    </div>
+                </div>
+                <div id="editRedirectorError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitEditRedirector()">
+                    <i data-feather="save" class="me-1"></i>Save Changes
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Add / Edit Stream Modal
+     ================================================================ -->
+<div class="modal fade" id="streamModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="streamModalTitle">
+                    <i data-feather="plus-circle" class="me-2"></i>Add Stream Config
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="sm_stream_id">
+                <div class="row g-3">
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">Name <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="sm_name" placeholder="HTTPS Beacon">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-semibold">Protocol</label>
+                        <select class="form-select" id="sm_protocol" onchange="updateProtocolHelp()">
+                            <option value="tcp">TCP</option>
+                            <option value="udp">UDP</option>
+                            <option value="dns">DNS (UDP/53)</option>
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-semibold">Listen Port <span class="text-danger">*</span></label>
+                        <div class="input-group">
+                            <input type="number" class="form-control" id="sm_listen_port" min="1" max="65535" placeholder="443"
+                                oninput="clearPortCheck()">
+                            <button class="btn btn-outline-secondary" type="button" onclick="checkPort()" title="Check if port is in use on redirector">
+                                <i data-feather="activity"></i>
+                            </button>
+                        </div>
+                        <div id="portCheckResult" class="form-text mt-1 d-none"></div>
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label fw-semibold">Redirect to IP <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="sm_cs_ip" placeholder="10.10.0.1">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label fw-semibold">Redirect to Port <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control" id="sm_cs_port" min="1" max="65535" placeholder="443">
+                    </div>
+                    <div class="col-md-3 d-flex align-items-end">
+                        <div class="form-check mb-1">
+                            <input class="form-check-input" type="checkbox" id="sm_enabled" checked>
+                            <label class="form-check-label fw-semibold" for="sm_enabled">Enabled</label>
+                        </div>
+                    </div>
+
+                    <!-- Access Control -->
+                    <div class="col-12">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="sm_acl_enabled"
+                                onchange="toggleCollapse('aclSection', this.checked)">
+                            <label class="form-check-label fw-semibold" for="sm_acl_enabled">
+                                <i data-feather="shield" class="me-1"></i>Enable Access Control
+                            </label>
+                        </div>
+                        <div id="aclSection" class="mt-2 ps-4 d-none">
+                            <label class="form-label small">Allowed CIDRs (comma-separated)</label>
+                            <input type="text" class="form-control" id="sm_cidrs"
+                                placeholder="1.2.3.4, 10.0.0.0/8, 203.0.113.0/24">
+                            <div class="form-text">Generates <code>allow &lt;cidr&gt;;</code> + <code>deny all;</code></div>
+                        </div>
+                    </div>
+
+                    <!-- SSL/TLS (TCP only) -->
+                    <div class="col-12" id="sslToggleRow">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="sm_ssl_enabled"
+                                onchange="toggleCollapse('sslSection', this.checked)">
+                            <label class="form-check-label fw-semibold" for="sm_ssl_enabled">
+                                <i data-feather="lock" class="me-1"></i>Enable SSL/TLS Termination
+                            </label>
+                        </div>
+                        <div id="sslSection" class="mt-2 ps-4 d-none">
+                            <div class="row g-2">
+                                <div class="col-12">
+                                    <label class="form-label small">Certificate Path (on redirector)</label>
+                                    <input type="text" class="form-control" id="sm_ssl_cert"
+                                        placeholder="/etc/ssl/certs/redir.pem">
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label small">Key Path (on redirector)</label>
+                                    <input type="text" class="form-control" id="sm_ssl_key"
+                                        placeholder="/etc/ssl/private/redir.key">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label small">SSL Protocols</label>
+                                    <input type="text" class="form-control" id="sm_ssl_protocols" value="TLSv1.2 TLSv1.3">
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="form-label small">SSL Ciphers</label>
+                                    <input type="text" class="form-control" id="sm_ssl_ciphers" value="HIGH:!aNULL:!MD5">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="streamModalError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitStream()">
+                    <i data-feather="save" class="me-1"></i>Save Stream
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Preview Modal
+     ================================================================ -->
+<div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i data-feather="eye" class="me-2"></i>Config Preview
+                    <span id="previewFilename" class="text-muted small ms-2 font-monospace"></span>
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <textarea class="form-control font-monospace bg-dark text-light border-0"
+                    id="previewContent" rows="20" readonly></textarea>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Deploy Result Modal
+     ================================================================ -->
+<div class="modal fade" id="deployResultModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deployResultTitle">Deploy Result</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div id="deployResultStatus" class="mb-3"></div>
+                <div id="deployResultFiles" class="mb-3 small"></div>
+                <div id="deployResultOutput"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Delete Stream Confirmation -->
+<div class="modal fade" id="deleteStreamModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <h5 class="modal-title text-danger"><i data-feather="trash-2" class="me-2"></i>Delete Stream</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Delete stream <strong id="deleteStreamName"></strong>?</p>
+                <p class="text-muted small">This removes it from the database only. Use <em>Remove</em> first to clean up the remote file.</p>
+            </div>
+            <div class="modal-footer border-0">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="confirmDeleteStream()">Delete</button>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- Port Conflict Info Modal -->
+<div class="modal fade" id="portConflictModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content border-danger">
+            <div class="modal-header border-0 pb-0">
+                <h6 class="modal-title text-danger">
+                    <i data-feather="alert-circle" class="me-2"></i>Port Status
+                </h6>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body pt-2">
+                <p id="portConflictMessage" class="mb-0 small"></p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// ============================================================
+// Constants
+// ============================================================
+const REDIRECTOR_ID = '{{ redirector.id }}';
+let _streams          = [];
+let _portConflicts    = {};   // stream_id → conflict message
+let _deleteStreamId   = null;
+let _deleteStreamName = null;
+
+// Bootstrap modals
+const editRedirModal    = new bootstrap.Modal(document.getElementById('editRedirectorModal'));
+const streamModal       = new bootstrap.Modal(document.getElementById('streamModal'));
+const previewModal      = new bootstrap.Modal(document.getElementById('previewModal'));
+const deployResultModal = new bootstrap.Modal(document.getElementById('deployResultModal'));
+const delStreamModal    = new bootstrap.Modal(document.getElementById('deleteStreamModal'));
+const portConflictModal = new bootstrap.Modal(document.getElementById('portConflictModal'));
+
+function refreshUI() {
+    feather.replace();
+    document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => {
+        bootstrap.Popover.getOrCreateInstance(el);
+    });
+}
+
+// Re-render feather icons after each modal shows
+document.querySelectorAll('.modal').forEach(el => {
+    el.addEventListener('shown.bs.modal', () => feather.replace());
+});
+
+// Format datetime spans
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.js-dt').forEach(el => {
+        el.textContent = formatDateTime(el.textContent);
+    });
+    loadStreams().then(startPolling);
+    checkNginxSetup();
+    checkPrereqs();
+});
+
+// ============================================================
+// Stream table
+// ============================================================
+async function loadStreams() {
+    const resp = await fetch(`/api/redirectors/${REDIRECTOR_ID}/streams`);
+    if (!resp.ok) { renderStreams([]); return; }
+    const streams = await resp.json();
+    renderStreams(streams);
+    // Run port checks in the background — updates row shading when done
+    if (streams.length) runPortChecks(streams);
+}
+
+function renderStreams(streams) {
+    _streams = streams;
+    const tbody = document.getElementById('streamsBody');
+    if (!streams.length) {
+        tbody.innerHTML = `<tr><td colspan="8" class="text-center text-muted py-5">
+            No stream configs yet. Click <strong>Add Stream</strong> to create one.
+        </td></tr>`;
+        refreshUI();
+        return;
+    }
+    tbody.innerHTML = streams.map(s => {
+        const conflict = _portConflicts[s.id];
+        const rowClass = conflict ? ' class="stream-conflict"' : '';
+        const conflictIcon = conflict
+            ? ` <i data-feather="alert-circle" class="text-danger ms-2"
+                  style="width:20px;height:20px;vertical-align:middle;flex-shrink:0;cursor:help;"
+                  data-bs-toggle="popover" data-bs-trigger="hover focus"
+                  data-bs-placement="right" data-bs-content="${escHtml(conflict)}"></i>`
+            : '';
+        return `
+        <tr${rowClass}>
+            <td class="fw-semibold">
+                <div class="d-flex align-items-center">${escHtml(s.name)}${conflictIcon}</div>
+            </td>
+            <td>${protoBadge(s.protocol)}</td>
+            <td><code>${s.listen_port}</code></td>
+            <td class="small text-muted"><code>${escHtml(s.cs_ip)}:${s.cs_port}</code></td>
+            <td class="text-center">${s.ssl_enabled ? '<i data-feather="lock" class="text-success" title="SSL enabled"></i>' : '<span class="text-muted">—</span>'}</td>
+            <td class="text-center">${s.access_control_enabled ? '<i data-feather="shield" class="text-warning" title="ACL enabled"></i>' : '<span class="text-muted">—</span>'}</td>
+            <td class="text-center">
+                <span class="badge ${s.enabled ? 'bg-success' : 'bg-danger'}">${s.enabled ? 'Yes' : 'No'}</span>
+            </td>
+            <td class="text-end">
+                <button class="btn btn-sm btn-outline-secondary me-1" title="Preview config"
+                    onclick="previewStream('${s.id}')"><i data-feather="eye"></i></button>
+                <button class="btn btn-sm btn-outline-primary me-1" title="Deploy this stream"
+                    onclick="deployStream('${s.id}', '${escHtml(s.name)}')"><i data-feather="upload"></i></button>
+                ${s.enabled
+                    ? `<button class="btn btn-sm btn-outline-warning me-1" title="Disable stream" onclick="removeStream('${s.id}', '${escHtml(s.name)}')"><i data-feather="x-circle"></i></button>`
+                    : `<button class="btn btn-sm btn-outline-success me-1" title="Enable stream" onclick="enableStream('${s.id}', '${escHtml(s.name)}')"><i data-feather="play-circle"></i></button>`
+                }
+                <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
+                    onclick="openEditStreamModal('${s.id}')"><i data-feather="edit-2"></i></button>
+                <button class="btn btn-sm btn-outline-danger" title="Delete from DB"
+                    onclick="openDeleteStreamModal('${s.id}', '${escHtml(s.name)}')"><i data-feather="trash-2"></i></button>
+            </td>
+        </tr>
+    `; }).join('');
+    refreshUI();
+}
+
+function protoBadge(proto) {
+    const map = { tcp: 'bg-primary', udp: 'bg-info text-dark', dns: 'bg-warning text-dark' };
+    return `<span class="badge ${map[proto] || 'bg-secondary'}">${proto.toUpperCase()}</span>`;
+}
+
+// ============================================================
+// Test Connection
+// ============================================================
+async function testConnection() {
+    showToast('Testing SSH connection...', 'info');
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/test-connection`, { method: 'POST' });
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Connection failed: ${data.detail}`, 'danger');
+            updateStatusBadge('offline');
+            return;
+        }
+        updateStatusBadge(data.status);
+        const rtt = data.rtt_ms ? ` (${data.rtt_ms}ms)` : '';
+        const streamWarn = data.stream_module_present ? '' : ' ⚠️ Stream module not found!';
+        showToast(`${data.message}${rtt}${streamWarn}`, data.success ? 'success' : 'warning');
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+// ============================================================
+// Deploy All
+// ============================================================
+async function deployAll() {
+    showToast('Deploying all streams...', 'info');
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/deploy-all`, { method: 'POST' });
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult('Deploy All', data);
+        if (data.success) loadStreams();
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+// ============================================================
+// Stream operations
+// ============================================================
+async function previewStream(streamId) {
+    try {
+        const resp = await fetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/preview`);
+        const data = await resp.json();
+        document.getElementById('previewFilename').textContent = data.filename;
+        document.getElementById('previewContent').value = data.content;
+        previewModal.show();
+    } catch (err) {
+        showToast(`Preview failed: ${err.message}`, 'danger');
+    }
+}
+
+async function deployStream(streamId, streamName) {
+    if (!confirm(`Deploy stream "${streamName}" to the redirector?`)) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/deploy`,
+            { method: 'POST' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Deploy failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult(`Deploy: ${streamName}`, data);
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+async function removeStream(streamId, streamName) {
+    if (!confirm(`Disable stream "${streamName}"?\n\nThis removes the config file from the redirector and marks the stream as disabled. The config is kept in the database and can be re-deployed.`)) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/remove`,
+            { method: 'POST' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Disable failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult(`Disable: ${streamName}`, data);
+        await loadStreams();
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+async function enableStream(streamId, streamName) {
+    if (!confirm(`Enable stream "${streamName}"?\n\nThis will deploy the config file to the redirector and mark the stream as enabled.`)) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/enable`,
+            { method: 'POST' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Enable failed: ${data.detail}`, 'danger');
+            return;
+        }
+        showDeployResult(`Enable: ${streamName}`, data);
+        await loadStreams();
+    } catch (err) {
+        showToast(`Request failed: ${err.message}`, 'danger');
+    }
+}
+
+// ============================================================
+// Add/Edit stream modal
+// ============================================================
+function openAddStreamModal() {
+    document.getElementById('sm_stream_id').value = '';
+    document.getElementById('streamModalTitle').innerHTML = '<i data-feather="plus-circle" class="me-2"></i>Add Stream Config';
+    document.getElementById('sm_name').value = '';
+    document.getElementById('sm_protocol').value = 'tcp';
+    document.getElementById('sm_listen_port').value = '';
+    clearPortCheck();
+    document.getElementById('sm_cs_ip').value = '';
+    document.getElementById('sm_cs_port').value = '';
+    document.getElementById('sm_enabled').checked = true;
+    document.getElementById('sm_acl_enabled').checked = false;
+    document.getElementById('sm_cidrs').value = '';
+    document.getElementById('sm_ssl_enabled').checked = false;
+    document.getElementById('sm_ssl_cert').value = '';
+    document.getElementById('sm_ssl_key').value = '';
+    document.getElementById('sm_ssl_protocols').value = 'TLSv1.2 TLSv1.3';
+    document.getElementById('sm_ssl_ciphers').value = 'HIGH:!aNULL:!MD5';
+    document.getElementById('aclSection').classList.add('d-none');
+    document.getElementById('sslSection').classList.add('d-none');
+    document.getElementById('streamModalError').classList.add('d-none');
+    updateProtocolHelp();
+    streamModal.show();
+}
+
+function openEditStreamModal(id) {
+    const s = _streams.find(x => x.id === id);
+    if (!s) return;
+    document.getElementById('sm_stream_id').value = s.id;
+    document.getElementById('streamModalTitle').innerHTML = '<i data-feather="edit-2" class="me-2"></i>Edit Stream Config';
+    document.getElementById('sm_name').value = s.name;
+    document.getElementById('sm_protocol').value = s.protocol;
+    document.getElementById('sm_listen_port').value = s.listen_port;
+    document.getElementById('sm_cs_ip').value = s.cs_ip;
+    document.getElementById('sm_cs_port').value = s.cs_port;
+    document.getElementById('sm_enabled').checked = s.enabled;
+    document.getElementById('sm_acl_enabled').checked = s.access_control_enabled;
+    document.getElementById('sm_cidrs').value = (s.allowed_cidrs || []).join(', ');
+    document.getElementById('sm_ssl_enabled').checked = s.ssl_enabled;
+    document.getElementById('sm_ssl_cert').value = s.ssl_cert_path || '';
+    document.getElementById('sm_ssl_key').value = s.ssl_key_path || '';
+    document.getElementById('sm_ssl_protocols').value = s.ssl_protocols;
+    document.getElementById('sm_ssl_ciphers').value = s.ssl_ciphers;
+    toggleCollapse('aclSection', s.access_control_enabled);
+    toggleCollapse('sslSection', s.ssl_enabled);
+    document.getElementById('streamModalError').classList.add('d-none');
+    updateProtocolHelp();
+    streamModal.show();
+}
+
+async function submitStream() {
+    const errEl = document.getElementById('streamModalError');
+    errEl.classList.add('d-none');
+    const streamId = document.getElementById('sm_stream_id').value;
+
+    const cidrsRaw = document.getElementById('sm_cidrs').value.trim();
+    const cidrs = cidrsRaw ? cidrsRaw.split(',').map(c => c.trim()).filter(c => c) : null;
+
+    const payload = {
+        name: document.getElementById('sm_name').value.trim(),
+        protocol: document.getElementById('sm_protocol').value,
+        listen_port: parseInt(document.getElementById('sm_listen_port').value, 10),
+        cs_ip: document.getElementById('sm_cs_ip').value.trim(),
+        cs_port: parseInt(document.getElementById('sm_cs_port').value, 10),
+        enabled: document.getElementById('sm_enabled').checked,
+        access_control_enabled: document.getElementById('sm_acl_enabled').checked,
+        allowed_cidrs: cidrs,
+        ssl_enabled: document.getElementById('sm_ssl_enabled').checked,
+        ssl_cert_path: document.getElementById('sm_ssl_cert').value.trim() || null,
+        ssl_key_path: document.getElementById('sm_ssl_key').value.trim() || null,
+        ssl_protocols: document.getElementById('sm_ssl_protocols').value.trim(),
+        ssl_ciphers: document.getElementById('sm_ssl_ciphers').value.trim(),
+    };
+
+    if (!payload.name || !payload.cs_ip || !payload.listen_port || !payload.cs_port) {
+        errEl.textContent = 'Please fill in all required fields.';
+        errEl.classList.remove('d-none');
+        return;
+    }
+
+    const url = streamId
+        ? `/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}`
+        : `/api/redirectors/${REDIRECTOR_ID}/streams`;
+    const method = streamId ? 'PUT' : 'POST';
+
+    // Detect ACL changes before saving (compare against current state in _streams)
+    const original = _streams.find(s => s.id === streamId);
+    const aclChanged = streamId && original && (
+        payload.access_control_enabled !== original.access_control_enabled ||
+        JSON.stringify((payload.allowed_cidrs || []).slice().sort()) !==
+        JSON.stringify((original.allowed_cidrs || []).slice().sort())
+    );
+
+    try {
+        const resp = await csrfFetch(url, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Failed to save stream config.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        streamModal.hide();
+
+        // Auto-deploy when ACL settings changed and stream is enabled
+        if (aclChanged && data.enabled) {
+            showToast(`Stream <strong>${escHtml(data.name)}</strong> updated — deploying ACL changes…`, 'info');
+            const deployResp = await csrfFetch(
+                `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/deploy`,
+                { method: 'POST' }
+            );
+            const deployData = await deployResp.json();
+            if (deployResp.ok && deployData.success) {
+                showToast(`Stream <strong>${escHtml(data.name)}</strong> ACL deployed successfully.`, 'success');
+            } else {
+                showToast(`ACL saved but deploy failed: ${escHtml(deployData.message || deployData.detail || 'unknown error')}`, 'warning');
+            }
+        } else {
+            showToast(`Stream <strong>${escHtml(data.name)}</strong> ${streamId ? 'updated' : 'created'}.`, 'success');
+        }
+
+        await loadStreams();
+        // Immediately check only the saved stream's port so the operator gets
+        // conflict feedback without waiting for a full re-check of all streams
+        runPortChecks([data]);
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Delete stream
+// ============================================================
+function openDeleteStreamModal(id, name) {
+    _deleteStreamId = id;
+    _deleteStreamName = name;
+    document.getElementById('deleteStreamName').textContent = name;
+    delStreamModal.show();
+}
+
+async function confirmDeleteStream() {
+    if (!_deleteStreamId) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${_deleteStreamId}`,
+            { method: 'DELETE' }
+        );
+        if (!resp.ok && resp.status !== 204) {
+            const d = await resp.json().catch(() => ({}));
+            showToast(d.detail || 'Delete failed.', 'danger');
+            return;
+        }
+        delStreamModal.hide();
+        showToast(`Stream <strong>${escHtml(_deleteStreamName)}</strong> deleted.`, 'success');
+        loadStreams();
+    } catch (err) {
+        showToast(`Delete failed: ${err.message}`, 'danger');
+    }
+    _deleteStreamId = null;
+}
+
+// ============================================================
+// Edit Redirector
+// ============================================================
+function openEditRedirectorModal() { editRedirModal.show(); }
+
+async function submitEditRedirector() {
+    const errEl = document.getElementById('editRedirectorError');
+    errEl.classList.add('d-none');
+    const payload = {};
+    const v = id => document.getElementById(id).value;
+    if (v('er_name').trim())  payload.name = v('er_name').trim();
+    if (v('er_ip').trim())    payload.current_ip = v('er_ip').trim();
+    const port = parseInt(v('er_port'), 10);
+    if (port)                 payload.ssh_port = port;
+    if (v('er_user').trim())  payload.ssh_username = v('er_user').trim();
+    if (v('er_key').trim())   payload.ssh_private_key = v('er_key').trim();
+    if (v('er_pass'))         payload.ssh_key_passphrase = v('er_pass');
+    if (v('er_dir').trim())   payload.nginx_stream_dir = v('er_dir').trim();
+    payload.notes = v('er_notes').trim() || null;
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Update failed.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        editRedirModal.hide();
+        showToast('Redirector updated. Reload page to see changes.', 'success');
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Deploy Result Modal
+// ============================================================
+function showDeployResult(title, data) {
+    document.getElementById('deployResultTitle').textContent = title;
+    const icon = data.success ? '✓' : '✗';
+    const cls  = data.success ? 'text-success' : 'text-danger';
+    document.getElementById('deployResultStatus').innerHTML =
+        `<span class="${cls} fw-bold fs-5">${icon} ${data.success ? 'Success' : 'Failed'}</span>
+         <span class="text-muted small ms-2">${escHtml(data.message)}</span>`;
+
+    let filesHtml = '';
+    if (data.files_written.length)
+        filesHtml += `<div>Written: ${data.files_written.map(f => `<code>${escHtml(f)}</code>`).join(', ')}</div>`;
+    if (data.files_deleted.length)
+        filesHtml += `<div>Removed: ${data.files_deleted.map(f => `<code>${escHtml(f)}</code>`).join(', ')}</div>`;
+    document.getElementById('deployResultFiles').innerHTML = filesHtml;
+
+    const nginxOut = data.nginx_test_output || data.nginx_reload_output;
+    document.getElementById('deployResultOutput').innerHTML = nginxOut
+        ? `<label class="form-label small fw-semibold">nginx output:</label>
+           <pre class="bg-dark text-light rounded p-3 small">${escHtml(nginxOut)}</pre>`
+        : '';
+
+    deployResultModal.show();
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+function updateStatusBadge(status) {
+    const badge = document.getElementById('statusBadge');
+    badge.textContent = status;
+    badge.className = 'badge fs-6 ' + (status === 'online' ? 'bg-success' : status === 'offline' ? 'bg-danger' : 'bg-secondary');
+}
+
+function toggleCollapse(sectionId, show) {
+    document.getElementById(sectionId).classList.toggle('d-none', !show);
+}
+
+function updateProtocolHelp() {
+    const proto = document.getElementById('sm_protocol').value;
+    // Hide SSL for UDP/DNS streams
+    const sslRow = document.getElementById('sslToggleRow');
+    if (proto === 'udp' || proto === 'dns') {
+        sslRow.classList.add('d-none');
+        document.getElementById('sm_ssl_enabled').checked = false;
+        document.getElementById('sslSection').classList.add('d-none');
+    } else {
+        sslRow.classList.remove('d-none');
+    }
+    // Auto-fill port for DNS
+    if (proto === 'dns' && !document.getElementById('sm_listen_port').value) {
+        document.getElementById('sm_listen_port').value = '53';
+    }
+}
+
+// ============================================================
+// Port conflict check (modal button)
+// ============================================================
+function clearPortCheck() {
+    const el = document.getElementById('portCheckResult');
+    el.classList.add('d-none');
+    el.textContent = '';
+}
+
+async function checkPort() {
+    const portVal = parseInt(document.getElementById('sm_listen_port').value, 10);
+    const protocol = document.getElementById('sm_protocol').value;
+    const el = document.getElementById('portCheckResult');
+
+    if (!portVal || portVal < 1 || portVal > 65535) {
+        el.textContent = 'Enter a valid port number first.';
+        el.className = 'form-text mt-1 text-warning';
+        el.classList.remove('d-none');
+        return;
+    }
+
+    el.textContent = 'Checking…';
+    el.className = 'form-text mt-1 text-muted';
+    el.classList.remove('d-none');
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/check-port`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ port: portVal, protocol }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            el.textContent = `Check failed: ${data.detail || resp.status}`;
+            el.className = 'form-text mt-1 text-danger';
+        } else if (data.in_use) {
+            el.textContent = `⚠ ${data.message}`;
+            el.className = 'form-text mt-1 text-warning fw-semibold';
+        } else {
+            el.textContent = `✓ ${data.message}`;
+            el.className = 'form-text mt-1 text-success';
+        }
+    } catch (err) {
+        el.textContent = `Check failed: ${err.message}`;
+        el.className = 'form-text mt-1 text-danger';
+    }
+    refreshUI();
+}
+
+// ============================================================
+// Background port checks + polling
+// ============================================================
+async function runPortChecks(streams) {
+    await Promise.allSettled(streams.map(async s => {
+        try {
+            const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/check-port`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ port: s.listen_port, protocol: s.protocol }),
+            });
+            if (!resp.ok) return;
+            const data = await resp.json();
+            if (data.status === 'conflict') {
+                _portConflicts[s.id] = data.message;
+            } else {
+                delete _portConflicts[s.id];
+            }
+        } catch (_) { /* SSH unreachable — skip silently */ }
+    }));
+    renderStreams(_streams);
+}
+
+let _pollTimer = null;
+let _pollTick  = 0;
+
+function startPolling() {
+    if (_pollTimer) clearInterval(_pollTimer);
+    _pollTick = 0;
+    _pollTimer = setInterval(() => {
+        _pollTick++;
+        if (!_streams.length) return;
+        // Every 5 s: re-check only streams that have a known conflict
+        const conflicted = _streams.filter(s => _portConflicts[s.id]);
+        if (conflicted.length) runPortChecks(conflicted);
+        // Every 60 s (12th tick): full sweep of all streams
+        if (_pollTick % 12 === 0) runPortChecks(_streams);
+    }, 5000);
+}
+
+function stopPolling() {
+    if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
+}
+
+window.addEventListener('beforeunload', stopPolling);
+
+// ============================================================
+// Prerequisites check + fix
+// ============================================================
+async function checkPrereqs() {
+    const resultsEl = document.getElementById('prereqResults');
+    const badge = document.getElementById('prereqBadge');
+    const fixBtn = document.getElementById('fixPrereqsBtn');
+    resultsEl.innerHTML = '<div class="text-muted small"><span class="spinner-border spinner-border-sm me-2"></span>Checking prerequisites…</div>';
+    badge.className = 'badge bg-secondary ms-2';
+    badge.textContent = '…';
+    badge.classList.remove('d-none');
+    fixBtn.classList.add('d-none');
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/check-prereqs`, { method: 'POST' });
+        if (!resp.ok) {
+            let detail = `HTTP ${resp.status}`;
+            try { const d = await resp.json(); detail = d.detail || detail; } catch (_) {}
+            resultsEl.innerHTML = `<div class="text-danger small"><strong>Check failed:</strong> ${escHtml(detail)}</div>`;
+            badge.className = 'badge bg-danger ms-2';
+            badge.textContent = '!';
+            return;
+        }
+        const data = await resp.json();
+
+        if (data.all_ok) {
+            resultsEl.innerHTML =
+                '<div class="d-flex align-items-center gap-2 text-success small fw-semibold">' +
+                '<span style="font-size:1.1rem;line-height:1;">&#10003;</span>' +
+                'All prerequisites met — this redirector is ready.' +
+                '</div>';
+            badge.className = 'badge bg-success ms-2';
+            badge.textContent = '✓';
+            return;
+        }
+
+        const rows = data.checks.map(c =>
+            '<div class="d-flex align-items-start gap-2 mb-2">' +
+            `<span class="${c.ok ? 'text-success' : 'text-danger'} flex-shrink-0 fw-bold" style="font-size:1rem;line-height:1.4;">${c.ok ? '&#10003;' : '&#10007;'}</span>` +
+            '<div>' +
+            `<span class="small fw-semibold">${escHtml(c.label)}</span>` +
+            `<div class="small text-muted">${escHtml(c.detail)}</div>` +
+            '</div></div>'
+        ).join('');
+        resultsEl.innerHTML = rows;
+
+        const failCount = data.checks.filter(c => !c.ok).length;
+        badge.className = 'badge bg-danger ms-2';
+        badge.textContent = failCount;
+        fixBtn.classList.remove('d-none');
+    } catch (err) {
+        resultsEl.innerHTML = `<div class="text-danger small"><strong>Error:</strong> ${escHtml(err.message)}</div>`;
+        badge.className = 'badge bg-danger ms-2';
+        badge.textContent = '!';
+    }
+}
+
+async function fixPrereqs() {
+    const btn = document.getElementById('fixPrereqsBtn');
+    const statusEl = document.getElementById('fixPrereqStatus');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Fixing…';
+    statusEl.classList.add('d-none');
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/fix-prereqs`, { method: 'POST' });
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            showToast('Prerequisites installed successfully.', 'success');
+            await checkPrereqs();
+        } else {
+            statusEl.textContent = data.message || 'Fix failed — ensure the SSH user has sudo access.';
+            statusEl.className = 'mt-2 small text-danger';
+            statusEl.classList.remove('d-none');
+        }
+    } catch (err) {
+        statusEl.textContent = `Failed: ${err.message}`;
+        statusEl.className = 'mt-2 small text-danger';
+        statusEl.classList.remove('d-none');
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i data-feather="tool" class="me-1"></i>Auto-fix';
+        refreshUI();
+    }
+}
+
+// ============================================================
+// nginx setup check + fix
+// ============================================================
+async function checkNginxSetup() {
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/check-nginx-setup`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        const banner = document.getElementById('nginxSetupBanner');
+        if (data.nginx_conf_ok) {
+            banner.classList.add('d-none');
+        } else {
+            document.getElementById('nginxSetupIssues').innerHTML =
+                data.issues.map(i => `<li>${escHtml(i)}</li>`).join('');
+            banner.classList.remove('d-none');
+            refreshUI();
+        }
+    } catch (_) { /* SSH unreachable — skip silently */ }
+}
+
+async function fixNginxSetup() {
+    const btn = document.getElementById('fixNginxBtn');
+    const status = document.getElementById('fixNginxStatus');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Fixing…';
+    status.classList.add('d-none');
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/fix-nginx-setup`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const data = await resp.json();
+        if (resp.ok && data.success) {
+            showToast('nginx configuration fixed successfully.', 'success');
+            await checkNginxSetup();
+        } else {
+            status.textContent = data.message || 'Fix failed — check sudoers permissions.';
+            status.className = 'small text-danger';
+            status.classList.remove('d-none');
+        }
+    } catch (err) {
+        status.textContent = `Failed: ${err.message}`;
+        status.className = 'small text-danger';
+        status.classList.remove('d-none');
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i data-feather="tool" class="me-1"></i>Fix nginx.conf';
+        refreshUI();
+    }
+}
+
+function escHtml(str) {
+    if (!str) return '';
+    return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+                      .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+}
+</script>
+{% endblock %}

--- a/redirector_app/web/templates/pages/redirectors/list.html
+++ b/redirector_app/web/templates/pages/redirectors/list.html
@@ -1,0 +1,450 @@
+{% extends "layouts/dashboard.html" %}
+
+{% block title %}Redirectors{% endblock %}
+
+{% block content %}
+<div class="container-fluid px-4 py-4">
+
+    <!-- Page Header -->
+    <div class="d-flex align-items-center justify-content-between mb-4">
+        <div>
+            <h1 class="h3 mb-0 fw-bold">
+                <i data-feather="server" class="me-2" style="color:#d32f2f;"></i>Redirectors
+            </h1>
+            <p class="text-muted small mb-0 mt-1">
+                Manage nginx stream proxy configurations on remote redirector servers via SSH.
+            </p>
+        </div>
+        <button class="btn btn-danger" onclick="openAddModal()">
+            <i data-feather="plus" class="me-1"></i> Add Redirector
+        </button>
+    </div>
+
+    <!-- Redirectors Table -->
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0" id="redirectorsTable">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>IP Address</th>
+                            <th>SSH User:Port</th>
+                            <th>Status</th>
+                            <th>Streams</th>
+                            <th>Last Deployed</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="redirectorsBody">
+                        <tr id="loadingRow">
+                            <td colspan="7" class="text-center text-muted py-4">
+                                <div class="spinner-border spinner-border-sm me-2" role="status"></div>
+                                Loading redirectors...
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Add Redirector Modal
+     ================================================================ -->
+<div class="modal fade" id="addRedirectorModal" tabindex="-1" aria-labelledby="addRedirectorModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addRedirectorModalLabel">
+                    <i data-feather="plus-circle" class="me-2"></i>Add Redirector
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addRedirectorForm">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">Name <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="add_name" placeholder="e.g. prod-redirector-01" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="add_ip" placeholder="203.0.113.10" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label fw-semibold">SSH Port</label>
+                            <input type="number" class="form-control" id="add_ssh_port" value="22" min="1" max="65535">
+                        </div>
+                        <div class="col-md-8">
+                            <label class="form-label fw-semibold">SSH Username <span class="text-danger">*</span></label>
+                            <input type="text" class="form-control" id="add_ssh_username" placeholder="debian" required>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">
+                                SSH Private Key (PEM) <span class="text-danger">*</span>
+                            </label>
+                            <textarea class="form-control font-monospace" id="add_ssh_key" rows="6"
+                                placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;...&#10;-----END OPENSSH PRIVATE KEY-----" required></textarea>
+                            <div class="form-text">Paste the full PEM private key. Stored encrypted at rest.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Key Passphrase <span class="text-muted small">(optional)</span></label>
+                            <input type="password" class="form-control" id="add_passphrase" placeholder="Leave blank if key has no passphrase">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">nginx Stream Directory</label>
+                            <input type="text" class="form-control" id="add_stream_dir" value="/etc/nginx/stream.d">
+                            <div class="form-text">Directory where <code>cyberx_*.conf</code> files are written. Must be included in nginx.conf.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Notes <span class="text-muted small">(optional)</span></label>
+                            <textarea class="form-control" id="add_notes" rows="2" placeholder="Optional notes about this redirector"></textarea>
+                        </div>
+                    </div>
+                </form>
+                <div id="addRedirectorError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitAddRedirector()">
+                    <i data-feather="save" class="me-1"></i>Save Redirector
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Edit Redirector Modal
+     ================================================================ -->
+<div class="modal fade" id="editRedirectorModal" tabindex="-1" aria-labelledby="editRedirectorModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="editRedirectorModalLabel">
+                    <i data-feather="edit-2" class="me-2"></i>Edit Redirector
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="edit_redirector_id">
+                <form id="editRedirectorForm">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">Name</label>
+                            <input type="text" class="form-control" id="edit_name" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label fw-semibold">IP Address</label>
+                            <input type="text" class="form-control" id="edit_ip" required>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label fw-semibold">SSH Port</label>
+                            <input type="number" class="form-control" id="edit_ssh_port" min="1" max="65535">
+                        </div>
+                        <div class="col-md-8">
+                            <label class="form-label fw-semibold">SSH Username</label>
+                            <input type="text" class="form-control" id="edit_ssh_username">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">SSH Private Key (PEM)</label>
+                            <textarea class="form-control font-monospace" id="edit_ssh_key" rows="6"
+                                placeholder="Leave blank to keep existing key"></textarea>
+                            <div class="form-text">Leave blank to keep the current key. Paste new PEM to replace it.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Key Passphrase</label>
+                            <input type="password" class="form-control" id="edit_passphrase"
+                                placeholder="Leave blank to keep existing passphrase">
+                            <div class="form-text">Leave blank to keep existing. Send a space to clear the passphrase.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">nginx Stream Directory</label>
+                            <input type="text" class="form-control" id="edit_stream_dir">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label fw-semibold">Notes</label>
+                            <textarea class="form-control" id="edit_notes" rows="2"></textarea>
+                        </div>
+                    </div>
+                </form>
+                <div id="editRedirectorError" class="alert alert-danger mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="submitEditRedirector()">
+                    <i data-feather="save" class="me-1"></i>Save Changes
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ================================================================
+     Delete Confirmation Modal
+     ================================================================ -->
+<div class="modal fade" id="deleteRedirectorModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header border-0">
+                <h5 class="modal-title text-danger">
+                    <i data-feather="trash-2" class="me-2"></i>Delete Redirector
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to delete <strong id="deleteRedirectorName"></strong>?</p>
+                <p class="text-muted small mb-0">
+                    This removes the redirector and all stream configs from the database.
+                    Remote nginx config files are <strong>not</strong> automatically removed.
+                    Run "Remove" on each stream before deleting if needed.
+                </p>
+            </div>
+            <div class="modal-footer border-0">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" onclick="confirmDeleteRedirector()">
+                    <i data-feather="trash-2" class="me-1"></i>Delete
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+// ============================================================
+// State
+// ============================================================
+let _redirectors = [];
+let _deleteTargetId = null;
+
+const addModal  = new bootstrap.Modal(document.getElementById('addRedirectorModal'));
+const editModal = new bootstrap.Modal(document.getElementById('editRedirectorModal'));
+const delModal  = new bootstrap.Modal(document.getElementById('deleteRedirectorModal'));
+
+// ============================================================
+// Bootstrap: re-render feather icons after modal shows
+// ============================================================
+document.querySelectorAll('.modal').forEach(el => {
+    el.addEventListener('shown.bs.modal', () => feather.replace());
+});
+
+// ============================================================
+// Load redirectors on page load
+// ============================================================
+document.addEventListener('DOMContentLoaded', loadRedirectors);
+
+async function loadRedirectors() {
+    try {
+        const resp = await fetch('/api/redirectors/');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        _redirectors = data.redirectors || [];
+        renderTable(_redirectors);
+    } catch (err) {
+        document.getElementById('redirectorsBody').innerHTML =
+            `<tr><td colspan="7" class="text-center text-danger py-4">Failed to load redirectors: ${err.message}</td></tr>`;
+    }
+}
+
+function renderTable(redirectors) {
+    const tbody = document.getElementById('redirectorsBody');
+    if (!redirectors.length) {
+        tbody.innerHTML = `<tr><td colspan="7" class="text-center text-muted py-5">
+            No redirectors yet. Click <strong>Add Redirector</strong> to get started.
+        </td></tr>`;
+        feather.replace();
+        return;
+    }
+    tbody.innerHTML = redirectors.map(r => `
+        <tr>
+            <td>
+                <a href="/redirectors/${r.id}" class="fw-semibold text-decoration-none">
+                    ${escHtml(r.name)}
+                </a>
+            </td>
+            <td><code>${escHtml(r.current_ip)}</code></td>
+            <td class="text-muted small">${escHtml(r.ssh_username)}@${r.current_ip}:${r.ssh_port}</td>
+            <td>${statusBadge(r.status)}</td>
+            <td><span class="badge bg-secondary rounded-pill">${r.stream_count}</span></td>
+            <td class="text-muted small">${r.last_deployed_at ? formatDateTime(r.last_deployed_at) : '—'}</td>
+            <td class="text-end">
+                <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
+                    onclick="openEditModal('${r.id}')">
+                    <i data-feather="edit-2"></i>
+                </button>
+                <button class="btn btn-sm btn-outline-danger" title="Delete"
+                    onclick="openDeleteModal('${r.id}', '${escHtml(r.name)}')">
+                    <i data-feather="trash-2"></i>
+                </button>
+            </td>
+        </tr>
+    `).join('');
+    feather.replace();
+}
+
+function statusBadge(status) {
+    const map = {
+        online:  'bg-success',
+        offline: 'bg-danger',
+        unknown: 'bg-secondary',
+    };
+    const cls = map[status] || 'bg-secondary';
+    return `<span class="badge ${cls}">${status}</span>`;
+}
+
+// ============================================================
+// Add Modal
+// ============================================================
+function openAddModal() {
+    document.getElementById('addRedirectorForm').reset();
+    document.getElementById('addRedirectorError').classList.add('d-none');
+    addModal.show();
+}
+
+async function submitAddRedirector() {
+    const errEl = document.getElementById('addRedirectorError');
+    errEl.classList.add('d-none');
+
+    const payload = {
+        name:             document.getElementById('add_name').value.trim(),
+        current_ip:       document.getElementById('add_ip').value.trim(),
+        ssh_port:         parseInt(document.getElementById('add_ssh_port').value, 10),
+        ssh_username:     document.getElementById('add_ssh_username').value.trim(),
+        ssh_private_key:  document.getElementById('add_ssh_key').value.trim(),
+        ssh_key_passphrase: document.getElementById('add_passphrase').value || null,
+        nginx_stream_dir: document.getElementById('add_stream_dir').value.trim(),
+        notes:            document.getElementById('add_notes').value.trim() || null,
+    };
+
+    if (!payload.name || !payload.current_ip || !payload.ssh_username || !payload.ssh_private_key) {
+        errEl.textContent = 'Please fill in all required fields.';
+        errEl.classList.remove('d-none');
+        return;
+    }
+
+    try {
+        const resp = await csrfFetch('/api/redirectors/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Failed to create redirector.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        addModal.hide();
+        showToast(`Redirector <strong>${escHtml(data.name)}</strong> created.`, 'success');
+        loadRedirectors();
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Edit Modal
+// ============================================================
+function openEditModal(id) {
+    const r = _redirectors.find(x => x.id === id);
+    if (!r) return;
+    document.getElementById('edit_redirector_id').value = r.id;
+    document.getElementById('edit_name').value         = r.name;
+    document.getElementById('edit_ip').value           = r.current_ip;
+    document.getElementById('edit_ssh_port').value     = r.ssh_port;
+    document.getElementById('edit_ssh_username').value = r.ssh_username;
+    document.getElementById('edit_ssh_key').value      = '';   // always blank
+    document.getElementById('edit_passphrase').value   = '';
+    document.getElementById('edit_stream_dir').value   = r.nginx_stream_dir;
+    document.getElementById('edit_notes').value        = r.notes || '';
+    document.getElementById('editRedirectorError').classList.add('d-none');
+    editModal.show();
+}
+
+async function submitEditRedirector() {
+    const id    = document.getElementById('edit_redirector_id').value;
+    const errEl = document.getElementById('editRedirectorError');
+    errEl.classList.add('d-none');
+
+    const payload = {};
+    const name    = document.getElementById('edit_name').value.trim();
+    const ip      = document.getElementById('edit_ip').value.trim();
+    const port    = parseInt(document.getElementById('edit_ssh_port').value, 10);
+    const user    = document.getElementById('edit_ssh_username').value.trim();
+    const key     = document.getElementById('edit_ssh_key').value.trim();
+    const pass    = document.getElementById('edit_passphrase').value;
+    const dir     = document.getElementById('edit_stream_dir').value.trim();
+    const notes   = document.getElementById('edit_notes').value.trim();
+
+    if (name)  payload.name = name;
+    if (ip)    payload.current_ip = ip;
+    if (port)  payload.ssh_port = port;
+    if (user)  payload.ssh_username = user;
+    if (key)   payload.ssh_private_key = key;
+    if (pass)  payload.ssh_key_passphrase = pass;
+    if (dir)   payload.nginx_stream_dir = dir;
+    payload.notes = notes || null;
+
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+            errEl.textContent = data.detail || 'Failed to update redirector.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        editModal.hide();
+        showToast(`Redirector <strong>${escHtml(data.name)}</strong> updated.`, 'success');
+        loadRedirectors();
+    } catch (err) {
+        errEl.textContent = `Request failed: ${err.message}`;
+        errEl.classList.remove('d-none');
+    }
+}
+
+// ============================================================
+// Delete
+// ============================================================
+function openDeleteModal(id, name) {
+    _deleteTargetId = id;
+    document.getElementById('deleteRedirectorName').textContent = name;
+    delModal.show();
+}
+
+async function confirmDeleteRedirector() {
+    if (!_deleteTargetId) return;
+    try {
+        const resp = await csrfFetch(`/api/redirectors/${_deleteTargetId}`, { method: 'DELETE' });
+        if (!resp.ok && resp.status !== 204) {
+            const data = await resp.json().catch(() => ({}));
+            showToast(data.detail || 'Delete failed.', 'danger');
+            return;
+        }
+        delModal.hide();
+        showToast('Redirector deleted.', 'success');
+        loadRedirectors();
+    } catch (err) {
+        showToast(`Delete failed: ${err.message}`, 'danger');
+    }
+    _deleteTargetId = null;
+}
+
+// ============================================================
+// Utility
+// ============================================================
+function escHtml(str) {
+    if (!str) return '';
+    return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+              .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
Centralized management of nginx stream proxy configs on remote Debian redirectors via SSH. Supports TCP/UDP/DNS stream proxying, SSL/TLS termination, per-CIDR ACL filtering, live port conflict detection, and prerequisite checking with auto-fix.

Uses cyberx-event-mgmt auth (get_current_admin_user), existing PostgreSQL database, and existing field encryption (app.utils.encryption). No standalone auth or separate database required for integrated mode.

New files:
- backend/app/models/redirector.py (Redirector, StreamConfig ORM models)
- backend/app/schemas/redirector.py (Pydantic I/O schemas)
- backend/app/api/routes/redirectors.py (REST API)
- backend/app/api/routes/redirectors_pages.py (web UI pages)
- backend/app/services/redirector_service.py (async CRUD)
- backend/app/services/ssh_service.py (paramiko SSH/SFTP)
- backend/app/services/nginx_config_service.py (nginx config generator)
- backend/migrations/versions/20260323_000000_add_redirector_tables.py
- frontend/templates/pages/redirectors/{list,detail}.html
- redirector_app/ (standalone deployment mode)

Modified:
- backend/app/main.py (register routers, CSRF exemptions)
- backend/app/models/__init__.py (export Redirector, StreamConfig)
- backend/migrations/env.py (import new models for autogenerate)
- backend/requirements.txt (add paramiko>=3.4.0)