### PR TITLE
fix: auto-deploy/undeploy when toggling Enabled checkbox in Edit Stream modal

### DIFF
--- a/frontend/templates/pages/participant/redirector_detail.html
+++ b/frontend/templates/pages/participant/redirector_detail.html
@@ -862,13 +862,16 @@ async function submitStream() {
         : `/api/redirectors/${REDIRECTOR_ID}/streams`;
     const method = streamId ? 'PUT' : 'POST';
 
-    // Detect ACL changes before saving (compare against current state in _streams)
+    // Detect changes before saving (compare against current state in _streams)
     const original = _streams.find(s => s.id === streamId);
     const aclChanged = streamId && original && (
         payload.access_control_enabled !== original.access_control_enabled ||
         JSON.stringify((payload.allowed_cidrs || []).slice().sort()) !==
         JSON.stringify((original.allowed_cidrs || []).slice().sort())
     );
+    const wasEnabled = original && original.enabled;
+    const nowEnabled = payload.enabled;
+    const enabledChanged = streamId && original && (wasEnabled !== nowEnabled);
 
     try {
         const resp = await csrfFetch(url, {
@@ -884,8 +887,41 @@ async function submitStream() {
         }
         streamModal.hide();
 
-        // Auto-deploy when ACL settings changed and stream is enabled
-        if (aclChanged && data.enabled) {
+        // Auto-deploy/undeploy when enabled state changes
+        if (enabledChanged && nowEnabled) {
+            showToast(`Stream <strong>${escHtml(data.name)}</strong> saved — deploying…`, 'info');
+            try {
+                const deployResp = await csrfFetch(
+                    `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/enable`,
+                    { method: 'POST' }
+                );
+                const deployData = await deployResp.json();
+                if (deployResp.ok) {
+                    showDeployResult(`Enable: ${data.name}`, deployData);
+                } else {
+                    showToast(`Saved but deploy failed: ${escHtml(deployData.detail || 'unknown error')}`, 'warning');
+                }
+            } catch (deployErr) {
+                showToast(`Saved but deploy failed: ${escHtml(deployErr.message)}`, 'warning');
+            }
+        } else if (enabledChanged && !nowEnabled) {
+            showToast(`Stream <strong>${escHtml(data.name)}</strong> saved — removing config…`, 'info');
+            try {
+                const deployResp = await csrfFetch(
+                    `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/remove`,
+                    { method: 'POST' }
+                );
+                const deployData = await deployResp.json();
+                if (deployResp.ok) {
+                    showDeployResult(`Disable: ${data.name}`, deployData);
+                } else {
+                    showToast(`Saved but removal failed: ${escHtml(deployData.detail || 'unknown error')}`, 'warning');
+                }
+            } catch (deployErr) {
+                showToast(`Saved but removal failed: ${escHtml(deployErr.message)}`, 'warning');
+            }
+        } else if (aclChanged && data.enabled) {
+            // Auto-deploy when ACL settings changed and stream is enabled
             showToast(`Stream <strong>${escHtml(data.name)}</strong> updated — deploying ACL changes…`, 'info');
             const deployResp = await csrfFetch(
                 `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/deploy`,

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -785,13 +785,16 @@ async function submitStream() {
         : `/api/redirectors/${REDIRECTOR_ID}/streams`;
     const method = streamId ? 'PUT' : 'POST';
 
-    // Detect ACL changes before saving (compare against current state in _streams)
+    // Detect changes before saving (compare against current state in _streams)
     const original = _streams.find(s => s.id === streamId);
     const aclChanged = streamId && original && (
         payload.access_control_enabled !== original.access_control_enabled ||
         JSON.stringify((payload.allowed_cidrs || []).slice().sort()) !==
         JSON.stringify((original.allowed_cidrs || []).slice().sort())
     );
+    const wasEnabled = original && original.enabled;
+    const nowEnabled = payload.enabled;
+    const enabledChanged = streamId && original && (wasEnabled !== nowEnabled);
 
     try {
         const resp = await csrfFetch(url, {
@@ -807,8 +810,41 @@ async function submitStream() {
         }
         streamModal.hide();
 
-        // Auto-deploy when ACL settings changed and stream is enabled
-        if (aclChanged && data.enabled) {
+        // Auto-deploy/undeploy when enabled state changes
+        if (enabledChanged && nowEnabled) {
+            showToast(`Stream <strong>${escHtml(data.name)}</strong> saved — deploying…`, 'info');
+            try {
+                const deployResp = await csrfFetch(
+                    `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/enable`,
+                    { method: 'POST' }
+                );
+                const deployData = await deployResp.json();
+                if (deployResp.ok) {
+                    showDeployResult(`Enable: ${data.name}`, deployData);
+                } else {
+                    showToast(`Saved but deploy failed: ${escHtml(deployData.detail || 'unknown error')}`, 'warning');
+                }
+            } catch (deployErr) {
+                showToast(`Saved but deploy failed: ${escHtml(deployErr.message)}`, 'warning');
+            }
+        } else if (enabledChanged && !nowEnabled) {
+            showToast(`Stream <strong>${escHtml(data.name)}</strong> saved — removing config…`, 'info');
+            try {
+                const deployResp = await csrfFetch(
+                    `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/remove`,
+                    { method: 'POST' }
+                );
+                const deployData = await deployResp.json();
+                if (deployResp.ok) {
+                    showDeployResult(`Disable: ${data.name}`, deployData);
+                } else {
+                    showToast(`Saved but removal failed: ${escHtml(deployData.detail || 'unknown error')}`, 'warning');
+                }
+            } catch (deployErr) {
+                showToast(`Saved but removal failed: ${escHtml(deployErr.message)}`, 'warning');
+            }
+        } else if (aclChanged && data.enabled) {
+            // Auto-deploy when ACL settings changed and stream is enabled
             showToast(`Stream <strong>${escHtml(data.name)}</strong> updated — deploying ACL changes…`, 'info');
             const deployResp = await csrfFetch(
                 `/api/redirectors/${REDIRECTOR_ID}/streams/${data.id}/deploy`,


### PR DESCRIPTION
## Summary
- The "Enabled" checkbox in the Edit Stream Config modal previously only updated the database flag without deploying/undeploying the nginx config on the redirector
- Now toggling enabled ON calls `POST /streams/{id}/enable` to deploy the config and reload nginx
- Now toggling enabled OFF calls `POST /streams/{id}/remove` to undeploy the config and reload nginx
- Existing ACL auto-deploy behavior preserved as a lower-priority check
- Fix applied to both admin (`detail.html`) and participant (`redirector_detail.html`) pages

## Test plan
- [ ] Edit a disabled stream, check "Enabled", click Save -> deploy result modal shown, stream deployed to nginx
- [ ] Edit an enabled stream, uncheck "Enabled", click Save -> deploy result modal shown, config removed from nginx
- [ ] Edit an enabled stream, change ACL only (no enable toggle) -> ACL auto-deploy still works
- [ ] Edit a stream without toggling enabled -> no deploy, just a toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)