### PR TITLE
fix: reject private IPs and FQDNs in BYOD redirector forms

### DIFF
--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -19,6 +19,38 @@ _SAFE_PATH_RE = re.compile(r"^/[a-zA-Z0-9_./-]+$")
 _SAFE_USERNAME_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
 _SAFE_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _SAFE_CIPHER_RE = re.compile(r"^[a-zA-Z0-9_:!+\-@.]+$")
+
+# RFC 1918 / RFC 6598 / link-local / loopback private ranges
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),   # Carrier-grade NAT
+    ipaddress.ip_network("169.254.0.0/16"),   # Link-local
+    ipaddress.ip_network("127.0.0.0/8"),      # Loopback
+    ipaddress.ip_network("::1/128"),           # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),          # IPv6 ULA
+    ipaddress.ip_network("fe80::/10"),         # IPv6 link-local
+]
+
+
+def _validate_public_ip(v: str) -> str:
+    """Validate that a string is a publicly routable IP address (not an FQDN, not private)."""
+    try:
+        addr = ipaddress.ip_address(v)
+    except ValueError:
+        raise ValueError(
+            f"'{v}' is not a valid IP address. Enter a publicly routable IPv4 or IPv6 address "
+            "(e.g. 203.0.113.10). Domain names and FQDNs are not accepted."
+        )
+    for net in _PRIVATE_NETWORKS:
+        if addr in net:
+            raise ValueError(
+                f"'{v}' is a private/non-routable address. "
+                "The redirector must be reachable over the internet. "
+                "Enter a publicly routable IP address (e.g. 203.0.113.10)."
+            )
+    return v
 _ALLOWED_SSL_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}
 _UNSAFE_NGINX_CHARS = re.compile(r"[;\n\r{}]")
 
@@ -41,8 +73,7 @@ class RedirectorCreate(BaseModel):
     @field_validator("current_ip")
     @classmethod
     def validate_ip(cls, v: str) -> str:
-        ipaddress.ip_address(v)
-        return v
+        return _validate_public_ip(v)
 
     @field_validator("ssh_username")
     @classmethod
@@ -137,7 +168,7 @@ class RedirectorUpdate(BaseModel):
     @classmethod
     def validate_ip(cls, v: Optional[str]) -> Optional[str]:
         if v is not None:
-            ipaddress.ip_address(v)
+            return _validate_public_ip(v)
         return v
 
     @field_validator("ssh_username")

--- a/backend/tests/unit/test_redirector_schemas.py
+++ b/backend/tests/unit/test_redirector_schemas.py
@@ -23,7 +23,7 @@ class TestRedirectorCreate:
         """BYOD mode: ssh_private_key is required."""
         schema = RedirectorCreate(
             name="redir-01",
-            current_ip="10.0.0.1",
+            current_ip="198.51.100.1",
             ssh_username="debian",
             ssh_private_key=VALID_PEM,
         )
@@ -34,12 +34,12 @@ class TestRedirectorCreate:
         with pytest.raises(ValidationError):
             RedirectorCreate(
                 name="redir-04",
-                current_ip="10.0.0.4",
+                current_ip="198.51.100.4",
                 ssh_username="debian",
             )
 
     def test_invalid_ip_rejected(self):
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="not a valid IP address"):
             RedirectorCreate(
                 name="redir-05",
                 current_ip="not-an-ip",
@@ -47,11 +47,30 @@ class TestRedirectorCreate:
                 ssh_private_key=VALID_PEM,
             )
 
+    def test_fqdn_rejected(self):
+        with pytest.raises(ValidationError, match="not a valid IP address"):
+            RedirectorCreate(
+                name="redir-fqdn",
+                current_ip="escape.golearn.us",
+                ssh_username="root",
+                ssh_private_key=VALID_PEM,
+            )
+
+    def test_private_ip_rejected(self):
+        for ip in ("10.0.0.1", "192.168.1.1", "172.16.0.1", "127.0.0.1"):
+            with pytest.raises(ValidationError, match="private/non-routable"):
+                RedirectorCreate(
+                    name="redir-priv",
+                    current_ip=ip,
+                    ssh_username="debian",
+                    ssh_private_key=VALID_PEM,
+                )
+
     def test_unsafe_username_rejected(self):
         with pytest.raises(ValidationError, match="invalid characters"):
             RedirectorCreate(
                 name="redir-06",
-                current_ip="10.0.0.6",
+                current_ip="198.51.100.6",
                 ssh_username="user;rm -rf",
                 ssh_private_key=VALID_PEM,
             )
