### PR TITLE
release: v1.5.0 — async background jobs for VPN bulk import + delete

### DIFF
--- a/ADMIN_GUIDE.md
+++ b/ADMIN_GUIDE.md
@@ -1039,24 +1039,52 @@ sequenceDiagram
 
 ### Bulk VPN Import
 
-1. **Prepare ZIP File**: Contains WireGuard `.conf` files
-2. **Upload**: Admin uploads via `/api/vpn/import`
-3. **Parse**: Extract private key, preshared key, IPs
-4. **Validate**: Check for duplicates, valid format
-5. **Store**: Save to `vpn_credentials` table
-6. **Report**: Return import statistics
+VPN imports run **asynchronously** in a background job so the admin UI does
+not block on large ZIPs. The flow is:
 
-Import response example:
+1. **Prepare ZIP file**: Contains WireGuard `.conf` files.
+2. **Upload**: Admin uploads via `POST /api/vpn/import`. The upload is
+   staged to R2 and a `vpn_import_jobs` row is created in `pending` state.
+3. **Queue response**: The endpoint returns immediately with the job id.
+4. **Background processing**: A scheduled task picks up pending jobs every
+   30 seconds, parses the ZIP cooperatively, deduplicates against existing
+   credentials, bulk-inserts new rows, and uploads per-credential configs
+   to R2 in parallel.
+5. **Polling**: The admin UI polls `GET /api/vpn/import-jobs/{job_id}` every
+   2 seconds to show a live progress bar.
+6. **Cleanup**: A daily cleanup task removes completed/failed jobs older
+   than `VPN_IMPORT_RETENTION_DAYS` (default 30 days).
+
+Queue response example:
 ```json
 {
   "success": true,
-  "imported_count": 150,
-  "skipped_count": 5,
-  "skipped_reasons": [
-    "Duplicate IP: 10.20.200.100"
-  ]
+  "message": "Import queued. Poll /api/vpn/import-jobs/42 for status.",
+  "job_id": 42,
+  "status": "pending"
 }
 ```
+
+Status response example (mid-import):
+```json
+{
+  "id": 42,
+  "status": "processing",
+  "filename": "wg-configs.zip",
+  "total_files": 2000,
+  "processed_files": 840,
+  "imported_count": 832,
+  "skipped_count": 8,
+  "error_count": 0,
+  "errors": [],
+  "started_at": "2026-04-09T14:03:11Z"
+}
+```
+
+Related endpoints:
+- `GET /api/vpn/import-jobs` — recent jobs (history)
+- `POST /api/vpn/import-jobs/{id}/retry` — retry a failed job
+- `DELETE /api/vpn/import-jobs/{id}` — delete a completed/failed job
 
 ---
 

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -119,6 +119,9 @@ Multi-stage reminder system for participants who haven't confirmed. The backgrou
 | `VPN_SERVER_ENDPOINT` | No | Yes | No | `""` | WireGuard server address and port. |
 | `VPN_DNS_SERVERS` | No | Yes | No | `10.20.200.1` | DNS servers pushed to VPN clients. |
 | `VPN_ALLOWED_IPS` | No | Yes | No | `10.0.0.0/8,fd00:a::/32` | IP ranges routed through the VPN tunnel. |
+| `VPN_IMPORT_MAX_FILE_SIZE_MB` | No | Yes | No | `20` | Maximum size in MB for ZIP uploads to `/api/vpn/import`. |
+| `VPN_IMPORT_RETENTION_DAYS` | No | Yes | No | `30` | How long to keep completed/failed VPN import job rows before the daily cleanup task removes them. |
+| `VPN_IMPORT_R2_PARALLELISM` | No | Yes | No | `10` | Maximum concurrent R2 uploads per import chunk. Lower this if R2 rate-limits or the host is memory-constrained. |
 
 **Notes:**
 - Only needed if generating WireGuard VPN credentials for participants

--- a/backend/app/api/routes/vpn.py
+++ b/backend/app/api/routes/vpn.py
@@ -25,7 +25,9 @@ from app.models.app_setting import AppSetting
 from app.models.audit_log import AuditLog
 from app.models.instance import Instance
 from app.services.vpn_service import VPNService
+from app.services.vpn_import_service import VPNImportService
 from app.services.participant_service import ParticipantService