@@ -60,7 +79,7 @@ class TestRedirectorCreate:
         with pytest.raises(ValidationError, match="safe characters"):
             RedirectorCreate(
                 name="redir-07",
-                current_ip="10.0.0.7",
+                current_ip="198.51.100.7",
                 ssh_username="debian",
                 ssh_private_key=VALID_PEM,
                 nginx_stream_dir="../etc/passwd",
@@ -69,7 +88,7 @@ class TestRedirectorCreate:
     def test_defaults(self):
         schema = RedirectorCreate(
             name="redir-08",
-            current_ip="10.0.0.8",
+            current_ip="198.51.100.8",
             ssh_username="debian",
             ssh_private_key=VALID_PEM,
         )
@@ -126,7 +145,7 @@ class TestRedirectorOut:
         out = RedirectorOut(
             id="abc",
             name="redir",
-            current_ip="10.0.0.1",
+            current_ip="198.51.100.1",
             ssh_port=22,
             ssh_username="debian",
             use_infrastructure_key=True,
@@ -147,7 +166,7 @@ class TestRedirectorOut:
         out = RedirectorOut(
             id="abc",
             name="redir",
-            current_ip="10.0.0.1",
+            current_ip="198.51.100.1",
             ssh_port=22,
             ssh_username="debian",
             nginx_stream_dir="/etc/nginx/stream.d",

--- a/frontend/templates/pages/participant/portal.html
+++ b/frontend/templates/pages/participant/portal.html
@@ -784,8 +784,15 @@
                                         <input type="text" class="form-control" id="redir_add_name" placeholder="e.g. prod-redirector-01" required>
                                     </div>
                                     <div class="col-md-6">
-                                        <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span></label>
-                                        <input type="text" class="form-control" id="redir_add_ip" placeholder="203.0.113.10" required>
+                                        <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span>
+                                            <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
+                                               data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
+                                               title="IP Address Requirements"
+                                               data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                                        </label>
+                                        <input type="text" class="form-control" id="redir_add_ip" placeholder="203.0.113.10" required
+                                               onblur="checkIPField(this, 'redirAddIpWarn')">
+                                        <div id="redirAddIpWarn" class="form-text text-warning d-none"></div>
                                     </div>
                                     <div class="col-md-4">
                                         <label class="form-label fw-semibold">SSH Port</label>
@@ -2012,6 +2019,47 @@ function escapeHtml(text) {
     return div.innerHTML;
 }
 
+function parseApiError(detail, fallback) {
+    if (!detail) return fallback || 'An unknown error occurred.';
+    if (typeof detail === 'string') return detail;
+    if (Array.isArray(detail)) return detail.map(function(e) { return e.msg || JSON.stringify(e); }).join('; ');
+    return String(detail);
+}
+
+function isPrivateIP(ip) {
+    var parts = ip.split('.');
+    if (parts.length === 4 && parts.every(function(p) { return /^\d{1,3}$/.test(p); })) {
+        var a = Number(parts[0]), b = Number(parts[1]);
+        if (a === 10) return true;
+        if (a === 172 && b >= 16 && b <= 31) return true;
+        if (a === 192 && b === 168) return true;
+        if (a === 100 && b >= 64 && b <= 127) return true;
+        if (a === 169 && b === 254) return true;
+        if (a === 127) return true;
+    }
+    if (ip === '::1') return true;
+    var lower = ip.toLowerCase();
+    if (lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80')) return true;
+    return false;
+}
+
+function looksLikeFQDN(val) { return /[a-zA-Z]/.test(val) && val.includes('.'); }
+
+function checkIPField(input, warnId) {
+    var val = input.value.trim();
+    var warnEl = document.getElementById(warnId);
+    if (!val) { warnEl.classList.add('d-none'); return; }
+    if (looksLikeFQDN(val)) {
+        warnEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
+        warnEl.classList.remove('d-none');
+    } else if (isPrivateIP(val)) {
+        warnEl.textContent = 'This is a private/non-routable address. The redirector must be reachable over the internet.';
+        warnEl.classList.remove('d-none');
+    } else {
+        warnEl.classList.add('d-none');
+    }
+}
+
 // =============================================================================
 // CPE Certificates Functions
 // =============================================================================
@@ -2338,12 +2386,18 @@ async function submitAddBYOD() {
     if (!payload.ssh_private_key) {
         errEl.textContent = 'SSH private key is required.'; errEl.classList.remove('d-none'); return;
     }
+    if (looksLikeFQDN(payload.current_ip)) {
+        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).'; errEl.classList.remove('d-none'); return;
+    }
+    if (isPrivateIP(payload.current_ip)) {
+        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.'; errEl.classList.remove('d-none'); return;
+    }
     try {
         var resp = await csrfFetch('/api/redirectors/', {
             method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
         });
         var data = await resp.json();
-        if (!resp.ok) { errEl.textContent = data.detail || 'Failed to create redirector.'; errEl.classList.remove('d-none'); return; }
+        if (!resp.ok) { errEl.textContent = parseApiError(data.detail, 'Failed to create redirector.'); errEl.classList.remove('d-none'); return; }
         _byodModal.hide();
         showToast('Redirector <strong>' + escapeHtml(data.name) + '</strong> created.', 'success');
         loadRedirectors();
@@ -2541,6 +2595,10 @@ document.addEventListener('DOMContentLoaded', function() {
     var cxEl = document.getElementById('addCyberXModal');
     if (cxEl) cxEl.addEventListener('hidden.bs.modal', function() {
         if (_cxPollTimer) { clearInterval(_cxPollTimer); _cxPollTimer = null; }
+    });
+    // Initialize Bootstrap popovers
+    document.querySelectorAll('[data-bs-toggle="popover"]').forEach(function(el) {
+        new bootstrap.Popover(el, { html: false });
     });
 });
 

--- a/frontend/templates/pages/participant/redirector_detail.html
+++ b/frontend/templates/pages/participant/redirector_detail.html
@@ -253,8 +253,15 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
                         <input type="text" class="form-control" id="er_name" value="{{ redirector.name | e }}">
                     </div>
                     <div class="col-md-6">
-                        <label class="form-label fw-semibold">IP Address</label>
-                        <input type="text" class="form-control" id="er_ip" value="{{ redirector.current_ip | e }}">
+                        <label class="form-label fw-semibold">IP Address
+                            <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
+                               data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
+                               title="IP Address Requirements"
+                               data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                        </label>
+                        <input type="text" class="form-control" id="er_ip" value="{{ redirector.current_ip | e }}"
+                               onblur="checkIPField(this, 'erIpWarn')">
+                        <div id="erIpWarn" class="form-text text-warning d-none"></div>
                     </div>
                     <div class="col-md-4">
                         <label class="form-label fw-semibold">SSH Port</label>
@@ -583,6 +590,10 @@ document.querySelectorAll('.modal').forEach(el => {
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.js-dt').forEach(el => {
         el.textContent = formatDateTime(el.textContent);
+    });
+    // Initialize Bootstrap popovers
+    document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => {
+        new bootstrap.Popover(el, { html: false });
     });
     loadStreams().then(startPolling);
     checkNginxSetup();
@@ -997,6 +1008,18 @@ async function submitEditRedirector() {
     if (v('er_dir').trim())   payload.nginx_stream_dir = v('er_dir').trim();
     payload.notes = v('er_notes').trim() || null;
 
+    const ip = payload.current_ip;
+    if (ip && looksLikeFQDN(ip)) {
+        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
+        errEl.classList.remove('d-none');
+        return;
+    }
+    if (ip && isPrivateIP(ip)) {
+        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.';
+        errEl.classList.remove('d-none');
+        return;
+    }
+
     try {
         const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}`, {
             method: 'PUT',
@@ -1005,7 +1028,7 @@ async function submitEditRedirector() {
         });
         const data = await resp.json();
         if (!resp.ok) {
-            errEl.textContent = data.detail || 'Update failed.';
+            errEl.textContent = parseApiError(data.detail, 'Update failed.');
             errEl.classList.remove('d-none');
             return;
         }
@@ -1351,6 +1374,47 @@ async function deleteRedirector() {
             showToast(escHtml(data.detail || 'Delete failed.'), 'danger');
         }
     } catch (e) { showToast('Delete failed: ' + escHtml(e.message), 'danger'); }
+}
+
+function parseApiError(detail, fallback) {
+    if (!detail) return fallback || 'An unknown error occurred.';
+    if (typeof detail === 'string') return detail;
+    if (Array.isArray(detail)) return detail.map(e => e.msg || JSON.stringify(e)).join('; ');
+    return String(detail);
+}
+
+function isPrivateIP(ip) {
+    const parts = ip.split('.');
+    if (parts.length === 4 && parts.every(p => /^\d{1,3}$/.test(p))) {
+        const [a, b] = parts.map(Number);
+        if (a === 10) return true;
+        if (a === 172 && b >= 16 && b <= 31) return true;
+        if (a === 192 && b === 168) return true;
+        if (a === 100 && b >= 64 && b <= 127) return true;
+        if (a === 169 && b === 254) return true;
+        if (a === 127) return true;
+    }
+    if (ip === '::1') return true;
+    const lower = ip.toLowerCase();
+    if (lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80')) return true;
+    return false;
+}
+
+function looksLikeFQDN(val) { return /[a-zA-Z]/.test(val) && val.includes('.'); }
+
+function checkIPField(input, warnId) {
+    const val = input.value.trim();
+    const warnEl = document.getElementById(warnId);
+    if (!val) { warnEl.classList.add('d-none'); return; }
+    if (looksLikeFQDN(val)) {
+        warnEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
+        warnEl.classList.remove('d-none');
+    } else if (isPrivateIP(val)) {
+        warnEl.textContent = 'This is a private/non-routable address. The redirector must be reachable over the internet.';
+        warnEl.classList.remove('d-none');
+    } else {
+        warnEl.classList.add('d-none');
+    }
 }
 
 function escHtml(str) {

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -95,8 +95,15 @@
                             <input type="text" class="form-control" id="add_name" placeholder="e.g. prod-redirector-01" required>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="add_ip" placeholder="203.0.113.10" required>
+                            <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span>
+                                <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
+                                   data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
+                                   title="IP Address Requirements"
+                                   data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                            </label>
+                            <input type="text" class="form-control" id="add_ip" placeholder="203.0.113.10" required
+                                   onblur="checkIPField(this, 'addBYODIpWarn')">
+                            <div id="addBYODIpWarn" class="form-text text-warning d-none"></div>
                         </div>
                         <div class="col-md-4">
                             <label class="form-label fw-semibold">SSH Port</label>
@@ -276,8 +283,15 @@
                             <input type="text" class="form-control" id="edit_name" required>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label fw-semibold">IP Address</label>
-                            <input type="text" class="form-control" id="edit_ip" required>
+                            <label class="form-label fw-semibold">IP Address
+                                <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
+                                   data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
+                                   title="IP Address Requirements"
+                                   data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                            </label>
+                            <input type="text" class="form-control" id="edit_ip" required
+                                   onblur="checkIPField(this, 'editIpWarn')">
+                            <div id="editIpWarn" class="form-text text-warning d-none"></div>
                         </div>
                         <div class="col-md-4">
                             <label class="form-label fw-semibold">SSH Port</label>
@@ -386,7 +400,13 @@ document.getElementById('addCyberXModal').addEventListener('hidden.bs.modal', ()
 // ============================================================
 // Load redirectors on page load
 // ============================================================
-document.addEventListener('DOMContentLoaded', loadRedirectors);
+document.addEventListener('DOMContentLoaded', () => {
+    // Initialize Bootstrap popovers
+    document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => {
+        new bootstrap.Popover(el, { html: false });
+    });
+    loadRedirectors();
+});
 
 async function loadRedirectors() {
     try {
@@ -485,6 +505,16 @@ async function submitAddBYOD() {
         errEl.classList.remove('d-none');
         return;
     }
+    if (looksLikeFQDN(payload.current_ip)) {
+        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
+        errEl.classList.remove('d-none');
+        return;
+    }
+    if (isPrivateIP(payload.current_ip)) {
+        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.';
+        errEl.classList.remove('d-none');
+        return;
+    }
 
     try {
         const resp = await csrfFetch('/api/redirectors/', {
@@ -494,7 +524,7 @@ async function submitAddBYOD() {
         });
         const data = await resp.json();
         if (!resp.ok) {
-            errEl.textContent = data.detail || 'Failed to create redirector.';
+            errEl.textContent = parseApiError(data.detail, 'Failed to create redirector.');
             errEl.classList.remove('d-none');
             return;
         }
@@ -797,6 +827,17 @@ async function submitEditRedirector() {
         if (pass) payload.ssh_key_passphrase = pass;
     }
 
+    if (ip && looksLikeFQDN(ip)) {
+        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
+        errEl.classList.remove('d-none');
+        return;
+    }
+    if (ip && isPrivateIP(ip)) {
+        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.';
+        errEl.classList.remove('d-none');
+        return;
+    }
+
     try {
         const resp = await csrfFetch(`/api/redirectors/${id}`, {
             method: 'PUT',
@@ -805,7 +846,7 @@ async function submitEditRedirector() {
         });
         const data = await resp.json();
         if (!resp.ok) {
-            errEl.textContent = data.detail || 'Failed to update redirector.';
+            errEl.textContent = parseApiError(data.detail, 'Failed to update redirector.');
             errEl.classList.remove('d-none');
             return;
         }
@@ -848,10 +889,64 @@ async function confirmDeleteRedirector() {
 // ============================================================
 // Utility
 // ============================================================
+/** Inline warning for IP address fields (blur handler) */
+function checkIPField(input, warnId) {
+    const val = input.value.trim();
+    const warnEl = document.getElementById(warnId);
+    if (!val) { warnEl.classList.add('d-none'); return; }
+    if (looksLikeFQDN(val)) {
+        warnEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
+        warnEl.classList.remove('d-none');
+    } else if (isPrivateIP(val)) {
+        warnEl.textContent = 'This is a private/non-routable address. The redirector must be reachable over the internet.';
+        warnEl.classList.remove('d-none');
+    } else {
+        warnEl.classList.add('d-none');
+    }
+}
+
 function escHtml(str) {
     if (!str) return '';
     return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
               .replace(/"/g,'&quot;').replace(/'/g,'&#039;');
+}
+
+/**
+ * Extract a human-readable error string from a FastAPI error response.
+ * Handles both string detail and Pydantic validation error arrays.
+ */
+function parseApiError(detail, fallback) {
+    if (!detail) return fallback || 'An unknown error occurred.';
+    if (typeof detail === 'string') return detail;
+    if (Array.isArray(detail)) {
+        return detail.map(e => e.msg || JSON.stringify(e)).join('; ');
+    }
+    return String(detail);
+}
+
+/** RFC 1918 / RFC 6598 / link-local / loopback check */
+function isPrivateIP(ip) {
+    // IPv4 check
+    const parts = ip.split('.');
+    if (parts.length === 4 && parts.every(p => /^\d{1,3}$/.test(p))) {
+        const [a, b] = parts.map(Number);
+        if (a === 10) return true;                          // 10.0.0.0/8
+        if (a === 172 && b >= 16 && b <= 31) return true;   // 172.16.0.0/12
+        if (a === 192 && b === 168) return true;            // 192.168.0.0/16
+        if (a === 100 && b >= 64 && b <= 127) return true;  // 100.64.0.0/10
+        if (a === 169 && b === 254) return true;            // 169.254.0.0/16
+        if (a === 127) return true;                         // 127.0.0.0/8
+    }
+    // IPv6 private/loopback
+    if (ip === '::1') return true;
+    const lower = ip.toLowerCase();
+    if (lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80')) return true;
+    return false;
+}
+
+/** Check if a value looks like a domain name rather than an IP */
+function looksLikeFQDN(val) {
+    return /[a-zA-Z]/.test(val) && val.includes('.');
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Backend rejects private/non-routable IPs and FQDNs with clear error messages
- Frontend info popovers, onblur warnings, and client-side validation on all IP fields
- Fix `[object Object]` error display for Pydantic validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)