+from app.models.vpn_import_job import VPNImportJob, VPNImportJobStatus
 from app.schemas.vpn import (
     VPNCredentialResponse,
     VPNCredentialListResponse,
@@ -38,6 +40,8 @@ from app.schemas.vpn import (
     VPNRequestRequest,
     VPNRequestResponse,
     VPNImportResponse,
+    VPNImportJobResponse,
+    VPNImportJobListResponse,
     VPNMyCredentialsResponse,
     VPNBulkDeleteRequest,
     VPNBulkDeleteResponse,
@@ -316,49 +320,168 @@ async def bulk_assign_vpn(
     )
 
 
+def _serialize_import_job(job: VPNImportJob) -> VPNImportJobResponse:
+    """Convert a VPNImportJob ORM row to its response schema."""
+    error_items: list[str] = []
+    if job.errors and isinstance(job.errors, dict):
+        items = job.errors.get("items")
+        if isinstance(items, list):
+            error_items = [str(x) for x in items]
+    return VPNImportJobResponse(
+        id=job.id,
+        status=job.status,
+        filename=job.filename,
+        file_size_bytes=job.file_size_bytes,
+        assignment_type=job.assignment_type,
+        endpoint_override=job.endpoint_override,
+        total_files=job.total_files,
+        processed_files=job.processed_files,
+        imported_count=job.imported_count,
+        skipped_count=job.skipped_count,
+        error_count=job.error_count,
+        errors=error_items,
+        created_at=job.created_at,
+        started_at=job.started_at,
+        completed_at=job.completed_at,
+        last_error=job.last_error,
+        created_by_user_id=job.created_by_user_id,
+    )
+
+
 @router.post("/import", response_model=VPNImportResponse)
 async def import_vpn_configs(
     file: UploadFile = File(..., description="ZIP file containing WireGuard .conf files"),
     endpoint: Optional[str] = Query(None, description="Optional VPN server endpoint override (ip:port)"),
     assignment_type: str = Query("USER_REQUESTABLE", description="Assignment type: USER_REQUESTABLE | INSTANCE_AUTO_ASSIGN | RESERVED"),
     current_user: User = Depends(require_permission("vpn.manage_pool")),
-    service: VPNService = Depends(get_vpn_service)
+    db: AsyncSession = Depends(get_db),
 ):
     """
-    Import VPN credentials from a ZIP file (admin only).
+    Queue a VPN credential import from a ZIP file (admin only).
 
-    The ZIP file should contain WireGuard .conf files with [Interface], [Peer], and Endpoint sections.
-    The endpoint will be parsed from each config file unless an override is provided.
+    The upload is staged to R2 and a background job is created. The actual
+    import runs in a scheduled task and progress can be polled via
+    ``GET /api/vpn/import-jobs/{job_id}``. This endpoint returns immediately
+    once the upload is staged.
+
+    The ZIP file should contain WireGuard ``.conf`` files with ``[Interface]``,
+    ``[Peer]``, and ``Endpoint`` sections. The endpoint will be parsed from
+    each config file unless an override is provided.
 
     Assignment types:
     - USER_REQUESTABLE: VPNs available for participant self-service requests (default)
     - INSTANCE_AUTO_ASSIGN: VPNs automatically assigned to instances in events with vpn_available=true
     - RESERVED: VPNs held in reserve, not available for auto-assignment
     """
-    # Validate assignment_type
     valid_types = ["USER_REQUESTABLE", "INSTANCE_AUTO_ASSIGN", "RESERVED"]
     if assignment_type not in valid_types:
-        raise bad_request(f"Invalid assignment_type. Must be one of: {', '.join(valid_types)}")
+        raise bad_request(
+            f"Invalid assignment_type. Must be one of: {', '.join(valid_types)}"
+        )
 
-    if not file.filename.endswith('.zip'):
+    if not file.filename or not file.filename.endswith(".zip"):
         raise bad_request("File must be a ZIP archive")
 
-    # Read file content
     content = await file.read()
 
-    # Limit file size (50MB)
-    if len(content) > 50 * 1024 * 1024:
-        raise bad_request("File too large (max 50MB)")
+    max_bytes = settings.VPN_IMPORT_MAX_FILE_SIZE_MB * 1024 * 1024
+    if len(content) > max_bytes:
+        raise bad_request(
+            f"File too large (max {settings.VPN_IMPORT_MAX_FILE_SIZE_MB}MB)"
+        )
 
-    imported, skipped, errors = await service.import_from_zip(content, endpoint, assignment_type)
+    import_service = VPNImportService(db)
+    try:
+        job = await import_service.stage_upload(
+            zip_bytes=content,
+            filename=file.filename,
+            assignment_type=assignment_type,
+            endpoint=endpoint,
+            user_id=current_user.id,
+        )
+    except RuntimeError as e:
+        raise server_error(str(e))
+
+    await db.commit()
 
     return VPNImportResponse(
-        success=imported > 0,
-        message=f"Imported {imported} VPN credentials, skipped {skipped}",
-        imported_count=imported,
-        skipped_count=skipped,
-        errors=errors[:10]  # Limit error messages
+        success=True,
+        message=f"Import queued. Poll /api/vpn/import-jobs/{job.id} for status.",
+        job_id=job.id,
+        status=job.status,
     )
+
+
+@router.get("/import-jobs", response_model=VPNImportJobListResponse)
+async def list_import_jobs(
+    limit: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the most recent VPN import jobs (admin only)."""
+    result = await db.execute(
+        select(VPNImportJob)
+        .order_by(VPNImportJob.created_at.desc())
+        .limit(limit)
+    )
+    jobs = list(result.scalars().all())
+    return VPNImportJobListResponse(
+        items=[_serialize_import_job(j) for j in jobs],
+        total=len(jobs),
+    )
+
+
+@router.get("/import-jobs/{job_id}", response_model=VPNImportJobResponse)
+async def get_import_job(
+    job_id: int,
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get the status and progress of a single VPN import job (admin only)."""
+    result = await db.execute(
+        select(VPNImportJob).where(VPNImportJob.id == job_id)
+    )
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise not_found("VPN import job not found")
+    return _serialize_import_job(job)
+
+
+@router.post("/import-jobs/{job_id}/retry", response_model=VPNImportJobResponse)
+async def retry_import_job(
+    job_id: int,
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reset a failed import job back to pending so the worker picks it up again."""
+    import_service = VPNImportService(db)
+    job = await import_service.retry_job(job_id)
+    if job is None:
+        raise not_found(
+            "Job not found, or job is not in a retryable state (must be 'failed')"
+        )
+    return _serialize_import_job(job)
+
+
+@router.delete("/import-jobs/{job_id}")
+async def delete_import_job(
+    job_id: int,
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Delete a completed or failed VPN import job (admin only).
+
+    Refuses to delete a job while it is processing.
+    """
+    import_service = VPNImportService(db)
+    try:
+        deleted = await import_service.delete_job(job_id)
+    except ValueError as e:
+        raise bad_request(str(e))
+    if not deleted:
+        raise not_found("VPN import job not found")
+    return {"success": True, "deleted_id": job_id}
 
 
 @router.get("/credentials/{vpn_id}", response_model=VPNCredentialResponse)

--- a/backend/app/api/routes/vpn.py
+++ b/backend/app/api/routes/vpn.py
@@ -26,8 +26,10 @@ from app.models.audit_log import AuditLog
 from app.models.instance import Instance
 from app.services.vpn_service import VPNService
 from app.services.vpn_import_service import VPNImportService
+from app.services.vpn_delete_service import VPNDeleteService
 from app.services.participant_service import ParticipantService
 from app.models.vpn_import_job import VPNImportJob, VPNImportJobStatus
+from app.models.vpn_delete_job import VPNDeleteJob, VPNDeleteJobStatus
 from app.schemas.vpn import (
     VPNCredentialResponse,
     VPNCredentialListResponse,
@@ -45,6 +47,8 @@ from app.schemas.vpn import (
     VPNMyCredentialsResponse,
     VPNBulkDeleteRequest,
     VPNBulkDeleteResponse,
+    VPNDeleteJobResponse,
+    VPNDeleteJobListResponse,
     VPNRequestBatchesResponse,
     VPNUpdateAssignmentTypeRequest,
     VPNUpdateAssignmentTypeResponse,
@@ -876,55 +880,155 @@ async def get_available_vpn_count(
     return {"available_count": count}
 
 
+def _serialize_delete_job(job: VPNDeleteJob) -> VPNDeleteJobResponse:
+    """Convert a VPNDeleteJob ORM row to its response schema."""
+    error_items: list[str] = []
+    if job.errors and isinstance(job.errors, dict):
+        items = job.errors.get("items")
+        if isinstance(items, list):
+            error_items = [str(x) for x in items]
+    return VPNDeleteJobResponse(
+        id=job.id,
+        status=job.status,
+        mode=job.mode,
+        total_credentials=job.total_credentials,
+        processed_credentials=job.processed_credentials,
+        deleted_count=job.deleted_count,
+        failed_count=job.failed_count,
+        errors=error_items,
+        created_at=job.created_at,
+        started_at=job.started_at,
+        completed_at=job.completed_at,
+        last_error=job.last_error,
+        created_by_user_id=job.created_by_user_id,
+    )
+
+
 @router.post("/bulk-delete", response_model=VPNBulkDeleteResponse)
 async def bulk_delete_vpn_credentials(
     request: VPNBulkDeleteRequest,
     current_user: User = Depends(require_permission("vpn.manage_pool")),
-    service: VPNService = Depends(get_vpn_service)
+    db: AsyncSession = Depends(get_db),
 ):
     """
-    Delete multiple VPN credentials by ID.
+    Queue a bulk delete of multiple VPN credentials by ID (admin only).
 
-    Requires admin role.
+    The deletion runs asynchronously in a background task. Progress can be
+    polled via ``GET /api/vpn/delete-jobs/{job_id}``. Requires admin role.
     """
     if not request.vpn_ids:
         raise bad_request("No VPN credential IDs provided")
 
-    deleted_count, failed_ids, errors = await service.delete_credentials(request.vpn_ids)
-
-    success = deleted_count > 0
-    message = f"Deleted {deleted_count} VPN credential(s)"
-    if failed_ids:
-        message += f", {len(failed_ids)} failed"
+    delete_service = VPNDeleteService(db)
+    try:
+        job = await delete_service.queue_delete_by_ids(
+            vpn_ids=request.vpn_ids, user_id=current_user.id
+        )
+    except ValueError as e:
+        raise bad_request(str(e))
+    await db.commit()
 
     return VPNBulkDeleteResponse(
-        success=success,
-        message=message,
-        deleted_count=deleted_count,
-        failed_ids=failed_ids,
-        errors=errors
+        success=True,
+        message=f"Bulk delete queued. Poll /api/vpn/delete-jobs/{job.id} for status.",
+        job_id=job.id,
+        status=job.status,
     )
 
 
 @router.post("/delete-all", response_model=VPNBulkDeleteResponse)
 async def delete_all_vpn_credentials(
     current_user: User = Depends(require_permission("vpn.manage_pool")),
-    service: VPNService = Depends(get_vpn_service)
+    db: AsyncSession = Depends(get_db),
 ):
     """
-    Delete all VPN credentials.
+    Queue a delete of every VPN credential (admin only).
 
-    Requires admin role.
+    The deletion runs asynchronously in a background task. Progress can be
+    polled via ``GET /api/vpn/delete-jobs/{job_id}``. Requires admin role.
     """
-    deleted_count = await service.delete_all_credentials()
+    delete_service = VPNDeleteService(db)
+    job = await delete_service.queue_delete_all(user_id=current_user.id)
+    await db.commit()
 
     return VPNBulkDeleteResponse(
         success=True,
-        message=f"Deleted all {deleted_count} VPN credential(s)",
-        deleted_count=deleted_count,
-        failed_ids=[],
-        errors=[]
+        message=f"Delete-all queued. Poll /api/vpn/delete-jobs/{job.id} for status.",
+        job_id=job.id,
+        status=job.status,
     )
+
+
+@router.get("/delete-jobs", response_model=VPNDeleteJobListResponse)
+async def list_delete_jobs(
+    limit: int = Query(20, ge=1, le=100),
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """List the most recent VPN bulk-delete jobs (admin only)."""
+    result = await db.execute(
+        select(VPNDeleteJob)
+        .order_by(VPNDeleteJob.created_at.desc())
+        .limit(limit)
+    )
+    jobs = list(result.scalars().all())
+    return VPNDeleteJobListResponse(
+        items=[_serialize_delete_job(j) for j in jobs],
+        total=len(jobs),
+    )
+
+
+@router.get("/delete-jobs/{job_id}", response_model=VPNDeleteJobResponse)
+async def get_delete_job(
+    job_id: int,
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get the status and progress of a single VPN bulk-delete job (admin only)."""
+    result = await db.execute(
+        select(VPNDeleteJob).where(VPNDeleteJob.id == job_id)
+    )
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise not_found("VPN delete job not found")
+    return _serialize_delete_job(job)
+
+
+@router.post("/delete-jobs/{job_id}/retry", response_model=VPNDeleteJobResponse)
+async def retry_delete_job(
+    job_id: int,
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reset a failed delete job back to pending so the worker picks it up again."""
+    delete_service = VPNDeleteService(db)
+    job = await delete_service.retry_job(job_id)
+    if job is None:
+        raise not_found(
+            "Job not found, or job is not in a retryable state (must be 'failed')"
+        )
+    return _serialize_delete_job(job)
+
+
+@router.delete("/delete-jobs/{job_id}")
+async def delete_delete_job(
+    job_id: int,
+    current_user: User = Depends(require_permission("vpn.manage_pool")),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Delete a completed or failed VPN delete-job row (admin only).
+
+    Refuses to delete a job while it is processing.
+    """
+    delete_service = VPNDeleteService(db)
+    try:
+        deleted = await delete_service.delete_job(job_id)
+    except ValueError as e:
+        raise bad_request(str(e))
+    if not deleted:
+        raise not_found("VPN delete job not found")
+    return {"success": True, "deleted_id": job_id}
 
 
 @router.get("/naming-pattern")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -70,6 +70,11 @@ class Settings(BaseSettings):
     VPN_DNS_SERVERS: str = "10.20.200.1"
     VPN_ALLOWED_IPS: str = "10.0.0.0/8,fd00:a::/32"
 
+    # VPN Import (background job for ZIP imports of WireGuard configs)
+    VPN_IMPORT_MAX_FILE_SIZE_MB: int = 20  # Reject staged uploads above this size
+    VPN_IMPORT_RETENTION_DAYS: int = 30  # Auto-delete completed/failed jobs older than this
+    VPN_IMPORT_R2_PARALLELISM: int = 10  # Concurrent R2 uploads per chunk
+
     # Session Configuration
     SESSION_EXPIRY_HOURS: int = 24
     CSRF_TOKEN_MAX_AGE: int = 0  # seconds; 0 = match session lifetime

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.role import Role, BaseType
 from app.models.user import User, UserRole
 from app.models.vpn import VPNCredential
 from app.models.vpn_import_job import VPNImportJob, VPNImportJobStatus
+from app.models.vpn_delete_job import VPNDeleteJob, VPNDeleteJobMode, VPNDeleteJobStatus
 from app.models.session import Session
 from app.models.audit_log import AuditLog, EmailEvent, VPNRequest
 from app.models.event import Event, EventParticipation, ParticipationStatus
@@ -31,6 +32,9 @@ __all__ = [
     "VPNCredential",
     "VPNImportJob",
     "VPNImportJobStatus",
+    "VPNDeleteJob",
+    "VPNDeleteJobMode",
+    "VPNDeleteJobStatus",
     "Session",
     "AuditLog",
     "EmailEvent",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,7 @@
 from app.models.role import Role, BaseType
 from app.models.user import User, UserRole
 from app.models.vpn import VPNCredential
+from app.models.vpn_import_job import VPNImportJob, VPNImportJobStatus
 from app.models.session import Session
 from app.models.audit_log import AuditLog, EmailEvent, VPNRequest
 from app.models.event import Event, EventParticipation, ParticipationStatus
@@ -28,6 +29,8 @@ __all__ = [
     "User",
     "UserRole",
     "VPNCredential",
+    "VPNImportJob",
+    "VPNImportJobStatus",
     "Session",
     "AuditLog",
     "EmailEvent",

--- a/backend/app/models/vpn_delete_job.py
+++ b/backend/app/models/vpn_delete_job.py
@@ -1,0 +1,84 @@
+"""VPN Delete Job model for asynchronous bulk credential deletion."""
+import enum
+
+from sqlalchemy import Column, ForeignKey, Index, Integer, String, TIMESTAMP, Text
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.sql import func
+
+from app.database import Base
+from app.models.vpn_import_job import JsonType
+
+
+class VPNDeleteJobStatus(str, enum.Enum):
+    """Lifecycle state of a VPN bulk delete job."""
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class VPNDeleteJobMode(str, enum.Enum):
+    """Whether the job deletes a specific id list or every credential."""
+    BY_IDS = "by_ids"  # uses target_ids
+    ALL = "all"  # ignores target_ids; resolves at processing time
+
+
+class VPNDeleteJob(Base):
+    """
+    Tracks a background bulk-delete of VPN credentials.
+
+    The HTTP handler creates a row with ``status=pending`` and either a list
+    of target ids (``mode=by_ids``) or a marker (``mode=all``) telling the
+    worker to delete every credential. A scheduled task picks up pending
+    rows and runs the deletion cooperatively, updating progress columns as
+    it goes.
+    """
+
+    __tablename__ = "vpn_delete_jobs"
+
+    id = Column(Integer, primary_key=True)
+
+    created_by_user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    mode = Column(String(20), nullable=False, default=VPNDeleteJobMode.BY_IDS.value)
+    # JSON list of integers; only meaningful when mode=by_ids. For mode=all,
+    # the worker resolves the list at processing time.
+    target_ids = Column(JsonType, nullable=True)
+
+    # Status / progress
+    status = Column(
+        String(20),
+        nullable=False,
+        default=VPNDeleteJobStatus.PENDING.value,
+        index=True,
+    )
+    total_credentials = Column(Integer, nullable=True)
+    processed_credentials = Column(Integer, nullable=False, default=0)
+    deleted_count = Column(Integer, nullable=False, default=0)
+    failed_count = Column(Integer, nullable=False, default=0)
+    # Capped list of error messages, stored under {"items": [...]}
+    errors = Column(JsonType, nullable=True)
+
+    # Timestamps
+    created_at = Column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    started_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    last_error = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("idx_vpn_delete_jobs_status", "status"),
+        Index("idx_vpn_delete_jobs_created_at", "created_at"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"<VPNDeleteJob(id={self.id}, mode={self.mode}, status={self.status}, "
+            f"deleted={self.deleted_count}/{self.total_credentials})>"
+        )

--- a/backend/app/models/vpn_import_job.py
+++ b/backend/app/models/vpn_import_job.py
@@ -1,0 +1,89 @@
+"""VPN Import Job model for asynchronous VPN credential imports."""
+import enum
+
+from sqlalchemy import BigInteger, Column, ForeignKey, Index, Integer, JSON, String, TIMESTAMP, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+# Portable JSON type: use JSONB on Postgres for indexable JSON, fall back to
+# generic JSON on other dialects (SQLite in tests). Wrapped with MutableDict
+# so in-place mutations on the column value are tracked by the SQLAlchemy
+# session — needed because the import job appends to ``errors`` over time.
+JsonType = MutableDict.as_mutable(JSON().with_variant(JSONB(), "postgresql"))
+
+
+class VPNImportJobStatus(str, enum.Enum):
+    """Lifecycle state of a VPN import job."""
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class VPNImportJob(Base):
+    """
+    Tracks a background VPN credential import from a ZIP archive.
+
+    The HTTP handler stages the uploaded ZIP in R2 and creates a row with
+    ``status=pending``. A scheduled task picks up pending rows and runs the
+    import cooperatively, updating the progress counters as it goes. The
+    admin UI polls the status endpoint to show a progress bar.
+    """
+
+    __tablename__ = "vpn_import_jobs"
+
+    id = Column(Integer, primary_key=True)
+
+    # Who and what
+    created_by_user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    filename = Column(String(255), nullable=True)
+    file_size_bytes = Column(BigInteger, nullable=False)
+    assignment_type = Column(String(50), nullable=False)
+    endpoint_override = Column(String(255), nullable=True)
+
+    # R2 key where the staged ZIP lives until processing completes. Cleared
+    # when the job completes so the staged upload is not retained forever.
+    r2_key = Column(String(255), nullable=True)
+
+    # Status / progress
+    status = Column(
+        String(20),
+        nullable=False,
+        default=VPNImportJobStatus.PENDING.value,
+        index=True,
+    )
+    total_files = Column(Integer, nullable=True)
+    processed_files = Column(Integer, nullable=False, default=0)
+    imported_count = Column(Integer, nullable=False, default=0)
+    skipped_count = Column(Integer, nullable=False, default=0)
+    error_count = Column(Integer, nullable=False, default=0)
+    # Capped list of error messages (stored under the "items" key)
+    errors = Column(JsonType, nullable=True)
+
+    # Timestamps
+    created_at = Column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    started_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    last_error = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("idx_vpn_import_jobs_status", "status"),
+        Index("idx_vpn_import_jobs_created_at", "created_at"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"<VPNImportJob(id={self.id}, status={self.status}, "
+            f"processed={self.processed_files}/{self.total_files})>"
+        )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -46,6 +46,8 @@ from app.schemas.vpn import (
     VPNRequestRequest,
     VPNRequestResponse,
     VPNImportResponse,
+    VPNImportJobResponse,
+    VPNImportJobListResponse,
     VPNMyCredentialsResponse,
 )
 
@@ -94,5 +96,7 @@ __all__ = [
     "VPNRequestRequest",
     "VPNRequestResponse",
     "VPNImportResponse",
+    "VPNImportJobResponse",
+    "VPNImportJobListResponse",
     "VPNMyCredentialsResponse",
 ]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -49,6 +49,8 @@ from app.schemas.vpn import (
     VPNImportJobResponse,
     VPNImportJobListResponse,
     VPNMyCredentialsResponse,
+    VPNDeleteJobResponse,
+    VPNDeleteJobListResponse,
 )
 
 __all__ = [
@@ -99,4 +101,6 @@ __all__ = [
     "VPNImportJobResponse",
     "VPNImportJobListResponse",
     "VPNMyCredentialsResponse",
+    "VPNDeleteJobResponse",
+    "VPNDeleteJobListResponse",
 ]

--- a/backend/app/schemas/vpn.py
+++ b/backend/app/schemas/vpn.py
@@ -173,13 +173,43 @@ class VPNBulkDeleteRequest(BaseModel):
 
 
 class VPNBulkDeleteResponse(BaseModel):
-    """Response for bulk VPN deletion."""
+    """Response from queueing a bulk VPN deletion job.
+
+    The actual deletion runs asynchronously in a background task. Clients
+    should poll ``GET /api/vpn/delete-jobs/{job_id}`` for progress and the
+    final deleted count.
+    """
 
     success: bool
     message: str
+    job_id: int
+    status: str
+
+
+class VPNDeleteJobResponse(BaseModel):
+    """Detailed status of a VPN bulk-delete job."""
+
+    id: int
+    status: str  # pending | processing | completed | failed
+    mode: str  # by_ids | all
+    total_credentials: Optional[int] = None
+    processed_credentials: int
     deleted_count: int
-    failed_ids: List[int] = []
+    failed_count: int
     errors: List[str] = []
+
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    last_error: Optional[str] = None
+    created_by_user_id: Optional[int] = None
+
+
+class VPNDeleteJobListResponse(BaseModel):
+    """List of recent VPN bulk-delete jobs."""
+
+    items: List[VPNDeleteJobResponse]
+    total: int
 
 
 class VPNRequestBatch(BaseModel):

--- a/backend/app/schemas/vpn.py
+++ b/backend/app/schemas/vpn.py
@@ -115,13 +115,48 @@ class VPNRequestResponse(BaseModel):
 
 
 class VPNImportResponse(BaseModel):
-    """Response for VPN bulk import."""
+    """Response from queueing a VPN bulk import job.
+
+    The actual import runs asynchronously in a background task. Clients
+    should poll ``GET /api/vpn/import-jobs/{job_id}`` for progress and the
+    final imported/skipped counts.
+    """
 
     success: bool
     message: str
+    job_id: int
+    status: str
+
+
+class VPNImportJobResponse(BaseModel):
+    """Detailed status of a VPN import job."""
+
+    id: int
+    status: str  # pending | processing | completed | failed
+    filename: Optional[str] = None
+    file_size_bytes: int
+    assignment_type: str
+    endpoint_override: Optional[str] = None
+
+    total_files: Optional[int] = None
+    processed_files: int
     imported_count: int
     skipped_count: int
+    error_count: int
     errors: List[str] = []
+
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    last_error: Optional[str] = None
+    created_by_user_id: Optional[int] = None
+
+
+class VPNImportJobListResponse(BaseModel):
+    """List of recent VPN import jobs."""
+
+    items: List[VPNImportJobResponse]
+    total: int
 
 
 class VPNMyCredentialsResponse(BaseModel):

--- a/backend/app/services/vpn_delete_service.py
+++ b/backend/app/services/vpn_delete_service.py
@@ -1,0 +1,271 @@
+"""Background VPN bulk-delete job processor.
+
+Mirrors the import job pattern: HTTP handlers create a pending row, a
+scheduled task picks it up and runs the delete cooperatively, the admin UI
+polls for progress.
+"""
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.models.vpn import VPNCredential
+from app.models.vpn_delete_job import (
+    VPNDeleteJob,
+    VPNDeleteJobMode,
+    VPNDeleteJobStatus,
+)
+from app.utils.r2_client import R2Client
+
+logger = logging.getLogger(__name__)
+
+
+# Process credentials in batches to keep individual SQL statements
+# reasonable and to update progress visibly between chunks.
+CHUNK_SIZE = 200
+
+# Cap the number of error messages stored on the job row.
+MAX_STORED_ERRORS = 50
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class VPNDeleteService:
+    """Manages the lifecycle of VPN bulk-delete jobs."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.r2 = R2Client.from_settings()
+        self.settings = get_settings()
+
+    # ─── public API: HTTP handler entry points ─────────────────────────
+
+    async def queue_delete_by_ids(
+        self, vpn_ids: list[int], user_id: Optional[int]
+    ) -> VPNDeleteJob:
+        """Create a pending bulk-delete job for an explicit id list."""
+        if not vpn_ids:
+            raise ValueError("No VPN credential IDs provided")
+        # Deduplicate and coerce to ints up front so the worker doesn't have
+        # to repeat the work and the stored payload is canonical.
+        unique_ids = sorted({int(i) for i in vpn_ids})
+        job = VPNDeleteJob(
+            created_by_user_id=user_id,
+            mode=VPNDeleteJobMode.BY_IDS.value,
+            target_ids={"items": unique_ids},
+            total_credentials=len(unique_ids),
+            status=VPNDeleteJobStatus.PENDING.value,
+        )
+        self.session.add(job)
+        await self.session.flush()
+        return job
+
+    async def queue_delete_all(self, user_id: Optional[int]) -> VPNDeleteJob:
+        """Create a pending bulk-delete job that targets every credential."""
+        job = VPNDeleteJob(
+            created_by_user_id=user_id,
+            mode=VPNDeleteJobMode.ALL.value,
+            target_ids=None,
+            status=VPNDeleteJobStatus.PENDING.value,
+        )
+        self.session.add(job)
+        await self.session.flush()
+        return job
+
+    # ─── public API: scheduled task entry points ───────────────────────
+
+    async def claim_next_pending_job(self) -> Optional[VPNDeleteJob]:
+        """
+        Pick the oldest pending delete job. Single-process deployment, so a
+        simple ``status='pending'`` filter is sufficient.
+        """
+        result = await self.session.execute(
+            select(VPNDeleteJob)
+            .where(VPNDeleteJob.status == VPNDeleteJobStatus.PENDING.value)
+            .order_by(VPNDeleteJob.created_at)
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def process_job(self, job: VPNDeleteJob) -> None:
+        """
+        Run a pending delete job to completion (or failure).
+
+        Resolves the target id list, then for each chunk:
+            1. Bulk-fetch (id, r2_key) for the chunk in one query
+            2. Parallel R2 deletes via asyncio.gather + Semaphore, each
+               wrapped in to_thread so boto3 does not block the event loop
+            3. Single ``DELETE FROM vpn_credentials WHERE id IN (...)`` SQL
+            4. Update progress and yield to the event loop
+        """
+        job.status = VPNDeleteJobStatus.PROCESSING.value
+        job.started_at = _utcnow()
+        job.processed_credentials = 0
+        job.deleted_count = 0
+        job.failed_count = 0
+        job.errors = {"items": []}
+        await self.session.commit()
+
+        try:
+            await self._run_delete(job)
+        except Exception as e:
+            job.status = VPNDeleteJobStatus.FAILED.value
+            job.last_error = str(e)
+            job.completed_at = _utcnow()
+            await self.session.commit()
+            logger.exception("VPN delete job %s failed", job.id)
+            return
+
+        job.status = VPNDeleteJobStatus.COMPLETED.value
+        job.completed_at = _utcnow()
+        await self.session.commit()
+
+    async def cleanup_old_jobs(self, retention_days: int) -> int:
+        """Delete completed/failed jobs older than the retention window."""
+        cutoff = _utcnow() - timedelta(days=retention_days)
+        terminal = [
+            VPNDeleteJobStatus.COMPLETED.value,
+            VPNDeleteJobStatus.FAILED.value,
+        ]
+        result = await self.session.execute(
+            delete(VPNDeleteJob)
+            .where(VPNDeleteJob.status.in_(terminal))
+            .where(VPNDeleteJob.completed_at.is_not(None))
+            .where(VPNDeleteJob.completed_at < cutoff)
+        )
+        await self.session.commit()
+        return result.rowcount or 0
+
+    async def retry_job(self, job_id: int) -> Optional[VPNDeleteJob]:
+        """Reset a failed job back to pending so the worker picks it up again."""
+        result = await self.session.execute(
+            select(VPNDeleteJob).where(VPNDeleteJob.id == job_id)
+        )
+        job = result.scalar_one_or_none()
+        if job is None:
+            return None
+        if job.status != VPNDeleteJobStatus.FAILED.value:
+            return None
+
+        job.status = VPNDeleteJobStatus.PENDING.value
+        job.started_at = None
+        job.completed_at = None
+        job.last_error = None
+        job.processed_credentials = 0
+        job.deleted_count = 0
+        job.failed_count = 0
+        job.errors = {"items": []}
+        await self.session.commit()
+        return job
+
+    async def delete_job(self, job_id: int) -> bool:
+        """Delete a completed or failed job. Refuses if currently processing."""
+        result = await self.session.execute(
+            select(VPNDeleteJob).where(VPNDeleteJob.id == job_id)
+        )
+        job = result.scalar_one_or_none()
+        if job is None:
+            return False
+        if job.status == VPNDeleteJobStatus.PROCESSING.value:
+            raise ValueError("Cannot delete a job while it is processing")
+        await self.session.execute(
+            delete(VPNDeleteJob).where(VPNDeleteJob.id == job_id)
+        )
+        await self.session.commit()
+        return True
+
+    # ─── internals ─────────────────────────────────────────────────────
+
+    async def _run_delete(self, job: VPNDeleteJob) -> None:
+        """The actual delete work. Resolves targets, then chunks through them."""
+        target_ids = await self._resolve_target_ids(job)
+        job.total_credentials = len(target_ids)
+        await self.session.commit()
+
+        if not target_ids:
+            return
+
+        for chunk_start in range(0, len(target_ids), CHUNK_SIZE):
+            chunk = target_ids[chunk_start : chunk_start + CHUNK_SIZE]
+            await self._process_chunk(chunk, job)
+            await self.session.commit()
+            await asyncio.sleep(0)  # yield to the event loop
+
+    async def _resolve_target_ids(self, job: VPNDeleteJob) -> list[int]:
+        """Build the canonical list of credential ids to delete."""
+        if job.mode == VPNDeleteJobMode.ALL.value:
+            result = await self.session.execute(
+                select(VPNCredential.id).order_by(VPNCredential.id)
+            )
+            return [row[0] for row in result.all()]
+
+        items = (job.target_ids or {}).get("items") or []
+        return [int(i) for i in items]
+
+    async def _process_chunk(self, chunk: list[int], job: VPNDeleteJob) -> None:
+        """Delete one batch of credentials and their R2 objects."""
+        # Step 1: bulk fetch (id, r2_key) for the chunk so we know which
+        # objects to remove from R2.
+        result = await self.session.execute(
+            select(VPNCredential.id, VPNCredential.r2_key).where(
+                VPNCredential.id.in_(chunk)
+            )
+        )
+        rows = list(result.all())
+        found_ids = {row[0] for row in rows}
+        r2_keys = [row[1] for row in rows if row[1]]
+
+        missing = [i for i in chunk if i not in found_ids]
+        for vpn_id in missing:
+            self._record_error(job, f"VPN {vpn_id}: Not found")
+
+        # Step 2: parallel R2 deletes — non-fatal if any fail. Each call
+        # goes through asyncio.to_thread so boto3 does not block the loop.
+        if r2_keys:
+            sem = asyncio.Semaphore(self.settings.VPN_IMPORT_R2_PARALLELISM)
+
+            async def _delete_one(key: str) -> tuple[str, bool]:
+                async with sem:
+                    ok = await asyncio.to_thread(self.r2.delete_object, key)
+                return key, ok
+
+            results = await asyncio.gather(
+                *(_delete_one(k) for k in r2_keys),
+                return_exceptions=True,
+            )
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.warning(
+                        "R2 delete exception during VPN bulk delete: %s", r
+                    )
+                elif isinstance(r, tuple):
+                    key, ok = r
+                    if not ok:
+                        logger.warning(
+                            "R2 delete returned False for key %s", key
+                        )
+
+        # Step 3: bulk delete from the database in one statement
+        if found_ids:
+            await self.session.execute(
+                delete(VPNCredential).where(VPNCredential.id.in_(found_ids))
+            )
+            job.deleted_count += len(found_ids)
+
+        job.processed_credentials += len(chunk)
+
+    def _record_error(self, job: VPNDeleteJob, message: str) -> None:
+        """Append an error to the job's capped error list."""
+        job.failed_count += 1
+        existing = (job.errors or {}).get("items") or []
+        if len(existing) >= MAX_STORED_ERRORS:
+            return
+        new_items = list(existing)
+        new_items.append(message)
+        job.errors = {"items": new_items}

--- a/backend/app/services/vpn_import_service.py
+++ b/backend/app/services/vpn_import_service.py
@@ -1,0 +1,432 @@
+"""Background VPN import job processor.
+
+This service drives the asynchronous VPN credential import flow:
+
+1. ``stage_upload`` is called from the HTTP handler — it uploads the raw ZIP
+   to R2 and creates a ``VPNImportJob`` row in ``pending`` state. The HTTP
+   request returns immediately.
+2. ``vpn_import_job`` (a scheduled task) calls ``claim_next_pending_job``
+   followed by ``process_job`` to do the actual work in the background.
+3. ``process_job`` parses the ZIP cooperatively, deduplicating against the
+   existing VPN pool and uploading per-credential configs to R2 in parallel.
+   It yields to the event loop between chunks so other HTTP requests can
+   make progress.
+4. ``cleanup_old_jobs`` (a daily scheduled task) deletes completed and
+   failed jobs older than ``VPN_IMPORT_RETENTION_DAYS`` so the table does
+   not grow forever.
+"""
+import asyncio
+import hashlib
+import io
+import logging
+import zipfile
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import uuid4
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.models.vpn import VPNCredential
+from app.models.vpn_import_job import VPNImportJob, VPNImportJobStatus
+from app.services.vpn_service import (
+    VPNService,
+    parse_wireguard_config,
+    split_addresses,
+)
+from app.utils.r2_client import R2Client
+
+logger = logging.getLogger(__name__)
+
+
+# Process this many ZIP entries per chunk before yielding to the event loop.
+# Smaller chunks = more responsive HTTP serving, more frequent progress
+# updates. Larger chunks = fewer commits and more efficient bulk inserts.
+CHUNK_SIZE = 100
+
+# Cap the number of error messages stored on the job row so a malformed ZIP
+# does not blow up the JSON column.
+MAX_STORED_ERRORS = 50
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _r2_staged_key(uid: str) -> str:
+    return f"vpn-import-jobs/{uid}.zip"
+
+
+def _should_skip_zip_entry(name: str) -> bool:
+    """True if a ZIP entry should be silently ignored (directory, hidden, system)."""
+    if name.endswith("/"):
+        return True
+    basename = name.rsplit("/", 1)[-1]
+    if basename.startswith(".") or basename.startswith("__"):
+        return True
+    return False
+
+
+class VPNImportService:
+    """Manages the lifecycle of VPN import jobs."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.r2 = R2Client.from_settings()
+        self.settings = get_settings()
+
+    # ─── public API: HTTP handler entry point ──────────────────────────
+
+    async def stage_upload(
+        self,
+        zip_bytes: bytes,
+        filename: Optional[str],
+        assignment_type: str,
+        endpoint: Optional[str],
+        user_id: Optional[int],
+    ) -> VPNImportJob:
+        """
+        Upload the raw ZIP to R2 and create a pending import job.
+
+        Returns the persisted ``VPNImportJob``. The caller is responsible for
+        ``commit()``-ing the surrounding transaction.
+        """
+        uid = uuid4().hex
+        r2_key = _r2_staged_key(uid)
+
+        ok = await asyncio.to_thread(
+            self.r2.put_object, r2_key, zip_bytes, "application/zip"
+        )
+        if not ok:
+            raise RuntimeError("Failed to stage VPN import upload to R2")
+
+        job = VPNImportJob(
+            created_by_user_id=user_id,
+            filename=filename,
+            file_size_bytes=len(zip_bytes),
+            assignment_type=assignment_type,
+            endpoint_override=endpoint,
+            r2_key=r2_key,
+            status=VPNImportJobStatus.PENDING.value,
+        )
+        self.session.add(job)
+        await self.session.flush()
+        return job
+
+    # ─── public API: scheduled task entry points ───────────────────────
+
+    async def claim_next_pending_job(self) -> Optional[VPNImportJob]:
+        """
+        Pick the oldest pending job. Single-process deployment, so a simple
+        ``status='pending'`` filter is sufficient — no row-level locking
+        required.
+        """
+        result = await self.session.execute(
+            select(VPNImportJob)
+            .where(VPNImportJob.status == VPNImportJobStatus.PENDING.value)
+            .order_by(VPNImportJob.created_at)
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def process_job(self, job: VPNImportJob) -> None:
+        """
+        Run a pending job to completion (or to failure).
+
+        Updates progress columns after each chunk so the polling UI can show
+        a live progress bar. On exception, marks the job as failed and
+        re-raises so the caller's logger sees the traceback.
+        """
+        job.status = VPNImportJobStatus.PROCESSING.value
+        job.started_at = _utcnow()
+        job.processed_files = 0
+        job.imported_count = 0
+        job.skipped_count = 0
+        job.error_count = 0
+        job.errors = {"items": []}
+        await self.session.commit()
+
+        try:
+            await self._run_import(job)
+        except Exception as e:
+            job.status = VPNImportJobStatus.FAILED.value
+            job.last_error = str(e)
+            job.completed_at = _utcnow()
+            await self.session.commit()
+            logger.exception("VPN import job %s failed", job.id)
+            return
+
+        # Success path: mark complete and clean up the staged ZIP
+        job.status = VPNImportJobStatus.COMPLETED.value
+        job.completed_at = _utcnow()
+        await self.session.commit()
+
+        if job.r2_key:
+            staged_key = job.r2_key
+            try:
+                await asyncio.to_thread(self.r2.delete_object, staged_key)
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete staged VPN import ZIP %s: %s", staged_key, e
+                )
+            job.r2_key = None
+            await self.session.commit()
+
+    async def cleanup_old_jobs(self, retention_days: int) -> int:
+        """
+        Delete completed/failed jobs whose ``completed_at`` is older than the
+        retention window. Returns the number of rows removed.
+        """
+        cutoff = _utcnow() - timedelta(days=retention_days)
+        terminal = [
+            VPNImportJobStatus.COMPLETED.value,
+            VPNImportJobStatus.FAILED.value,
+        ]
+        result = await self.session.execute(
+            delete(VPNImportJob)
+            .where(VPNImportJob.status.in_(terminal))
+            .where(VPNImportJob.completed_at.is_not(None))
+            .where(VPNImportJob.completed_at < cutoff)
+        )
+        await self.session.commit()
+        return result.rowcount or 0
+
+    async def retry_job(self, job_id: int) -> Optional[VPNImportJob]:
+        """
+        Reset a failed job back to ``pending`` so the worker picks it up
+        again. Returns the updated job, or None if not found / not eligible.
+        """
+        result = await self.session.execute(
+            select(VPNImportJob).where(VPNImportJob.id == job_id)
+        )
+        job = result.scalar_one_or_none()
+        if job is None:
+            return None
+        if job.status != VPNImportJobStatus.FAILED.value:
+            return None
+        if not job.r2_key:
+            # Staged ZIP was deleted on prior success path; can't replay.
+            job.last_error = (
+                "Cannot retry — staged upload no longer available. Re-upload required."
+            )
+            await self.session.commit()
+            return job
+
+        job.status = VPNImportJobStatus.PENDING.value
+        job.started_at = None
+        job.completed_at = None
+        job.last_error = None
+        job.processed_files = 0
+        job.imported_count = 0
+        job.skipped_count = 0
+        job.error_count = 0
+        job.errors = {"items": []}
+        await self.session.commit()
+        return job
+
+    async def delete_job(self, job_id: int) -> bool:
+        """
+        Delete a completed or failed job (and any staged R2 object).
+        Refuses to delete a job that is currently processing.
+        """
+        result = await self.session.execute(
+            select(VPNImportJob).where(VPNImportJob.id == job_id)
+        )
+        job = result.scalar_one_or_none()
+        if job is None:
+            return False
+        if job.status == VPNImportJobStatus.PROCESSING.value:
+            raise ValueError("Cannot delete a job while it is processing")
+
+        if job.r2_key:
+            try:
+                await asyncio.to_thread(self.r2.delete_object, job.r2_key)
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete staged VPN import ZIP %s: %s", job.r2_key, e
+                )
+
+        await self.session.execute(
+            delete(VPNImportJob).where(VPNImportJob.id == job_id)
+        )
+        await self.session.commit()
+        return True
+
+    # ─── internals ─────────────────────────────────────────────────────
+
+    async def _run_import(self, job: VPNImportJob) -> None:
+        """The actual import work, called from process_job inside a try/except."""
+        if not job.r2_key:
+            raise RuntimeError("Job has no staged ZIP to process")
+
+        zip_bytes = await asyncio.to_thread(self.r2.get_object, job.r2_key)
+        if zip_bytes is None:
+            raise RuntimeError(f"Could not download staged ZIP {job.r2_key}")
+
+        try:
+            zf = zipfile.ZipFile(io.BytesIO(zip_bytes), "r")
+        except zipfile.BadZipFile as e:
+            raise RuntimeError(f"Invalid ZIP file: {e}")
+
+        with zf:
+            entries = [n for n in zf.namelist() if not _should_skip_zip_entry(n)]
+            job.total_files = len(entries)
+            await self.session.commit()
+
+            for chunk_start in range(0, len(entries), CHUNK_SIZE):
+                chunk = entries[chunk_start : chunk_start + CHUNK_SIZE]
+                await self._process_chunk(zf, chunk, job)
+                await self.session.commit()
+                # Yield to the event loop so HTTP requests can make progress
+                await asyncio.sleep(0)
+
+    async def _process_chunk(
+        self,
+        zf: zipfile.ZipFile,
+        chunk: list[str],
+        job: VPNImportJob,
+    ) -> None:
+        """
+        Parse, dedup, insert, and R2-upload one batch of ZIP entries.
+
+        Reads each entry from the ZIP (synchronous, but in-memory and fast),
+        parses it via the pure ``parse_wireguard_config`` helper, and then:
+            - Bulk-checks the file_hash set against existing rows in one query
+            - Inserts non-duplicates with ``add_all`` + ``flush`` (one DB
+              round-trip for the whole chunk)
+            - Uploads the per-credential configs to R2 in parallel via
+              ``asyncio.gather`` with a concurrency limit
+        """
+        # Step 1: parse all entries in the chunk
+        parsed_records: list[dict] = []
+        for filename in chunk:
+            try:
+                raw = zf.read(filename)
+                try:
+                    config_text = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    job.skipped_count += 1
+                    continue
+
+                parsed = parse_wireguard_config(
+                    config_text, endpoint_override=job.endpoint_override
+                )
+                file_hash = hashlib.sha256(config_text.encode("utf-8")).hexdigest()
+                parsed_records.append(
+                    {
+                        "filename": filename,
+                        "config_text": config_text,
+                        "file_hash": file_hash,
+                        "parsed": parsed,
+                    }
+                )
+            except ValueError as e:
+                self._record_error(job, filename, str(e))
+            except Exception as e:
+                logger.warning("Unexpected error parsing %s: %s", filename, e)
+                self._record_error(job, filename, str(e))
+
+        if not parsed_records:
+            job.processed_files += len(chunk)
+            return
+
+        # Step 2: dedup against existing credentials in one query
+        hashes = [r["file_hash"] for r in parsed_records]
+        existing_result = await self.session.execute(
+            select(VPNCredential.file_hash).where(VPNCredential.file_hash.in_(hashes))
+        )
+        existing_hashes = {row[0] for row in existing_result.all()}
+
+        # Also dedup within the chunk itself (same file present twice)
+        seen_in_chunk: set[str] = set()
+        new_records: list[dict] = []
+        for rec in parsed_records:
+            h = rec["file_hash"]
+            if h in existing_hashes or h in seen_in_chunk:
+                job.skipped_count += 1
+                continue
+            seen_in_chunk.add(h)
+            new_records.append(rec)
+
+        if not new_records:
+            job.processed_files += len(chunk)
+            return
+
+        # Step 3: build VPNCredential objects and bulk-flush to assign IDs
+        new_credentials: list[VPNCredential] = []
+        for rec in new_records:
+            parsed = rec["parsed"]
+            interface_ip, ipv4, ipv6_local, ipv6_global = split_addresses(
+                parsed["addresses"]
+            )
+            vpn = VPNCredential(
+                interface_ip=interface_ip,
+                ipv4_address=ipv4,
+                ipv6_local=ipv6_local,
+                ipv6_global=ipv6_global,
+                private_key=parsed["private_key"],
+                preshared_key=parsed["preshared_key"],
+                endpoint=parsed["endpoint"],
+                key_type="vpn",
+                mtu=parsed["mtu"],
+                dns=parsed["dns"],
+                public_key=parsed["public_key"],
+                allowed_ips=parsed["allowed_ips"],
+                persistent_keepalive=parsed["persistent_keepalive"],
+                table=parsed["table"],
+                save_config=parsed["save_config"],
+                fwmark=parsed["fwmark"],
+                file_hash=rec["file_hash"],
+                assignment_type=job.assignment_type,
+                is_available=True,
+                is_active=True,
+            )
+            new_credentials.append(vpn)
+            rec["vpn"] = vpn
+
+        self.session.add_all(new_credentials)
+        await self.session.flush()  # assigns ids
+
+        # Step 4: parallel R2 uploads, throttled by a semaphore
+        sem = asyncio.Semaphore(self.settings.VPN_IMPORT_R2_PARALLELISM)
+
+        async def upload_one(rec: dict) -> tuple[VPNCredential, bool]:
+            vpn: VPNCredential = rec["vpn"]
+            r2_key = VPNService._make_r2_key(vpn.id)
+            payload = rec["config_text"].encode("utf-8")
+            async with sem:
+                ok = await asyncio.to_thread(
+                    self.r2.put_object, r2_key, payload, "text/plain"
+                )
+            if ok:
+                vpn.r2_key = r2_key
+            return vpn, ok
+
+        upload_results = await asyncio.gather(
+            *(upload_one(rec) for rec in new_records),
+            return_exceptions=True,
+        )
+
+        for result in upload_results:
+            if isinstance(result, Exception):
+                logger.warning("R2 upload exception during VPN import: %s", result)
+                # Still counts as imported — the lazy fallback in
+                # VPNService.get_raw_config will regenerate from DB fields.
+                continue
+
+        job.imported_count += len(new_records)
+        job.processed_files += len(chunk)
+
+    def _record_error(self, job: VPNImportJob, filename: str, message: str) -> None:
+        """Append a per-file error to the job's capped error list."""
+        job.error_count += 1
+        job.skipped_count += 1
+        existing = (job.errors or {}).get("items") or []
+        if len(existing) >= MAX_STORED_ERRORS:
+            return
+        # Always assign a brand-new outer dict + inner list so SQLAlchemy
+        # detects the change even when MutableDict tracking is unavailable.
+        new_items = list(existing)
+        new_items.append(f"{filename}: {message}")
+        job.errors = {"items": new_items}

--- a/backend/app/services/vpn_service.py
+++ b/backend/app/services/vpn_service.py
@@ -13,10 +13,156 @@ from sqlalchemy.orm import selectinload
 from app.models.user import User
 from app.models.vpn import VPNCredential
 from app.config import get_settings
+from app.utils.r2_client import R2Client
 
 logger = logging.getLogger(__name__)
 
 settings = get_settings()
+
+
+def parse_wireguard_config(
+    config_content: str,
+    endpoint_override: Optional[str] = None,
+) -> dict:
+    """
+    Parse a WireGuard configuration file into a flat dictionary of fields.
+
+    This is a pure function with no side effects so it can be reused by both
+    the synchronous import path and the background import service.
+
+    Args:
+        config_content: Raw text content of the config file
+        endpoint_override: Optional endpoint to use instead of the parsed value
+
+    Returns:
+        Dict with the parsed fields. Keys: ``private_key``, ``preshared_key``,
+        ``addresses`` (list), ``endpoint``, ``mtu``, ``dns``, ``public_key``,
+        ``allowed_ips``, ``persistent_keepalive``, ``table``, ``save_config``,
+        ``fwmark``.
+
+    Raises:
+        ValueError: If required fields (PrivateKey, Address, Endpoint) are missing.
+    """
+    private_key = None
+    addresses: list[str] = []
+    parsed_endpoint = None
+    preshared_key = None
+    mtu = None
+    dns = None
+    public_key = None
+    allowed_ips = None
+    persistent_keepalive = None
+    table = None
+    save_config = None
+    fwmark = None
+
+    for line in config_content.split("\n"):
+        line = line.strip()
+        if line.startswith("PrivateKey"):
+            match = re.match(r"PrivateKey\s*=\s*(.+)", line)
+            if match:
+                private_key = match.group(1).strip()
+        elif line.startswith("PresharedKey"):
+            match = re.match(r"PresharedKey\s*=\s*(.+)", line)
+            if match:
+                preshared_key = match.group(1).strip()
+        elif line.startswith("Address"):
+            match = re.match(r"Address\s*=\s*(.+)", line)
+            if match:
+                addr_str = match.group(1).strip()
+                addresses = [a.strip() for a in addr_str.split(",")]
+        elif line.startswith("Endpoint"):
+            match = re.match(r"Endpoint\s*=\s*(.+)", line)
+            if match:
+                parsed_endpoint = match.group(1).strip()
+        elif line.startswith("MTU"):
+            match = re.match(r"MTU\s*=\s*(.+)", line)
+            if match:
+                mtu = match.group(1).strip()
+        elif line.startswith("DNS"):
+            match = re.match(r"DNS\s*=\s*(.+)", line)
+            if match:
+                dns = match.group(1).strip()
+        elif line.startswith("#") and "DNS" in line:
+            match = re.match(r"#\s*DNS\s*=\s*(.+)", line)
+            if match:
+                dns = match.group(1).strip()
+        elif line.startswith("PublicKey"):
+            match = re.match(r"PublicKey\s*=\s*(.+)", line)
+            if match:
+                public_key = match.group(1).strip()
+        elif line.startswith("AllowedIPs"):
+            match = re.match(r"AllowedIPs\s*=\s*(.+)", line)
+            if match:
+                allowed_ips = match.group(1).strip()
+        elif line.startswith("PersistentKeepalive"):
+            match = re.match(r"PersistentKeepalive\s*=\s*(.+)", line)
+            if match:
+                persistent_keepalive = match.group(1).strip()
+        elif line.startswith("Table"):
+            match = re.match(r"Table\s*=\s*(.+)", line)
+            if match:
+                table = match.group(1).strip()
+        elif line.startswith("SaveConfig"):
+            match = re.match(r"SaveConfig\s*=\s*(.+)", line)
+            if match:
+                save_config = match.group(1).strip()
+        elif line.startswith("FwMark"):
+            match = re.match(r"FwMark\s*=\s*(.+)", line)
+            if match:
+                fwmark = match.group(1).strip()
+
+    final_endpoint = endpoint_override or parsed_endpoint
+
+    missing = []
+    if not private_key:
+        missing.append("PrivateKey")
+    if not addresses:
+        missing.append("Address")
+    if not final_endpoint:
+        missing.append("Endpoint")
+    if missing:
+        raise ValueError(
+            f"Invalid WireGuard config - missing required fields: {', '.join(missing)}"
+        )
+
+    return {
+        "private_key": private_key,
+        "preshared_key": preshared_key,
+        "addresses": addresses,
+        "endpoint": final_endpoint,
+        "mtu": mtu,
+        "dns": dns,
+        "public_key": public_key,
+        "allowed_ips": allowed_ips,
+        "persistent_keepalive": persistent_keepalive,
+        "table": table,
+        "save_config": save_config,
+        "fwmark": fwmark,
+    }
+
+
+def split_addresses(addresses: list[str]) -> tuple[str, Optional[str], Optional[str], Optional[str]]:
+    """
+    Split a list of WireGuard interface addresses into the per-family columns.
+
+    Returns ``(interface_ip, ipv4_address, ipv6_local, ipv6_global)``.
+    """
+    interface_ip = ",".join(addresses)
+    ipv4_address: Optional[str] = None
+    ipv6_local: Optional[str] = None
+    ipv6_global: Optional[str] = None
+
+    for addr in addresses:
+        ip = addr.split("/")[0]
+        if "." in ip:  # IPv4
+            ipv4_address = ip
+        elif ip.startswith("fd00:") or ip.startswith("fe80:"):
+            ipv6_local = ip
+        elif ":" in ip:
+            ipv6_global = ip
+
+    return interface_ip, ipv4_address, ipv6_local, ipv6_global
 
 
 class VPNService:
@@ -25,52 +171,31 @@ class VPNService:
     def __init__(self, session: AsyncSession):
         """Initialize VPN service."""
         self.session = session
+        self._r2: Optional[R2Client] = None
 
     # ─── R2 helpers ──────────────────────────────────────────────────
 
-    def _get_r2_client(self):
-        """Get an S3 client configured for Cloudflare R2."""
-        import boto3
-        from botocore.config import Config as BotoConfig
-        return boto3.client(
-            "s3",
-            endpoint_url=f"https://{settings.R2_ACCOUNT_ID}.r2.cloudflarestorage.com",
-            aws_access_key_id=settings.R2_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
-            region_name="auto",
-            config=BotoConfig(signature_version="s3v4"),
-        )
+    @property
+    def r2(self) -> R2Client:
+        """Lazy-initialized shared R2 client."""
+        if self._r2 is None:
+            self._r2 = R2Client.from_settings()
+        return self._r2
 
     def _upload_to_r2(self, key: str, data: bytes) -> bool:
-        """Upload raw VPN config to R2."""
-        try:
-            s3 = self._get_r2_client()
-            s3.put_object(Bucket=settings.R2_BUCKET, Key=key, Body=data, ContentType="text/plain")
+        """Upload raw VPN config to R2 (synchronous)."""
+        ok = self.r2.put_object(key, data, content_type="text/plain")
+        if ok:
             logger.info("Uploaded VPN config to R2: %s", key)
-            return True
-        except Exception as e:
-            logger.error("R2 upload failed for %s: %s", key, e)
-            return False
+        return ok
 
     def _download_from_r2(self, key: str) -> Optional[bytes]:
-        """Download raw VPN config from R2."""
-        try:
-            s3 = self._get_r2_client()
-            response = s3.get_object(Bucket=settings.R2_BUCKET, Key=key)
-            return response["Body"].read()
-        except Exception as e:
-            logger.error("R2 download failed for %s: %s", key, e)
-            return None
+        """Download raw VPN config from R2 (synchronous)."""
+        return self.r2.get_object(key)
 
     def _delete_from_r2(self, key: str) -> bool:
-        """Delete a VPN config from R2."""
-        try:
-            s3 = self._get_r2_client()
-            s3.delete_object(Bucket=settings.R2_BUCKET, Key=key)
-            return True
-        except Exception as e:
-            logger.error("R2 delete failed for %s: %s", key, e)
-            return False
+        """Delete a VPN config from R2 (synchronous)."""
+        return self.r2.delete_object(key)
 
     @staticmethod
     def _make_r2_key(credential_id: int) -> str:
@@ -658,11 +783,8 @@ class VPNService:
         """
         Parse a WireGuard config file and create a VPN credential.
 
-        Validates that the file contains required WireGuard fields:
-        - PrivateKey (under [Interface]) - REQUIRED
-        - Address (under [Interface]) - REQUIRED
-        - Endpoint (under [Peer]) - REQUIRED (parsed from config or provided)
-        - PresharedKey (under [Peer]) - OPTIONAL (provides post-quantum security)
+        Delegates parsing to ``parse_wireguard_config`` (a pure helper) and
+        handles the database + R2 side effects.
 
         Args:
             config_content: Raw text content of the config file
@@ -676,110 +798,8 @@ class VPNService:
         Raises:
             ValueError: If config is missing required fields
         """
-        # Required fields
-        private_key = None
-        addresses = []
-        parsed_endpoint = None
-
-        # Optional fields (preserve from original config)
-        preshared_key = None
-        mtu = None
-        dns = None
-        public_key = None
-        allowed_ips = None
-        persistent_keepalive = None
-        table = None
-        save_config = None
-        fwmark = None
-
-        # Parse the config
-        for line in config_content.split('\n'):
-            line = line.strip()
-            if line.startswith('PrivateKey'):
-                match = re.match(r'PrivateKey\s*=\s*(.+)', line)
-                if match:
-                    private_key = match.group(1).strip()
-            elif line.startswith('PresharedKey'):
-                match = re.match(r'PresharedKey\s*=\s*(.+)', line)
-                if match:
-                    preshared_key = match.group(1).strip()
-            elif line.startswith('Address'):
-                match = re.match(r'Address\s*=\s*(.+)', line)
-                if match:
-                    # Parse comma-separated addresses
-                    addr_str = match.group(1).strip()
-                    addresses = [a.strip() for a in addr_str.split(',')]
-            elif line.startswith('Endpoint'):
-                match = re.match(r'Endpoint\s*=\s*(.+)', line)
-                if match:
-                    parsed_endpoint = match.group(1).strip()
-            elif line.startswith('MTU'):
-                match = re.match(r'MTU\s*=\s*(.+)', line)
-                if match:
-                    mtu = match.group(1).strip()
-            elif line.startswith('DNS'):
-                match = re.match(r'DNS\s*=\s*(.+)', line)
-                if match:
-                    dns = match.group(1).strip()
-            elif line.startswith('#') and 'DNS' in line:
-                match = re.match(r'#\s*DNS\s*=\s*(.+)', line)
-                if match:
-                    dns = match.group(1).strip()
-            elif line.startswith('PublicKey'):
-                match = re.match(r'PublicKey\s*=\s*(.+)', line)
-                if match:
-                    public_key = match.group(1).strip()
-            elif line.startswith('AllowedIPs'):
-                match = re.match(r'AllowedIPs\s*=\s*(.+)', line)
-                if match:
-                    allowed_ips = match.group(1).strip()
-            elif line.startswith('PersistentKeepalive'):
-                match = re.match(r'PersistentKeepalive\s*=\s*(.+)', line)
-                if match:
-                    persistent_keepalive = match.group(1).strip()
-            elif line.startswith('Table'):
-                match = re.match(r'Table\s*=\s*(.+)', line)
-                if match:
-                    table = match.group(1).strip()
-            elif line.startswith('SaveConfig'):
-                match = re.match(r'SaveConfig\s*=\s*(.+)', line)
-                if match:
-                    save_config = match.group(1).strip()
-            elif line.startswith('FwMark'):
-                match = re.match(r'FwMark\s*=\s*(.+)', line)
-                if match:
-                    fwmark = match.group(1).strip()
-
-        # Use provided endpoint or parsed endpoint
-        final_endpoint = endpoint or parsed_endpoint
-
-        # Validate required fields (PresharedKey is optional)
-        missing_fields = []
-        if not private_key:
-            missing_fields.append("PrivateKey")
-        if not addresses:
-            missing_fields.append("Address")
-        if not final_endpoint:
-            missing_fields.append("Endpoint")
-
-        if missing_fields:
-            raise ValueError(f"Invalid WireGuard config - missing required fields: {', '.join(missing_fields)}")
-
-        # Extract IP addresses (no spaces after commas)
-        interface_ip = ','.join(addresses)
-        ipv4_address = None
-        ipv6_local = None
-        ipv6_global = None
-
-        for addr in addresses:
-            # Remove CIDR notation
-            ip = addr.split('/')[0]
-            if '.' in ip:  # IPv4
-                ipv4_address = ip
-            elif ip.startswith('fd00:') or ip.startswith('fe80:'):  # Link-local IPv6
-                ipv6_local = ip
-            elif ':' in ip:  # Other IPv6
-                ipv6_global = ip
+        parsed = parse_wireguard_config(config_content, endpoint_override=endpoint)
+        interface_ip, ipv4_address, ipv6_local, ipv6_global = split_addresses(parsed["addresses"])
 
         # Generate file hash to detect duplicates
         file_hash = hashlib.sha256(config_content.encode()).hexdigest()
@@ -791,37 +811,34 @@ class VPNService:
         if existing.scalar_one_or_none():
             return None  # Skip duplicate
 
-        # Create the credential (preserve all fields from original config)
         vpn = VPNCredential(
             interface_ip=interface_ip,
             ipv4_address=ipv4_address,
             ipv6_local=ipv6_local,
             ipv6_global=ipv6_global,
-            private_key=private_key,
-            preshared_key=preshared_key,
-            endpoint=final_endpoint,
-            key_type="vpn",  # Generic type
-            # Optional fields from original config (NULL if not present)
-            mtu=mtu,
-            dns=dns,
-            public_key=public_key,
-            allowed_ips=allowed_ips,
-            persistent_keepalive=persistent_keepalive,
-            table=table,
-            save_config=save_config,
-            fwmark=fwmark,
+            private_key=parsed["private_key"],
+            preshared_key=parsed["preshared_key"],
+            endpoint=parsed["endpoint"],
+            key_type="vpn",
+            mtu=parsed["mtu"],
+            dns=parsed["dns"],
+            public_key=parsed["public_key"],
+            allowed_ips=parsed["allowed_ips"],
+            persistent_keepalive=parsed["persistent_keepalive"],
+            table=parsed["table"],
+            save_config=parsed["save_config"],
+            fwmark=parsed["fwmark"],
             file_hash=file_hash,
-            assignment_type=assignment_type,  # Assignment type from import
+            assignment_type=assignment_type,
             is_available=True,
-            is_active=True
+            is_active=True,
         )
 
         self.session.add(vpn)
-        await self.session.flush()  # Get auto-generated ID for R2 key
+        await self.session.flush()
 
-        # Upload raw config to R2
         r2_key = self._make_r2_key(vpn.id)
-        if self._upload_to_r2(r2_key, config_content.encode('utf-8')):
+        if self._upload_to_r2(r2_key, config_content.encode("utf-8")):
             vpn.r2_key = r2_key
         else:
             logger.warning(

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -56,6 +56,8 @@ async def start_scheduler():
     from app.tasks.agent_task_timeout import schedule_agent_task_timeout_job
     from app.tasks.vpn_import import schedule_vpn_import_job
     from app.tasks.vpn_import_cleanup import schedule_vpn_import_cleanup_job
+    from app.tasks.vpn_delete import schedule_vpn_delete_job
+    from app.tasks.vpn_delete_cleanup import schedule_vpn_delete_cleanup_job
 
     sched = get_scheduler()
 
@@ -73,6 +75,8 @@ async def start_scheduler():
     schedule_agent_task_timeout_job(sched)
     schedule_vpn_import_job(sched)
     schedule_vpn_import_cleanup_job(sched)
+    schedule_vpn_delete_job(sched)
+    schedule_vpn_delete_cleanup_job(sched)
 
     # Register status heartbeat job (updates database every 60 seconds)
     sched.add_job(

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -54,6 +54,8 @@ async def start_scheduler():
     from app.tasks.license_slot_reaper import schedule_license_slot_reaper_job
     from app.tasks.keycloak_sync import schedule_keycloak_sync_job
     from app.tasks.agent_task_timeout import schedule_agent_task_timeout_job
+    from app.tasks.vpn_import import schedule_vpn_import_job
+    from app.tasks.vpn_import_cleanup import schedule_vpn_import_cleanup_job
 
     sched = get_scheduler()
 
@@ -69,6 +71,8 @@ async def start_scheduler():
     schedule_license_slot_reaper_job(sched)
     schedule_keycloak_sync_job(sched)
     schedule_agent_task_timeout_job(sched)
+    schedule_vpn_import_job(sched)
+    schedule_vpn_import_cleanup_job(sched)
 
     # Register status heartbeat job (updates database every 60 seconds)
     sched.add_job(

--- a/backend/app/tasks/vpn_delete.py
+++ b/backend/app/tasks/vpn_delete.py
@@ -1,0 +1,47 @@
+"""Background job that processes pending VPN bulk-delete jobs."""
+import logging
+
+from app.database import AsyncSessionLocal
+from app.services.vpn_delete_service import VPNDeleteService
+
+logger = logging.getLogger(__name__)
+
+
+# Drain a small backlog per tick rather than waiting another 30s for the
+# next pending job.
+MAX_JOBS_PER_TICK = 5
+
+
+async def vpn_delete_job():
+    """
+    Pick up pending VPN bulk-delete jobs and process them cooperatively.
+
+    Runs in the same event loop as the FastAPI app, so each chunk of work
+    yields back via ``await asyncio.sleep(0)`` so HTTP requests can still
+    be served while a large delete runs.
+    """
+    async with AsyncSessionLocal() as session:
+        service = VPNDeleteService(session)
+        for _ in range(MAX_JOBS_PER_TICK):
+            job = await service.claim_next_pending_job()
+            if job is None:
+                return
+            try:
+                await service.process_job(job)
+            except Exception:
+                logger.exception("Unhandled error in VPN delete job %s", job.id)
+                # Continue draining; the failed job is already marked failed
+                # by process_job's own except block.
+
+
+def schedule_vpn_delete_job(scheduler):
+    """Register the VPN delete job with APScheduler (every 30 seconds)."""
+    scheduler.add_job(
+        func=vpn_delete_job,
+        trigger="interval",
+        seconds=30,
+        id="vpn_delete",
+        name="VPN Bulk Delete Job Processor",
+        replace_existing=True,
+    )
+    logger.info("Scheduled VPN delete job to run every 30 seconds")

--- a/backend/app/tasks/vpn_delete_cleanup.py
+++ b/backend/app/tasks/vpn_delete_cleanup.py
@@ -1,0 +1,31 @@
+"""Daily cleanup of old VPN bulk-delete jobs."""
+import logging
+
+from app.config import get_settings
+from app.database import AsyncSessionLocal
+from app.services.vpn_delete_service import VPNDeleteService
+
+logger = logging.getLogger(__name__)
+
+
+async def vpn_delete_cleanup_job():
+    """Delete completed/failed VPN delete jobs older than the retention window."""
+    settings = get_settings()
+    async with AsyncSessionLocal() as session:
+        service = VPNDeleteService(session)
+        deleted = await service.cleanup_old_jobs(settings.VPN_IMPORT_RETENTION_DAYS)
+        if deleted:
+            logger.info("VPN delete cleanup: deleted %d old job(s)", deleted)
+
+
+def schedule_vpn_delete_cleanup_job(scheduler):
+    """Register the cleanup job with APScheduler (daily)."""
+    scheduler.add_job(
+        func=vpn_delete_cleanup_job,
+        trigger="interval",
+        hours=24,
+        id="vpn_delete_cleanup",
+        name="VPN Delete Job Cleanup",
+        replace_existing=True,
+    )
+    logger.info("Scheduled VPN delete cleanup job to run daily")

--- a/backend/app/tasks/vpn_import.py
+++ b/backend/app/tasks/vpn_import.py
@@ -1,0 +1,47 @@
+"""Background job that processes pending VPN import jobs."""
+import logging
+
+from app.database import AsyncSessionLocal
+from app.services.vpn_import_service import VPNImportService
+
+logger = logging.getLogger(__name__)
+
+
+# Number of jobs to process per scheduler tick. Normally there's at most one,
+# but loop a few times to drain a small backlog without waiting another tick.
+MAX_JOBS_PER_TICK = 5
+
+
+async def vpn_import_job():
+    """
+    Pick up pending VPN import jobs and process them cooperatively.
+
+    Runs in the same event loop as the FastAPI app, so each call to
+    ``process_job`` is responsible for yielding (via ``await asyncio.sleep(0)``
+    between chunks) so HTTP requests can still be served.
+    """
+    async with AsyncSessionLocal() as session:
+        service = VPNImportService(session)
+        for _ in range(MAX_JOBS_PER_TICK):
+            job = await service.claim_next_pending_job()
+            if job is None:
+                return
+            try:
+                await service.process_job(job)
+            except Exception:
+                logger.exception("Unhandled error in VPN import job %s", job.id)
+                # Continue to next pending job; the failed one is already
+                # marked as failed by process_job's own except block.
+
+
+def schedule_vpn_import_job(scheduler):
+    """Register the VPN import job with APScheduler (every 30 seconds)."""
+    scheduler.add_job(
+        func=vpn_import_job,
+        trigger="interval",
+        seconds=30,
+        id="vpn_import",
+        name="VPN Import Job Processor",
+        replace_existing=True,
+    )
+    logger.info("Scheduled VPN import job to run every 30 seconds")

--- a/backend/app/tasks/vpn_import_cleanup.py
+++ b/backend/app/tasks/vpn_import_cleanup.py
@@ -1,0 +1,31 @@
+"""Daily cleanup of old VPN import jobs."""
+import logging
+
+from app.config import get_settings
+from app.database import AsyncSessionLocal
+from app.services.vpn_import_service import VPNImportService
+
+logger = logging.getLogger(__name__)
+
+
+async def vpn_import_cleanup_job():
+    """Delete completed/failed VPN import jobs older than the retention window."""
+    settings = get_settings()
+    async with AsyncSessionLocal() as session:
+        service = VPNImportService(session)
+        deleted = await service.cleanup_old_jobs(settings.VPN_IMPORT_RETENTION_DAYS)
+        if deleted:
+            logger.info("VPN import cleanup: deleted %d old job(s)", deleted)
+
+
+def schedule_vpn_import_cleanup_job(scheduler):
+    """Register the cleanup job with APScheduler (daily)."""
+    scheduler.add_job(
+        func=vpn_import_cleanup_job,
+        trigger="interval",
+        hours=24,
+        id="vpn_import_cleanup",
+        name="VPN Import Job Cleanup",
+        replace_existing=True,
+    )
+    logger.info("Scheduled VPN import cleanup job to run daily")

--- a/backend/app/utils/r2_client.py
+++ b/backend/app/utils/r2_client.py
@@ -1,0 +1,82 @@
+"""Shared Cloudflare R2 client wrapper.
+
+A thin synchronous boto3 wrapper used by services that need to read or write
+objects in the Cloudflare R2 bucket configured via R2_* settings. Callers in
+async code paths must offload these calls via ``asyncio.to_thread`` so the
+event loop is not blocked.
+"""
+import logging
+from typing import Optional
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class R2Client:
+    """Synchronous Cloudflare R2 client.
+
+    Wraps boto3 with R2-specific configuration. All methods are blocking and
+    must be called via ``asyncio.to_thread(...)`` from async code.
+    """
+
+    def __init__(self, account_id: str, access_key_id: str, secret_access_key: str, bucket: str):
+        self.account_id = account_id
+        self.access_key_id = access_key_id
+        self.secret_access_key = secret_access_key
+        self.bucket = bucket
+        self._client = None
+
+    @classmethod
+    def from_settings(cls) -> "R2Client":
+        """Build a client from the application settings."""
+        settings = get_settings()
+        return cls(
+            account_id=settings.R2_ACCOUNT_ID,
+            access_key_id=settings.R2_ACCESS_KEY_ID,
+            secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+            bucket=settings.R2_BUCKET,
+        )
+
+    def _get_boto_client(self):
+        if self._client is None:
+            import boto3
+            from botocore.config import Config as BotoConfig
+            self._client = boto3.client(
+                "s3",
+                endpoint_url=f"https://{self.account_id}.r2.cloudflarestorage.com",
+                aws_access_key_id=self.access_key_id,
+                aws_secret_access_key=self.secret_access_key,
+                region_name="auto",
+                config=BotoConfig(signature_version="s3v4"),
+            )
+        return self._client
+
+    def put_object(self, key: str, data: bytes, content_type: str = "application/octet-stream") -> bool:
+        """Upload bytes to R2. Returns True on success."""
+        try:
+            self._get_boto_client().put_object(
+                Bucket=self.bucket, Key=key, Body=data, ContentType=content_type
+            )
+            return True
+        except Exception as e:
+            logger.error("R2 put_object failed for %s: %s", key, e)
+            return False
+
+    def get_object(self, key: str) -> Optional[bytes]:
+        """Download an R2 object as bytes. Returns None on failure."""
+        try:
+            response = self._get_boto_client().get_object(Bucket=self.bucket, Key=key)
+            return response["Body"].read()
+        except Exception as e:
+            logger.error("R2 get_object failed for %s: %s", key, e)
+            return None
+
+    def delete_object(self, key: str) -> bool:
+        """Delete an R2 object. Returns True on success."""
+        try:
+            self._get_boto_client().delete_object(Bucket=self.bucket, Key=key)
+            return True
+        except Exception as e:
+            logger.error("R2 delete_object failed for %s: %s", key, e)
+            return False

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -4,4 +4,4 @@
 # - MAJOR: Breaking changes or significant architectural changes
 # - MINOR: New features, functionality additions
 # - PATCH: Bug fixes, small improvements
-VERSION = "1.4.2"
+VERSION = "1.5.0"

--- a/backend/migrations/versions/20260409_000000_add_vpn_import_jobs.py
+++ b/backend/migrations/versions/20260409_000000_add_vpn_import_jobs.py
@@ -1,0 +1,89 @@
+"""Add vpn_import_jobs table for async VPN credential imports
+
+Revision ID: 20260409_000000
+Revises: 20260330_000000
+Create Date: 2026-04-09 00:00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "20260409_000000"
+down_revision = "20260330_000000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create vpn_import_jobs table."""
+    op.create_table(
+        "vpn_import_jobs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("filename", sa.String(length=255), nullable=True),
+        sa.Column("file_size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("assignment_type", sa.String(length=50), nullable=False),
+        sa.Column("endpoint_override", sa.String(length=255), nullable=True),
+        sa.Column("r2_key", sa.String(length=255), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("total_files", sa.Integer(), nullable=True),
+        sa.Column(
+            "processed_files",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "imported_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "skipped_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "error_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("errors", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_vpn_import_jobs_status", "vpn_import_jobs", ["status"]
+    )
+    op.create_index(
+        "idx_vpn_import_jobs_created_at", "vpn_import_jobs", ["created_at"]
+    )
+
+
+def downgrade():
+    """Drop vpn_import_jobs table."""
+    op.drop_index("idx_vpn_import_jobs_created_at", table_name="vpn_import_jobs")
+    op.drop_index("idx_vpn_import_jobs_status", table_name="vpn_import_jobs")
+    op.drop_table("vpn_import_jobs")

--- a/backend/migrations/versions/20260409_000001_add_vpn_delete_jobs.py
+++ b/backend/migrations/versions/20260409_000001_add_vpn_delete_jobs.py
@@ -1,0 +1,87 @@
+"""Add vpn_delete_jobs table for async bulk credential deletion
+
+Revision ID: 20260409_000001
+Revises: 20260409_000000
+Create Date: 2026-04-09 00:00:01
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "20260409_000001"
+down_revision = "20260409_000000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create vpn_delete_jobs table."""
+    op.create_table(
+        "vpn_delete_jobs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "mode",
+            sa.String(length=20),
+            server_default="by_ids",
+            nullable=False,
+        ),
+        sa.Column(
+            "target_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("total_credentials", sa.Integer(), nullable=True),
+        sa.Column(
+            "processed_credentials",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "deleted_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "failed_count",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("errors", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_vpn_delete_jobs_status", "vpn_delete_jobs", ["status"]
+    )
+    op.create_index(
+        "idx_vpn_delete_jobs_created_at", "vpn_delete_jobs", ["created_at"]
+    )
+
+
+def downgrade():
+    """Drop vpn_delete_jobs table."""
+    op.drop_index("idx_vpn_delete_jobs_created_at", table_name="vpn_delete_jobs")
+    op.drop_index("idx_vpn_delete_jobs_status", table_name="vpn_delete_jobs")
+    op.drop_table("vpn_delete_jobs")

--- a/backend/tests/unit/test_vpn_delete_service.py
+++ b/backend/tests/unit/test_vpn_delete_service.py
@@ -1,0 +1,343 @@
+"""
+Unit tests for VPNDeleteService.
+
+Covers job lifecycle, cooperative chunked processing, missing-id error
+recording, retry, cleanup, delete-all mode, and the manual delete-job
+admin endpoint.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vpn import VPNCredential
+from app.models.vpn_delete_job import (
+    VPNDeleteJob,
+    VPNDeleteJobMode,
+    VPNDeleteJobStatus,
+)
+from app.services.vpn_delete_service import VPNDeleteService
+from app.utils.r2_client import R2Client
+
+
+@pytest.fixture
+def mock_r2(monkeypatch):
+    """In-memory R2 stand-in shared with the import-service tests."""
+    storage: dict[str, bytes] = {}
+
+    class _FakeR2:
+        def __init__(self):
+            self.bucket = "test-bucket"
+
+        def put_object(self, key, data, content_type=None):
+            storage[key] = bytes(data)
+            return True
+
+        def get_object(self, key):
+            return storage.get(key)
+
+        def delete_object(self, key):
+            storage.pop(key, None)
+            return True
+
+    monkeypatch.setattr(
+        R2Client, "from_settings", classmethod(lambda cls: _FakeR2())
+    )
+    return storage
+
+
+def _make_credential(idx: int, with_r2_key: bool = True) -> VPNCredential:
+    return VPNCredential(
+        interface_ip=f"10.66.66.{idx}/32",
+        ipv4_address=f"10.66.66.{idx}",
+        private_key=f"privkey-{idx}",
+        endpoint="vpn.example.com:51820",
+        key_type="vpn",
+        is_available=True,
+        is_active=True,
+        r2_key=f"vpn-configs/{idx}.conf" if with_r2_key else None,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNDeleteServiceQueueing:
+    """HTTP-handler entry points: queue_delete_by_ids / queue_delete_all."""
+
+    async def test_queue_delete_by_ids_creates_pending_job(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=[3, 1, 2, 1], user_id=None)
+        await db_session.commit()
+
+        assert job.id is not None
+        assert job.status == VPNDeleteJobStatus.PENDING.value
+        assert job.mode == VPNDeleteJobMode.BY_IDS.value
+        # Should be deduped and sorted
+        assert job.target_ids == {"items": [1, 2, 3]}
+        assert job.total_credentials == 3
+
+    async def test_queue_delete_by_ids_rejects_empty(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        with pytest.raises(ValueError):
+            await service.queue_delete_by_ids(vpn_ids=[], user_id=None)
+
+    async def test_queue_delete_all_creates_pending_job(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_all(user_id=None)
+        await db_session.commit()
+
+        assert job.status == VPNDeleteJobStatus.PENDING.value
+        assert job.mode == VPNDeleteJobMode.ALL.value
+        assert job.target_ids is None
+        assert job.total_credentials is None  # resolved at processing time
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNDeleteServiceProcessing:
+    """End-to-end processing of delete jobs."""
+
+    async def test_process_by_ids_deletes_credentials(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        # Pre-seed three credentials
+        creds = [_make_credential(i) for i in range(1, 4)]
+        db_session.add_all(creds)
+        await db_session.commit()
+        # Pre-populate fake R2 so we can verify deletes
+        for c in creds:
+            mock_r2[c.r2_key] = b"x"
+        ids = [c.id for c in creds]
+
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=ids, user_id=None)
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNDeleteJobStatus.COMPLETED.value
+        assert job.total_credentials == 3
+        assert job.processed_credentials == 3
+        assert job.deleted_count == 3
+        assert job.failed_count == 0
+
+        # All three credentials are gone from the DB and R2
+        result = await db_session.execute(select(VPNCredential))
+        assert list(result.scalars().all()) == []
+        for c in creds:
+            assert c.r2_key not in mock_r2
+
+    async def test_process_records_missing_ids_as_errors(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        c = _make_credential(1)
+        db_session.add(c)
+        await db_session.commit()
+        mock_r2[c.r2_key] = b"x"
+
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=[c.id, 9999], user_id=None)
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNDeleteJobStatus.COMPLETED.value
+        assert job.deleted_count == 1
+        assert job.failed_count == 1
+        items = (job.errors or {}).get("items", [])
+        assert any("9999" in s for s in items)
+
+    async def test_process_skips_r2_for_credentials_without_key(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        c = _make_credential(1, with_r2_key=False)
+        db_session.add(c)
+        await db_session.commit()
+
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=[c.id], user_id=None)
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNDeleteJobStatus.COMPLETED.value
+        assert job.deleted_count == 1
+
+    async def test_process_delete_all_targets_every_credential(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        creds = [_make_credential(i) for i in range(1, 6)]
+        db_session.add_all(creds)
+        await db_session.commit()
+        for c in creds:
+            mock_r2[c.r2_key] = b"x"
+
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_all(user_id=None)
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNDeleteJobStatus.COMPLETED.value
+        assert job.total_credentials == 5
+        assert job.deleted_count == 5
+
+        result = await db_session.execute(select(VPNCredential))
+        assert list(result.scalars().all()) == []
+
+    async def test_process_chunks_large_id_lists(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        # 250 credentials > CHUNK_SIZE (200) — should require two chunks
+        creds = [_make_credential(i) for i in range(1, 251)]
+        db_session.add_all(creds)
+        await db_session.commit()
+        ids = [c.id for c in creds]
+
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=ids, user_id=None)
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNDeleteJobStatus.COMPLETED.value
+        assert job.deleted_count == 250
+        assert job.processed_credentials == 250
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNDeleteServiceClaim:
+    """Job claiming."""
+
+    async def test_claim_returns_oldest_pending(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        older = await service.queue_delete_by_ids(vpn_ids=[1], user_id=None)
+        await db_session.commit()
+        older.created_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        await db_session.commit()
+
+        await service.queue_delete_by_ids(vpn_ids=[2], user_id=None)
+        await db_session.commit()
+
+        claimed = await service.claim_next_pending_job()
+        assert claimed is not None
+        assert claimed.id == older.id
+
+    async def test_claim_returns_none_when_no_pending(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        claimed = await service.claim_next_pending_job()
+        assert claimed is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNDeleteServiceCleanup:
+    """Retention cleanup."""
+
+    async def test_cleanup_deletes_old_completed_jobs(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        old = VPNDeleteJob(
+            mode=VPNDeleteJobMode.BY_IDS.value,
+            status=VPNDeleteJobStatus.COMPLETED.value,
+            completed_at=datetime.now(timezone.utc) - timedelta(days=60),
+        )
+        fresh = VPNDeleteJob(
+            mode=VPNDeleteJobMode.BY_IDS.value,
+            status=VPNDeleteJobStatus.COMPLETED.value,
+            completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([old, fresh])
+        await db_session.commit()
+
+        service = VPNDeleteService(db_session)
+        deleted = await service.cleanup_old_jobs(retention_days=30)
+        assert deleted == 1
+
+        result = await db_session.execute(select(VPNDeleteJob))
+        remaining = list(result.scalars().all())
+        assert len(remaining) == 1
+        assert remaining[0].id == fresh.id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNDeleteServiceRetryAndDelete:
+    """Retry and manual job-row delete behaviors."""
+
+    async def test_retry_failed_job(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=[1, 2], user_id=None)
+        await db_session.commit()
+
+        job.status = VPNDeleteJobStatus.FAILED.value
+        job.last_error = "boom"
+        await db_session.commit()
+
+        result = await service.retry_job(job.id)
+        assert result is not None
+        assert result.status == VPNDeleteJobStatus.PENDING.value
+        assert result.last_error is None
+
+    async def test_retry_non_failed_returns_none(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNDeleteService(db_session)
+        job = await service.queue_delete_by_ids(vpn_ids=[1], user_id=None)
+        await db_session.commit()
+
+        result = await service.retry_job(job.id)
+        assert result is None
+
+    async def test_delete_completed_job(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        job = VPNDeleteJob(
+            mode=VPNDeleteJobMode.BY_IDS.value,
+            status=VPNDeleteJobStatus.COMPLETED.value,
+            completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add(job)
+        await db_session.commit()
+
+        service = VPNDeleteService(db_session)
+        ok = await service.delete_job(job.id)
+        assert ok is True
+
+        result = await db_session.execute(
+            select(VPNDeleteJob).where(VPNDeleteJob.id == job.id)
+        )
+        assert result.scalar_one_or_none() is None
+
+    async def test_delete_processing_job_refuses(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        job = VPNDeleteJob(
+            mode=VPNDeleteJobMode.BY_IDS.value,
+            status=VPNDeleteJobStatus.PROCESSING.value,
+        )
+        db_session.add(job)
+        await db_session.commit()
+
+        service = VPNDeleteService(db_session)
+        with pytest.raises(ValueError):
+            await service.delete_job(job.id)

--- a/backend/tests/unit/test_vpn_import_service.py
+++ b/backend/tests/unit/test_vpn_import_service.py
@@ -1,0 +1,479 @@
+"""
+Unit tests for VPNImportService.
+
+Covers job lifecycle, cooperative chunked processing, deduplication,
+error handling, retry, cleanup, and the dispatcher task.
+"""
+import io
+import zipfile
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vpn import VPNCredential
+from app.models.vpn_import_job import VPNImportJob, VPNImportJobStatus
+from app.services.vpn_import_service import VPNImportService
+from app.utils.r2_client import R2Client
+
+
+# Two valid WireGuard configs and one invalid one
+SAMPLE_CONFIG_1 = """[Interface]
+PrivateKey = oK56DE9Ue9zK76rAc8pBl6opph+1v36lm7cXXsQKrQM=
+Address = 10.66.66.2/32
+
+[Peer]
+PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=
+Endpoint = vpn.example.com:51820
+AllowedIPs = 0.0.0.0/0
+"""
+
+SAMPLE_CONFIG_2 = """[Interface]
+PrivateKey = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+Address = 10.66.66.3/32
+
+[Peer]
+PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=
+Endpoint = vpn.example.com:51820
+AllowedIPs = 0.0.0.0/0
+"""
+
+INVALID_CONFIG = """[Interface]
+# Missing PrivateKey, Address, Endpoint
+"""
+
+
+def _make_zip(files: dict[str, str]) -> bytes:
+    """Build a ZIP archive in memory from a {name: content} mapping."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def mock_r2(monkeypatch):
+    """
+    Replace ``R2Client.from_settings`` with an in-memory fake so the import
+    service can be exercised without touching the network.
+    """
+    storage: dict[str, bytes] = {}
+
+    class _FakeR2:
+        def __init__(self):
+            self.bucket = "test-bucket"
+
+        def put_object(self, key, data, content_type=None):
+            storage[key] = bytes(data)
+            return True
+
+        def get_object(self, key):
+            return storage.get(key)
+
+        def delete_object(self, key):
+            storage.pop(key, None)
+            return True
+
+    monkeypatch.setattr(
+        R2Client, "from_settings", classmethod(lambda cls: _FakeR2())
+    )
+    return storage
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNImportServiceStaging:
+    """Stage-upload step (HTTP handler entry point)."""
+
+    async def test_stage_upload_creates_pending_job(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        zip_bytes = _make_zip({"a.conf": SAMPLE_CONFIG_1})
+
+        job = await service.stage_upload(
+            zip_bytes=zip_bytes,
+            filename="upload.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        assert job.id is not None
+        assert job.status == VPNImportJobStatus.PENDING.value
+        assert job.r2_key is not None
+        assert job.r2_key.startswith("vpn-import-jobs/")
+        assert job.file_size_bytes == len(zip_bytes)
+        assert job.filename == "upload.zip"
+        # The staged ZIP should be in (fake) R2
+        assert job.r2_key in mock_r2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNImportServiceProcessing:
+    """End-to-end processing of a staged job."""
+
+    async def test_process_job_imports_configs(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        zip_bytes = _make_zip(
+            {
+                "a.conf": SAMPLE_CONFIG_1,
+                "b.conf": SAMPLE_CONFIG_2,
+            }
+        )
+        job = await service.stage_upload(
+            zip_bytes=zip_bytes,
+            filename="upload.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        await service.process_job(job)
+
+        await db_session.refresh(job)
+        assert job.status == VPNImportJobStatus.COMPLETED.value
+        assert job.total_files == 2
+        assert job.processed_files == 2
+        assert job.imported_count == 2
+        assert job.skipped_count == 0
+        assert job.error_count == 0
+        # Staged ZIP should have been removed on success
+        assert job.r2_key is None
+
+        # Two VPNCredential rows should now exist
+        result = await db_session.execute(select(VPNCredential))
+        creds = list(result.scalars().all())
+        assert len(creds) == 2
+
+    async def test_process_job_skips_duplicates_in_zip(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        # Same content in two filenames -> same hash -> one import
+        zip_bytes = _make_zip(
+            {
+                "a.conf": SAMPLE_CONFIG_1,
+                "a-copy.conf": SAMPLE_CONFIG_1,
+            }
+        )
+        job = await service.stage_upload(
+            zip_bytes=zip_bytes,
+            filename="dups.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNImportJobStatus.COMPLETED.value
+        assert job.imported_count == 1
+        assert job.skipped_count == 1
+        result = await db_session.execute(select(VPNCredential))
+        assert len(list(result.scalars().all())) == 1
+
+    async def test_process_job_skips_existing_credentials(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        # Pre-seed a credential whose hash matches SAMPLE_CONFIG_1
+        import hashlib
+        existing_hash = hashlib.sha256(SAMPLE_CONFIG_1.encode()).hexdigest()
+        existing = VPNCredential(
+            interface_ip="10.66.66.2/32",
+            ipv4_address="10.66.66.2",
+            private_key="oK56DE9Ue9zK76rAc8pBl6opph+1v36lm7cXXsQKrQM=",
+            endpoint="vpn.example.com:51820",
+            key_type="vpn",
+            file_hash=existing_hash,
+            is_available=True,
+        )
+        db_session.add(existing)
+        await db_session.commit()
+
+        service = VPNImportService(db_session)
+        zip_bytes = _make_zip(
+            {"a.conf": SAMPLE_CONFIG_1, "b.conf": SAMPLE_CONFIG_2}
+        )
+        job = await service.stage_upload(
+            zip_bytes=zip_bytes,
+            filename="mix.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNImportJobStatus.COMPLETED.value
+        assert job.imported_count == 1  # only the new one
+        assert job.skipped_count == 1  # the duplicate
+
+    async def test_process_job_records_invalid_config_errors(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        zip_bytes = _make_zip(
+            {
+                "good.conf": SAMPLE_CONFIG_1,
+                "bad.conf": INVALID_CONFIG,
+            }
+        )
+        job = await service.stage_upload(
+            zip_bytes=zip_bytes,
+            filename="mix.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNImportJobStatus.COMPLETED.value
+        assert job.imported_count == 1
+        assert job.skipped_count == 1
+        assert job.error_count == 1
+        items = (job.errors or {}).get("items", [])
+        assert len(items) == 1
+        assert "bad.conf" in items[0]
+
+    async def test_process_job_handles_invalid_zip(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        # Stage a non-zip blob
+        job = await service.stage_upload(
+            zip_bytes=b"not a zip file",
+            filename="bogus.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNImportJobStatus.FAILED.value
+        assert job.last_error
+        assert "Invalid ZIP" in job.last_error
+
+    async def test_process_job_skips_hidden_and_directory_entries(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("subdir/", "")  # directory
+            zf.writestr(".hidden.conf", SAMPLE_CONFIG_1)  # hidden
+            zf.writestr("__macosx", "junk")  # system
+            zf.writestr("real.conf", SAMPLE_CONFIG_2)
+        zip_bytes = buf.getvalue()
+
+        job = await service.stage_upload(
+            zip_bytes=zip_bytes,
+            filename="mixed.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        await service.process_job(job)
+        await db_session.refresh(job)
+
+        assert job.status == VPNImportJobStatus.COMPLETED.value
+        assert job.imported_count == 1
+        assert job.total_files == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNImportServiceClaim:
+    """Job claiming."""
+
+    async def test_claim_returns_oldest_pending(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        # Create three jobs with intentionally distinct created_at values
+        older = await service.stage_upload(
+            zip_bytes=_make_zip({"a.conf": SAMPLE_CONFIG_1}),
+            filename="older.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+        older.created_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        await db_session.commit()
+
+        newer = await service.stage_upload(
+            zip_bytes=_make_zip({"b.conf": SAMPLE_CONFIG_2}),
+            filename="newer.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        claimed = await service.claim_next_pending_job()
+        assert claimed is not None
+        assert claimed.id == older.id
+
+    async def test_claim_returns_none_when_no_pending(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        claimed = await service.claim_next_pending_job()
+        assert claimed is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNImportServiceCleanup:
+    """Retention cleanup."""
+
+    async def test_cleanup_deletes_old_completed_jobs(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        # Insert two jobs: one old, one fresh
+        old_completed = VPNImportJob(
+            file_size_bytes=10,
+            assignment_type="USER_REQUESTABLE",
+            status=VPNImportJobStatus.COMPLETED.value,
+            completed_at=datetime.now(timezone.utc) - timedelta(days=60),
+        )
+        fresh_completed = VPNImportJob(
+            file_size_bytes=10,
+            assignment_type="USER_REQUESTABLE",
+            status=VPNImportJobStatus.COMPLETED.value,
+            completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([old_completed, fresh_completed])
+        await db_session.commit()
+
+        service = VPNImportService(db_session)
+        deleted = await service.cleanup_old_jobs(retention_days=30)
+        assert deleted == 1
+
+        result = await db_session.execute(select(VPNImportJob))
+        remaining = list(result.scalars().all())
+        assert len(remaining) == 1
+        assert remaining[0].id == fresh_completed.id
+
+    async def test_cleanup_does_not_delete_pending_or_processing(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        old_pending = VPNImportJob(
+            file_size_bytes=10,
+            assignment_type="USER_REQUESTABLE",
+            status=VPNImportJobStatus.PENDING.value,
+        )
+        old_processing = VPNImportJob(
+            file_size_bytes=10,
+            assignment_type="USER_REQUESTABLE",
+            status=VPNImportJobStatus.PROCESSING.value,
+        )
+        db_session.add_all([old_pending, old_processing])
+        await db_session.commit()
+
+        service = VPNImportService(db_session)
+        deleted = await service.cleanup_old_jobs(retention_days=30)
+        assert deleted == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVPNImportServiceRetryAndDelete:
+    """Retry and manual delete behaviors."""
+
+    async def test_retry_failed_job_with_staged_zip(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        job = await service.stage_upload(
+            zip_bytes=_make_zip({"a.conf": SAMPLE_CONFIG_1}),
+            filename="x.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        # Manually mark as failed
+        job.status = VPNImportJobStatus.FAILED.value
+        job.last_error = "boom"
+        await db_session.commit()
+
+        result = await service.retry_job(job.id)
+        assert result is not None
+        assert result.status == VPNImportJobStatus.PENDING.value
+        assert result.last_error is None
+        assert result.processed_files == 0
+
+    async def test_retry_non_failed_job_returns_none(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        service = VPNImportService(db_session)
+        job = await service.stage_upload(
+            zip_bytes=_make_zip({"a.conf": SAMPLE_CONFIG_1}),
+            filename="x.zip",
+            assignment_type="USER_REQUESTABLE",
+            endpoint=None,
+            user_id=None,
+        )
+        await db_session.commit()
+
+        result = await service.retry_job(job.id)
+        assert result is None  # still pending, not retryable
+
+    async def test_delete_completed_job(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        job = VPNImportJob(
+            file_size_bytes=10,
+            assignment_type="USER_REQUESTABLE",
+            status=VPNImportJobStatus.COMPLETED.value,
+            completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add(job)
+        await db_session.commit()
+
+        service = VPNImportService(db_session)
+        ok = await service.delete_job(job.id)
+        assert ok is True
+
+        result = await db_session.execute(
+            select(VPNImportJob).where(VPNImportJob.id == job.id)
+        )
+        assert result.scalar_one_or_none() is None
+
+    async def test_delete_processing_job_refuses(
+        self, db_session: AsyncSession, mock_r2
+    ):
+        job = VPNImportJob(
+            file_size_bytes=10,
+            assignment_type="USER_REQUESTABLE",
+            status=VPNImportJobStatus.PROCESSING.value,
+        )
+        db_session.add(job)
+        await db_session.commit()
+
+        service = VPNImportService(db_session)
+        with pytest.raises(ValueError):
+            await service.delete_job(job.id)

--- a/frontend/templates/pages/admin/vpn.html
+++ b/frontend/templates/pages/admin/vpn.html
@@ -1082,6 +1082,74 @@ function getSelectedVPNIds() {
     return Array.from(checkboxes).map(cb => parseInt(cb.value));
 }
 
+// Tracks the current bulk-delete poll loop so a new delete cancels any
+// previous one cleanly.
+let _vpnDeletePollHandle = null;
+
+async function _vpnDeletePollOnce(jobId) {
+    const resp = await csrfFetch(`/api/vpn/delete-jobs/${jobId}`);
+    if (!resp.ok) {
+        throw new Error(`Status fetch failed: HTTP ${resp.status}`);
+    }
+    return await resp.json();
+}
+
+function _vpnDeleteShowProgressToast(job) {
+    const total = job.total_credentials;
+    const processed = job.processed_credentials || 0;
+    if (total && total > 0) {
+        return `Deleting ${processed} / ${total} (Deleted: ${job.deleted_count}, Failed: ${job.failed_count})`;
+    }
+    if (job.status === 'pending') {
+        return 'Queued — waiting for worker to pick it up...';
+    }
+    return 'Processing...';
+}
+
+function _vpnDeleteStartPolling(jobId, label) {
+    if (_vpnDeletePollHandle !== null) {
+        clearInterval(_vpnDeletePollHandle);
+        _vpnDeletePollHandle = null;
+    }
+
+    showToast(`${label} — job queued`, 'info');
+
+    _vpnDeletePollHandle = setInterval(async () => {
+        let job;
+        try {
+            job = await _vpnDeletePollOnce(jobId);
+        } catch (e) {
+            console.error('Delete poll error:', e);
+            return;
+        }
+
+        if (job.status === 'completed') {
+            clearInterval(_vpnDeletePollHandle);
+            _vpnDeletePollHandle = null;
+            const failedSuffix = job.failed_count > 0
+                ? ` (${job.failed_count} failed)`
+                : '';
+            showToast(
+                `Deleted ${job.deleted_count} VPN credential(s)${failedSuffix}`,
+                'success'
+            );
+            loadVPNCredentials(1);
+            loadStats();
+        } else if (job.status === 'failed') {
+            clearInterval(_vpnDeletePollHandle);
+            _vpnDeletePollHandle = null;
+            showToast(
+                `Bulk delete failed: ${job.last_error || 'Unknown error'}`,
+                'danger'
+            );
+        } else if (job.status === 'processing') {
+            // Render a quiet status update; the toast may be debounced.
+            const msg = _vpnDeleteShowProgressToast(job);
+            showToast(msg, 'info');
+        }
+    }, 2000);
+}
+
 async function deleteSelectedVPNs() {
     const vpnIds = getSelectedVPNIds();
 
@@ -1102,20 +1170,14 @@ async function deleteSelectedVPNs() {
 
         const data = await response.json();
 
-        if (response.ok && data.success) {
-            showToast(`Successfully deleted ${data.deleted_count} VPN credential(s)`, 'success');
-            if (data.failed_ids && data.failed_ids.length > 0) {
-                showToast(`Failed to delete ${data.failed_ids.length} credential(s)`, 'warning');
-            }
-            // Reload the table and stats
-            loadVPNCredentials(currentPage);
-            loadStats();
+        if (response.ok && data.success && data.job_id) {
+            _vpnDeleteStartPolling(data.job_id, `Bulk delete ${vpnIds.length} credential(s)`);
         } else {
-            showToast(data.message || 'Failed to delete VPN credentials', 'danger');
+            showToast(data.detail || data.message || 'Failed to queue bulk delete', 'danger');
         }
     } catch (error) {
-        console.error('Error deleting VPN credentials:', error);
-        showToast('An error occurred while deleting VPN credentials', 'danger');
+        console.error('Error queueing bulk delete:', error);
+        showToast('An error occurred while queueing bulk delete', 'danger');
     }
 }
 
@@ -1138,17 +1200,14 @@ async function deleteAllVPNs() {
 
         const data = await response.json();
 
-        if (response.ok && data.success) {
-            showToast(`Successfully deleted all ${data.deleted_count} VPN credential(s)`, 'success');
-            // Reload the table and stats
-            loadVPNCredentials(1);
-            loadStats();
+        if (response.ok && data.success && data.job_id) {
+            _vpnDeleteStartPolling(data.job_id, `Delete all ${totalCount} credential(s)`);
         } else {
-            showToast(data.message || 'Failed to delete VPN credentials', 'danger');
+            showToast(data.detail || data.message || 'Failed to queue delete-all', 'danger');
         }
     } catch (error) {
-        console.error('Error deleting all VPN credentials:', error);
-        showToast('An error occurred while deleting VPN credentials', 'danger');
+        console.error('Error queueing delete-all:', error);
+        showToast('An error occurred while queueing delete-all', 'danger');
     }
 }
 

--- a/frontend/templates/pages/admin/vpn.html
+++ b/frontend/templates/pages/admin/vpn.html
@@ -140,9 +140,9 @@
                     </div>
                     <div id="uploadProgress" class="mt-3" style="display: none;">
                         <div class="progress">
-                            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 100%"></div>
+                            <div id="uploadProgressBar" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%"></div>
                         </div>
-                        <p class="small text-muted mt-1 mb-0">Importing VPN credentials...</p>
+                        <p id="uploadProgressLabel" class="small text-muted mt-1 mb-0">Queueing import...</p>
                     </div>
                     <div id="uploadResult" class="mt-3" style="display: none;"></div>
                 </div>
@@ -889,65 +889,151 @@ fileInput.addEventListener('change', () => {
     }
 });
 
+// Tracks the current poll loop so cancelling a previous upload (or replacing
+// one with a new file) doesn't leave a zombie interval running.
+let _vpnImportPollHandle = null;
+
+function _vpnImportSetProgress(percent, label) {
+    const bar = document.getElementById('uploadProgressBar');
+    const lbl = document.getElementById('uploadProgressLabel');
+    if (bar) {
+        bar.style.width = `${Math.max(0, Math.min(100, percent))}%`;
+        bar.setAttribute('aria-valuenow', String(percent));
+    }
+    if (lbl) {
+        lbl.textContent = label;
+    }
+}
+
+function _vpnImportShowResult(html, alertClass) {
+    document.getElementById('uploadProgress').style.display = 'none';
+    dropzone.classList.remove('uploading');
+    const resultDiv = document.getElementById('uploadResult');
+    resultDiv.style.display = 'block';
+    resultDiv.className = `mt-3 alert ${alertClass}`;
+    resultDiv.innerHTML = html;
+}
+
+function _vpnImportRenderJobProgress(job) {
+    const total = job.total_files;
+    const processed = job.processed_files || 0;
+    let percent = 0;
+    let label;
+
+    if (job.status === 'pending') {
+        label = 'Queued — waiting for worker to pick it up...';
+        percent = 5;
+    } else if (job.status === 'processing') {
+        if (total && total > 0) {
+            percent = Math.round((processed / total) * 100);
+            label = `Processing ${processed} / ${total} (Imported: ${job.imported_count}, Skipped: ${job.skipped_count})`;
+        } else {
+            percent = 10;
+            label = 'Processing — reading ZIP archive...';
+        }
+    } else {
+        percent = 100;
+        label = 'Complete';
+    }
+
+    _vpnImportSetProgress(percent, label);
+}
+
+async function _vpnImportPollOnce(jobId) {
+    const resp = await csrfFetch(`/api/vpn/import-jobs/${jobId}`);
+    if (!resp.ok) {
+        throw new Error(`Status fetch failed: HTTP ${resp.status}`);
+    }
+    return await resp.json();
+}
+
 async function handleFileUpload(file) {
     if (!file.name.endsWith('.zip')) {
         showToast('Please upload a ZIP file', 'warning');
         return;
     }
 
+    // Cancel any previous in-flight poll loop
+    if (_vpnImportPollHandle !== null) {
+        clearInterval(_vpnImportPollHandle);
+        _vpnImportPollHandle = null;
+    }
+
     dropzone.classList.add('uploading');
     document.getElementById('uploadProgress').style.display = 'block';
     document.getElementById('uploadResult').style.display = 'none';
+    _vpnImportSetProgress(2, 'Uploading ZIP...');
 
-    // Get assignment type from dropdown
     const assignmentType = document.getElementById('assignmentType').value;
-
     const formData = new FormData();
     formData.append('file', file);
-
-    // Build URL with assignment_type query parameter
     const url = `/api/vpn/import?assignment_type=${encodeURIComponent(assignmentType)}`;
 
+    let jobId;
     try {
         const response = await csrfFetch(url, {
             method: 'POST',
-            body: formData
+            body: formData,
         });
-
         const data = await response.json();
-
-        document.getElementById('uploadProgress').style.display = 'none';
-        dropzone.classList.remove('uploading');
-
-        const resultDiv = document.getElementById('uploadResult');
-        resultDiv.style.display = 'block';
-
-        if (response.ok) {
-            resultDiv.className = 'mt-3 alert alert-success';
-            resultDiv.innerHTML = `
-                <strong>Import Complete</strong><br>
-                Imported: ${data.imported_count}<br>
-                Skipped: ${data.skipped_count}
-                ${data.errors.length > 0 ? '<br><small class="text-muted">Errors: ' + data.errors.slice(0, 3).join(', ') + '</small>' : ''}
-            `;
-            loadVPNCredentials(1);
-            loadStats();
-        } else {
-            resultDiv.className = 'mt-3 alert alert-danger';
-            resultDiv.innerHTML = `<strong>Import Failed</strong><br>${data.detail || 'Unknown error'}`;
+        if (!response.ok) {
+            _vpnImportShowResult(
+                `<strong>Upload Failed</strong><br>${data.detail || 'Unknown error'}`,
+                'alert-danger'
+            );
+            fileInput.value = '';
+            return;
         }
+        jobId = data.job_id;
     } catch (error) {
         console.error('Error:', error);
-        document.getElementById('uploadProgress').style.display = 'none';
-        dropzone.classList.remove('uploading');
-
-        const resultDiv = document.getElementById('uploadResult');
-        resultDiv.style.display = 'block';
-        resultDiv.className = 'mt-3 alert alert-danger';
-        resultDiv.innerHTML = '<strong>Upload Failed</strong><br>Please try again.';
+        _vpnImportShowResult(
+            '<strong>Upload Failed</strong><br>Please try again.',
+            'alert-danger'
+        );
+        fileInput.value = '';
+        return;
     }
 
     fileInput.value = '';
+    _vpnImportSetProgress(5, 'Queued — waiting for worker to pick it up...');
+
+    // Poll the job status every 2 seconds until it terminates
+    _vpnImportPollHandle = setInterval(async () => {
+        let job;
+        try {
+            job = await _vpnImportPollOnce(jobId);
+        } catch (e) {
+            console.error('Poll error:', e);
+            return; // try again next tick
+        }
+
+        _vpnImportRenderJobProgress(job);
+
+        if (job.status === 'completed') {
+            clearInterval(_vpnImportPollHandle);
+            _vpnImportPollHandle = null;
+            const errorsHtml = (job.errors && job.errors.length > 0)
+                ? `<br><small class="text-muted">Errors: ${job.errors.slice(0, 3).join(', ')}${job.errors.length > 3 ? ` (+${job.errors.length - 3} more)` : ''}</small>`
+                : '';
+            _vpnImportShowResult(
+                `<strong>Import Complete</strong><br>` +
+                `Imported: ${job.imported_count}<br>` +
+                `Skipped: ${job.skipped_count}` +
+                errorsHtml,
+                'alert-success'
+            );
+            loadVPNCredentials(1);
+            loadStats();
+        } else if (job.status === 'failed') {
+            clearInterval(_vpnImportPollHandle);
+            _vpnImportPollHandle = null;
+            _vpnImportShowResult(
+                `<strong>Import Failed</strong><br>${job.last_error || 'Unknown error'}`,
+                'alert-danger'
+            );
+        }
+    }, 2000);
 }
 {% endif %}
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,17 @@
-# Render.com Blueprint for CyberX Event Management System - STAGING
+# Render.com Blueprint for CyberX Event Management System - PRODUCTION
 # Deploys: FastAPI app + Background Worker
 # Uses Supabase for PostgreSQL (configured via environment variables)
 # Estimated cost: ~$14/month (2x $7 services)
 # Trigger: DATABASE_URL will be injected via GitHub Actions
 
 services:
-  # FastAPI Web Application - STAGING
+  # FastAPI Web Application - PRODUCTION
   - type: web
-    name: cyberx-event-mgmt-staging
+    name: cyberx-event-mgmt-production
     runtime: python
     region: virginia  # US East
     plan: starter  # $7/month - 512MB RAM (sufficient for 100 users)
-    branch: staging  # Staging service watches staging branch
+    branch: main  # Production deploys from main branch
     autoDeploy: false  # Disable auto deploy - only deploy via GitHub Actions
     buildCommand: |
       cd backend
@@ -25,7 +25,7 @@ services:
       - key: PYTHON_VERSION
         value: 3.12.8
       - key: ENVIRONMENT
-        value: staging
+        value: production
       - key: DEBUG
         value: "false"
       # Database - Supabase connection string (set manually in Render dashboard)
@@ -46,7 +46,7 @@ services:
       - key: SENDGRID_FROM_NAME
         value: CyberX Red Team
       - key: SENDGRID_SANDBOX_MODE
-        value: "true"  # STAGING: Sandbox mode
+        value: "false"  # PRODUCTION: Send real emails
       # SendGrid webhook verification
       - key: SENDGRID_WEBHOOK_VERIFICATION_KEY
         sync: false
@@ -59,26 +59,30 @@ services:
         value: 10.20.200.1
       - key: VPN_ALLOWED_IPS
         value: 10.0.0.0/8,fd00:a::/32
-      # Application configuration - STAGING URLs
+      # Application configuration - PRODUCTION URLs
       - key: FRONTEND_URL
-        value: https://staging.events.cyberxredteam.org
+        value: https://events.cyberxredteam.org
       - key: ALLOWED_HOSTS
-        value: staging.events.cyberxredteam.org
+        value: events.cyberxredteam.org
       - key: SESSION_EXPIRY_HOURS
         value: 24
-      - key: CSRF_TOKEN_MAX_AGE
-        value: 30
       - key: BULK_EMAIL_INTERVAL_MINUTES
-        value: 45
+        value: 15
       # Reminder configuration
+      - key: REMINDER_1_ENABLED
+        value: "true"
       - key: REMINDER_1_DAYS_AFTER_INVITE
         value: 7
       - key: REMINDER_1_MIN_DAYS_BEFORE_EVENT
         value: 14
+      - key: REMINDER_2_ENABLED
+        value: "false"
       - key: REMINDER_2_DAYS_AFTER_INVITE
         value: 14
       - key: REMINDER_2_MIN_DAYS_BEFORE_EVENT
         value: 7
+      - key: REMINDER_3_ENABLED
+        value: "true"
       - key: REMINDER_3_DAYS_BEFORE_EVENT
         value: 3
       - key: REMINDER_CHECK_INTERVAL_HOURS
@@ -102,7 +106,7 @@ services:
       - key: DISCORD_BOT_TOKEN
         sync: false
       - key: DISCORD_INVITE_ENABLED
-        value: "false"
+        value: "true"
       # PowerDNS configuration
       - key: POWERDNS_API_URL
         sync: false
@@ -146,7 +150,7 @@ services:
       - key: CPE_SIGNER_2_NAME
         sync: false
       - key: GOTENBERG_URL
-        value: http://cyberx-gotenberg-staging:3000
+        value: http://cyberx-gotenberg-production:3000
       # Render API (for sidecar lifecycle management)
       - key: RENDER_API_KEY
         sync: false
@@ -167,7 +171,7 @@ services:
 
   # Gotenberg - DOCX to PDF conversion for CPE certificates
   - type: pserv
-    name: cyberx-gotenberg-staging
+    name: cyberx-gotenberg-production
     runtime: docker
     region: virginia
     plan: standard


### PR DESCRIPTION
## Summary

- **VPN bulk import** is now an async background job. The HTTP handler stages the upload to R2 and returns immediately; a scheduled task processes the ZIP cooperatively, dedups in bulk, and uploads per-credential configs to R2 in parallel. Fixes the gateway timeout on large imports (2k+ configs) that was freezing the web service for the duration of every R2 upload.
- **VPN bulk delete + delete-all** are also now async background jobs, using the same pattern. Each chunk does one bulk SQL delete plus parallel R2 deletes via `asyncio.gather` + `Semaphore`, all offloaded through `asyncio.to_thread` so boto3 doesn't block the event loop.
- Bumps app version to **1.5.0**.

## What changed

### Backend
- New `vpn_import_jobs` and `vpn_delete_jobs` tables (migrations `20260409_000000` and `20260409_000001`)
- New `VPNImportService` and `VPNDeleteService` running cooperatively in chunks (100 / 200 entries) with `await asyncio.sleep(0)` between chunks so HTTP requests stay responsive on the single uvicorn worker
- New scheduled tasks: `vpn_import_job` + `vpn_delete_job` (every 30 seconds) and matching daily cleanup tasks that purge completed/failed jobs older than `VPN_IMPORT_RETENTION_DAYS`
- Shared `R2Client` helper (`backend/app/utils/r2_client.py`) so the import and delete services use the same boto3 wrapper as `VPNService`
- Extracted `parse_wireguard_config` and `split_addresses` from `VPNService` as pure helpers, reused by both services
- New endpoints (admin only, `vpn.manage_pool` permission):
  - `POST /api/vpn/import` — now stages + queues, returns `{job_id, status}`
  - `GET /api/vpn/import-jobs` / `GET /api/vpn/import-jobs/{id}` / `POST .../retry` / `DELETE ...`
  - `POST /api/vpn/bulk-delete` and `POST /api/vpn/delete-all` — now queue + return `{job_id}`
  - `GET /api/vpn/delete-jobs` / `GET /api/vpn/delete-jobs/{id}` / `POST .../retry` / `DELETE ...`

### Frontend
- Admin VPN page dropzone now polls `/import-jobs/{id}` every 2 seconds and renders a live progress bar with running counts
- Bulk-delete and delete-all now poll `/delete-jobs/{id}` and surface progress via toasts

### Configuration
- Three new optional env vars (all have working defaults — **no Render dashboard changes required**):
  - `VPN_IMPORT_MAX_FILE_SIZE_MB` (default `20`)
  - `VPN_IMPORT_RETENTION_DAYS` (default `30`)
  - `VPN_IMPORT_R2_PARALLELISM` (default `10`)

### Tests
- 15 new unit tests for `VPNImportService`
- 15 new unit tests for `VPNDeleteService`
- All 645 unit tests pass (was 615 before)
- Existing 45 `VPNService` tests still pass — the legacy `import_from_zip` and `delete_credentials` methods are kept on the service so internal callers and tests are unaffected

## Migration order on deploy

`alembic upgrade head` (run automatically per `render.yaml`) will apply:
1. `20260409_000000_add_vpn_import_jobs` (on top of `20260330_000000`)
2. `20260409_000001_add_vpn_delete_jobs`

## Test plan

- [ ] CI passes (alembic upgrade, unit tests)
- [ ] After deploy, verify the scheduler logs show `Scheduled VPN import job to run every 30 seconds` and `Scheduled VPN delete job to run every 30 seconds` on startup
- [ ] Upload a small ZIP via the admin VPN page and watch the progress bar tick to completion
- [ ] Upload a large ZIP (~2k configs) and confirm the request returns immediately and the background job processes without freezing the web service
- [ ] Bulk-delete a handful of credentials via the admin UI and confirm the toast progress updates and final count are correct, including R2 cleanup
- [ ] Run `delete-all` on a small set and confirm the credentials and their R2 objects are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)