### PR TITLE
release: v1.5.1 — redirector visibility + collaboration overhaul

### DIFF
--- a/backend/app/api/routes/instances.py
+++ b/backend/app/api/routes/instances.py
@@ -316,6 +316,18 @@ async def update_instance(
     if "visibility" in data:
         if data["visibility"] not in ("private", "public"):
             raise bad_request("Visibility must be 'private' or 'public'")
+        if instance.visibility == "public" and data["visibility"] == "private":
+            redir_svc = RedirectorService(db)
+            linked = await redir_svc.get_redirector_by_instance_id(instance_id)
+            if linked is not None:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"This instance is managed by redirector '{linked.name}'. "
+                        "Delete the redirector management row first before changing "
+                        "the instance visibility to private."
+                    ),
+                )
         changes["visibility"] = {"old": instance.visibility, "new": data["visibility"]}
         instance.visibility = data["visibility"]
 

--- a/backend/app/api/routes/instances.py
+++ b/backend/app/api/routes/instances.py
@@ -331,6 +331,21 @@ async def update_instance(
         changes["visibility"] = {"old": instance.visibility, "new": data["visibility"]}
         instance.visibility = data["visibility"]
 
+        # Parity: when an instance is promoted to public, any linked redirector
+        # must also be public, otherwise collaborators silently lose visibility
+        # even though the parent instance is shared.
+        if data["visibility"] == "public":
+            redir_svc = RedirectorService(db)
+            linked = await redir_svc.get_redirector_by_instance_id(instance_id)
+            if linked is not None and linked.visibility != "public":
+                changes["redirector_visibility_auto_promoted"] = {
+                    "redirector_id": linked.id,
+                    "redirector_name": linked.name,
+                    "old": linked.visibility,
+                    "new": "public",
+                }
+                linked.visibility = "public"
+
     if "notes" in data:
         changes["notes"] = True
         instance.notes = data["notes"]

--- a/backend/app/api/routes/participant_instances.py
+++ b/backend/app/api/routes/participant_instances.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, List
 from pydantic import BaseModel
 
-from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, and_, or_, func
 from sqlalchemy.orm import selectinload
@@ -325,6 +325,21 @@ async def update_my_instance(
     if visibility is not None:
         if visibility not in ["private", "public"]:
             raise bad_request("Invalid visibility. Must be private or public")
+        # Visibility parity: a public instance linked to a managed redirector
+        # cannot be demoted to private without first removing the redirector,
+        # otherwise other operators' stream configs would silently lose access.
+        if instance.visibility == "public" and visibility == "private":
+            redir_svc = RedirectorService(db)
+            linked = await redir_svc.get_redirector_by_instance_id(instance_id)
+            if linked is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"This instance is managed by redirector '{linked.name}'. "
+                        "Delete the redirector management row first before changing "
+                        "the instance visibility to private."
+                    ),
+                )
         changes["visibility"] = {"old": instance.visibility, "new": visibility}
         instance.visibility = visibility
 

--- a/backend/app/api/routes/participant_instances.py
+++ b/backend/app/api/routes/participant_instances.py
@@ -343,6 +343,21 @@ async def update_my_instance(
         changes["visibility"] = {"old": instance.visibility, "new": visibility}
         instance.visibility = visibility
 
+        # Parity: when an instance is promoted to public, any linked redirector
+        # must also be public, otherwise collaborators silently lose visibility
+        # even though the parent instance is shared.
+        if visibility == "public":
+            redir_svc = RedirectorService(db)
+            linked = await redir_svc.get_redirector_by_instance_id(instance_id)
+            if linked is not None and linked.visibility != "public":
+                changes["redirector_visibility_auto_promoted"] = {
+                    "redirector_id": linked.id,
+                    "redirector_name": linked.name,
+                    "old": linked.visibility,
+                    "new": "public",
+                }
+                linked.visibility = "public"
+
     # Update notes if provided
     if notes is not None:
         changes["notes"] = True

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -72,18 +72,26 @@ router = APIRouter(prefix="/api/redirectors", tags=["Redirectors"])
 def _build_redirector_out(
     redirector: Redirector,
     stream_count: int | None = None,
+    owner_username: str | None = None,
 ) -> RedirectorOut:
     """Build RedirectorOut from ORM object, always redacting key fields.
 
-    stream_count can be passed explicitly to avoid lazy-loading the
-    stream_configs relationship (which fails outside a greenlet context
-    after session commits have expired the ORM object).
+    stream_count and owner_username can be passed explicitly to avoid
+    lazy-loading the corresponding relationships (which fails outside a
+    greenlet context after session commits have expired the ORM object).
     """
     if stream_count is None:
         try:
             stream_count = redirector.stream_count
         except Exception:
             stream_count = 0
+    if owner_username is None:
+        try:
+            owner = redirector.owner
+            if owner is not None:
+                owner_username = owner.pandas_username or owner.email
+        except Exception:
+            owner_username = None
     return RedirectorOut(
         id=redirector.id,
         name=redirector.name,
@@ -104,6 +112,8 @@ def _build_redirector_out(
         created_at=redirector.created_at,
         updated_at=redirector.updated_at,
         owner_id=redirector.owner_id,
+        owner_username=owner_username,
+        visibility=redirector.visibility or "private",
     )
 
 
@@ -176,13 +186,26 @@ async def _get_redirector_or_404(
 
 
 async def _get_authorized_redirector(
-    redirector_id: str, current_user: User, svc: RedirectorService
+    redirector_id: str,
+    current_user: User,
+    svc: RedirectorService,
+    *,
+    allow_public: bool = False,
 ) -> Redirector:
-    """Fetch redirector and verify the user has access (owner or admin)."""
+    """Fetch redirector and verify the user has access.
+
+    Admins (redirectors.view_all) always pass. Owners always pass. When
+    allow_public=True, any user who can view the list may read a public
+    redirector (used by read-only routes like GET).
+    """
     redir = await _get_redirector_or_404(redirector_id, svc)
-    if not current_user.has_permission("redirectors.view_all") and redir.owner_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
-    return redir
+    if current_user.has_permission("redirectors.view_all"):
+        return redir
+    if redir.owner_id == current_user.id:
+        return redir
+    if allow_public and redir.visibility == "public":
+        return redir
+    raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
 
 async def _get_stream_or_404(
@@ -203,12 +226,18 @@ async def list_redirectors(
     current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """List redirectors. Admins see all; others see only their own."""
+    """List redirectors.
+
+    Admins (redirectors.view_all) see all rows regardless of visibility.
+    Other users see their own redirectors plus any redirector marked public.
+    """
     svc = RedirectorService(db)
     if current_user.has_permission("redirectors.view_all"):
         redirectors = await svc.list_redirectors()
     else:
-        redirectors = await svc.list_redirectors(owner_id=current_user.id)
+        redirectors = await svc.list_redirectors(
+            owner_id=current_user.id, include_public=True
+        )
     return RedirectorListOut(
         redirectors=[_build_redirector_out(r) for r in redirectors],
         total=len(redirectors),
@@ -475,6 +504,7 @@ async def create_from_instance(
         "notes": payload.notes,
         "owner_id": current_user.id,
         "instance_id": instance.id,
+        "visibility": payload.visibility,
     })
 
     # Best-effort connection test
@@ -612,9 +642,15 @@ async def get_redirector(
     current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get a single redirector with its stream count."""
+    """Get a single redirector with its stream count.
+
+    Non-owners may fetch a redirector when its visibility is 'public';
+    mutating routes below still require owner or admin permissions.
+    """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True
+    )
     return _build_redirector_out(redirector)
 
 

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -73,12 +73,14 @@ def _build_redirector_out(
     redirector: Redirector,
     stream_count: int | None = None,
     owner_username: str | None = None,
+    instance_visibility: str | None = None,
 ) -> RedirectorOut:
     """Build RedirectorOut from ORM object, always redacting key fields.
 
-    stream_count and owner_username can be passed explicitly to avoid
-    lazy-loading the corresponding relationships (which fails outside a
-    greenlet context after session commits have expired the ORM object).
+    stream_count, owner_username, and instance_visibility can be passed
+    explicitly to avoid lazy-loading the corresponding relationships
+    (which fails outside a greenlet context after session commits have
+    expired the ORM object).
     """
     if stream_count is None:
         try:
@@ -114,7 +116,21 @@ def _build_redirector_out(
         owner_id=redirector.owner_id,
         owner_username=owner_username,
         visibility=redirector.visibility or "private",
+        instance_visibility=instance_visibility,
     )
+
+
+async def _instance_visibilities_for(
+    db: AsyncSession, redirectors: list[Redirector]
+) -> dict[int, str]:
+    """Return {instance_id: visibility} for the linked instances of a list."""
+    ids = [r.instance_id for r in redirectors if r.instance_id is not None]
+    if not ids:
+        return {}
+    result = await db.execute(
+        select(Instance.id, Instance.visibility).where(Instance.id.in_(ids))
+    )
+    return {row[0]: row[1] for row in result.all()}
 
 
 async def _make_ssh_service(
@@ -257,8 +273,12 @@ async def list_redirectors(
             include_public=True,
             sponsored_owner_ids=sponsored_ids or None,
         )
+    inst_vis = await _instance_visibilities_for(db, redirectors)
     return RedirectorListOut(
-        redirectors=[_build_redirector_out(r) for r in redirectors],
+        redirectors=[
+            _build_redirector_out(r, instance_visibility=inst_vis.get(r.instance_id))
+            for r in redirectors
+        ],
         total=len(redirectors),
     )
 
@@ -534,6 +554,22 @@ async def create_from_instance(
             detail=f"A redirector named '{name}' already exists.",
         )
 
+    # Visibility parity: a public instance can only host a public redirector
+    # row (so every operator with access to the instance also has access to
+    # the management record and its stream configs).
+    effective_visibility = payload.visibility
+    if instance.visibility == "public":
+        if payload.visibility == "private":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "The source instance is public, so the redirector management "
+                    "row must also be public. Set visibility to public or make "
+                    "the instance private first."
+                ),
+            )
+        effective_visibility = "public"
+
     # Auto-populate from instance + template
     redirector = await svc.create_redirector({
         "name": name,
@@ -544,7 +580,7 @@ async def create_from_instance(
         "notes": payload.notes,
         "owner_id": current_user.id,
         "instance_id": instance.id,
-        "visibility": payload.visibility,
+        "visibility": effective_visibility,
     })
 
     # Best-effort connection test
@@ -575,7 +611,9 @@ async def create_from_instance(
     )
 
     await db.refresh(redirector)
-    return _build_redirector_out(redirector, stream_count=0)
+    return _build_redirector_out(
+        redirector, stream_count=0, instance_visibility=instance.visibility
+    )
 
 
 @router.post("/provision-and-register", status_code=status.HTTP_201_CREATED)
@@ -691,7 +729,11 @@ async def get_redirector(
     redirector = await _get_authorized_redirector(
         redirector_id, current_user, svc, allow_public=True, db=db
     )
-    return _build_redirector_out(redirector)
+    inst_vis: str | None = None
+    if redirector.instance_id:
+        linked_instance = await db.get(Instance, redirector.instance_id)
+        inst_vis = linked_instance.visibility if linked_instance else None
+    return _build_redirector_out(redirector, instance_visibility=inst_vis)
 
 
 @router.put("/{redirector_id}", response_model=RedirectorOut)
@@ -708,9 +750,25 @@ async def update_redirector(
     """
     svc = RedirectorService(db)
     redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
-    redirector = await svc.update_redirector(
-        redirector, payload.model_dump(exclude_unset=True)
-    )
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    # Visibility parity: if the linked instance is public, this row must
+    # remain public too, otherwise other operators would lose access to the
+    # management record for a resource they can still see.
+    if update_data.get("visibility") == "private" and redirector.instance_id:
+        linked_instance = await db.get(Instance, redirector.instance_id)
+        if linked_instance is not None and linked_instance.visibility == "public":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "The linked instance is public, so this redirector must also "
+                    "be public. Make the instance private first, or delete the "
+                    "redirector, before setting the redirector to private."
+                ),
+            )
+
+    redirector = await svc.update_redirector(redirector, update_data)
 
     audit = AuditService(db)
     await audit.log(
@@ -721,7 +779,11 @@ async def update_redirector(
         ip_address=request.client.host if request.client else None,
     )
 
-    return _build_redirector_out(redirector)
+    inst_vis: str | None = None
+    if redirector.instance_id:
+        linked_instance = await db.get(Instance, redirector.instance_id)
+        inst_vis = linked_instance.visibility if linked_instance else None
+    return _build_redirector_out(redirector, instance_visibility=inst_vis)
 
 
 @router.delete("/{redirector_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -682,6 +682,7 @@ async def provision_redirector_instance(
         name=instance.name,
         ip_address=instance.ip_address,
         status=instance.status,
+        visibility=instance.visibility or "private",
     )
 
 
@@ -711,6 +712,7 @@ async def get_instance_status(
         name=instance.name,
         ip_address=instance.ip_address,
         status=instance.status,
+        visibility=instance.visibility or "private",
     )
 
 

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -819,15 +819,20 @@ async def delete_redirector(
 async def test_connection(
     redirector_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     SSH connect to the redirector and verify nginx stream module presence.
     Updates the redirector status (online/offline) and last_tested_at.
+
+    Read-only probe: anyone who can view the redirector (including public
+    rows and sponsors viewing their invitees' rows) may run it.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     ssh = await _make_ssh_service(svc, redirector, db)
 
     try:
@@ -864,15 +869,19 @@ async def test_connection(
 @router.post("/{redirector_id}/check-nginx-setup")
 async def check_nginx_setup(
     redirector_id: str,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     SSH into the redirector and check for common nginx config issues:
     default site active (port 80) and stream block presence.
+
+    Read-only probe: open to anyone who can view the redirector.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     ssh = await _make_ssh_service(svc, redirector, db)
     try:
         return await run_check_nginx_setup(ssh)
@@ -918,12 +927,17 @@ async def fix_nginx_setup(
 @router.post("/{redirector_id}/check-prereqs")
 async def check_prereqs(
     redirector_id: str,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Check that all CyberX prerequisites are met on the redirector."""
+    """Check that all CyberX prerequisites are met on the redirector.
+
+    Read-only probe: open to anyone who can view the redirector.
+    """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     ssh = await _make_ssh_service(svc, redirector, db)
     try:
         return await run_check_prereqs(ssh, redirector.nginx_stream_dir)
@@ -962,15 +976,19 @@ async def fix_prereqs(
 async def check_port(
     redirector_id: str,
     body: CheckPortRequest,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     SSH into the redirector and check whether a port is already in use.
     Returns: {"in_use": bool, "listeners": [...], "message": str}
+
+    Read-only probe: open to anyone who can view the redirector.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     ssh = await _make_ssh_service(svc, redirector, db)
 
     try:
@@ -1103,7 +1121,9 @@ async def list_streams(
 ):
     """List all stream configs for a redirector."""
     svc = RedirectorService(db)
-    await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     streams = await svc.list_streams(redirector_id)
     return [StreamConfigOut.model_validate(s) for s in streams]
 

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -191,10 +191,12 @@ async def _get_authorized_redirector(
     svc: RedirectorService,
     *,
     allow_public: bool = False,
+    db: AsyncSession | None = None,
 ) -> Redirector:
     """Fetch redirector and verify the user has access.
 
-    Admins (redirectors.view_all) always pass. Owners always pass. When
+    Admins (redirectors.view_all) always pass. Owners always pass. Sponsors
+    pass when the redirector belongs to one of their invitees. When
     allow_public=True, any user who can view the list may read a public
     redirector (used by read-only routes like GET).
     """
@@ -205,6 +207,14 @@ async def _get_authorized_redirector(
         return redir
     if allow_public and redir.visibility == "public":
         return redir
+    if (
+        getattr(current_user, "is_sponsor_role", False)
+        and redir.owner_id
+        and db is not None
+    ):
+        owner = await db.get(User, redir.owner_id)
+        if owner is not None and owner.sponsor_id == current_user.id:
+            return redir
     raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
 
@@ -228,15 +238,24 @@ async def list_redirectors(
 ):
     """List redirectors.
 
-    Admins (redirectors.view_all) see all rows regardless of visibility.
-    Other users see their own redirectors plus any redirector marked public.
+    Admins (redirectors.view_all) see every row regardless of visibility.
+    Sponsors see their own, any public row, and any row owned by one of
+    their invitees. Everyone else sees their own plus any public row.
     """
     svc = RedirectorService(db)
     if current_user.has_permission("redirectors.view_all"):
         redirectors = await svc.list_redirectors()
     else:
+        sponsored_ids: List[int] = []
+        if getattr(current_user, "is_sponsor_role", False):
+            sponsored_result = await db.execute(
+                select(User.id).where(User.sponsor_id == current_user.id)
+            )
+            sponsored_ids = [row[0] for row in sponsored_result.all()]
         redirectors = await svc.list_redirectors(
-            owner_id=current_user.id, include_public=True
+            owner_id=current_user.id,
+            include_public=True,
+            sponsored_owner_ids=sponsored_ids or None,
         )
     return RedirectorListOut(
         redirectors=[_build_redirector_out(r) for r in redirectors],
@@ -397,9 +416,21 @@ async def list_available_instances(
         .order_by(Instance.name)
     )
 
-    # Owner scoping: non-admins see only their own instances
+    # Visibility scoping:
+    #   - Admins (redirectors.view_all): see everything.
+    #   - Sponsors: see their own + any instance owned by a user they sponsor.
+    #   - Everyone else: see their own + public instances.
     if not current_user.has_permission("redirectors.view_all"):
-        query = query.where(Instance.created_by_user_id == current_user.id)
+        conditions = [
+            Instance.created_by_user_id == current_user.id,
+            Instance.visibility == "public",
+        ]
+        if getattr(current_user, "is_sponsor_role", False):
+            sponsored_ids_subq = (
+                select(User.id).where(User.sponsor_id == current_user.id).scalar_subquery()
+            )
+            conditions.append(Instance.created_by_user_id.in_(sponsored_ids_subq))
+        query = query.where(or_(*conditions))
 
     result = await db.execute(query)
     return [AvailableInstanceOut.model_validate(i) for i in result.scalars().all()]
@@ -449,9 +480,18 @@ async def create_from_instance(
             detail=f"Instance is not active (status: {instance.status}).",
         )
 
-    # Owner check
-    if not current_user.has_permission("redirectors.view_all") and instance.created_by_user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not authorized to use this instance.")
+    # Authorization: admins pass; owners pass; sponsors pass when the
+    # instance belongs to one of their invitees; everyone else may use
+    # the instance only when it is marked public.
+    if not current_user.has_permission("redirectors.view_all"):
+        is_owner = instance.created_by_user_id == current_user.id
+        is_public = instance.visibility == "public"
+        is_sponsor_of_owner = False
+        if getattr(current_user, "is_sponsor_role", False) and instance.created_by_user_id:
+            owner = await db.get(User, instance.created_by_user_id)
+            is_sponsor_of_owner = bool(owner and owner.sponsor_id == current_user.id)
+        if not (is_owner or is_public or is_sponsor_of_owner):
+            raise HTTPException(status_code=403, detail="Not authorized to use this instance.")
 
     # Validate template is a redirector template
     template = None
@@ -649,7 +689,7 @@ async def get_redirector(
     """
     svc = RedirectorService(db)
     redirector = await _get_authorized_redirector(
-        redirector_id, current_user, svc, allow_public=True
+        redirector_id, current_user, svc, allow_public=True, db=db
     )
     return _build_redirector_out(redirector)
 
@@ -667,7 +707,7 @@ async def update_redirector(
     Send an empty string for ssh_key_passphrase to clear it.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     redirector = await svc.update_redirector(
         redirector, payload.model_dump(exclude_unset=True)
     )
@@ -693,7 +733,7 @@ async def delete_redirector(
 ):
     """Delete a redirector and all its stream configs (cascade). Does not remove remote files."""
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     name = redirector.name
     await svc.delete_redirector(redirector)
 
@@ -723,7 +763,7 @@ async def test_connection(
     Updates the redirector status (online/offline) and last_tested_at.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     ssh = await _make_ssh_service(svc, redirector, db)
 
     try:
@@ -768,7 +808,7 @@ async def check_nginx_setup(
     default site active (port 80) and stream block presence.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     ssh = await _make_ssh_service(svc, redirector, db)
     try:
         return await run_check_nginx_setup(ssh)
@@ -794,7 +834,7 @@ async def fix_nginx_setup(
         <user> ALL=(ALL) NOPASSWD: /bin/bash /tmp/.cyberx_nginx_fix.sh
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     ssh = await _make_ssh_service(svc, redirector, db)
     try:
         return await run_fix_nginx_setup(ssh, redirector.nginx_stream_dir)
@@ -819,7 +859,7 @@ async def check_prereqs(
 ):
     """Check that all CyberX prerequisites are met on the redirector."""
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     ssh = await _make_ssh_service(svc, redirector, db)
     try:
         return await run_check_prereqs(ssh, redirector.nginx_stream_dir)
@@ -842,7 +882,7 @@ async def fix_prereqs(
     Requires the SSH user to have sudo access (NOPASSWD preferred).
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     ssh = await _make_ssh_service(svc, redirector, db)
     try:
         return await run_fix_prereqs(ssh, redirector.nginx_stream_dir)
@@ -866,7 +906,7 @@ async def check_port(
     Returns: {"in_use": bool, "listeners": [...], "message": str}
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     ssh = await _make_ssh_service(svc, redirector, db)
 
     try:
@@ -893,7 +933,7 @@ async def deploy_all(
     mark all as enabled, write configs, remove orphans, reload nginx.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     streams = await svc.list_streams(redirector_id)
 
     # Mark all streams as enabled before deploying
@@ -948,7 +988,7 @@ async def disable_all(
     mark all as disabled, remove all config files, reload nginx.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     streams = await svc.list_streams(redirector_id)
 
     # Mark all streams as disabled before deploying
@@ -999,7 +1039,7 @@ async def list_streams(
 ):
     """List all stream configs for a redirector."""
     svc = RedirectorService(db)
-    await _get_authorized_redirector(redirector_id, current_user, svc)
+    await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     streams = await svc.list_streams(redirector_id)
     return [StreamConfigOut.model_validate(s) for s in streams]
 
@@ -1018,7 +1058,7 @@ async def create_stream(
 ):
     """Create a stream config for a redirector (does not deploy immediately)."""
     svc = RedirectorService(db)
-    await _get_authorized_redirector(redirector_id, current_user, svc)
+    await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     stream = await svc.create_stream(redirector_id, payload.model_dump())
 
     audit = AuditService(db)
@@ -1090,7 +1130,7 @@ async def delete_stream(
 ):
     """Delete a stream config from the database and remove the config file from the redirector."""
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     name = stream.name
 
@@ -1148,7 +1188,7 @@ async def enable_stream(
     so the operator can fix the config and retry.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
 
     stream = await svc.update_stream(stream, {"enabled": True})
@@ -1197,7 +1237,7 @@ async def deploy_stream(
     Returns HTTP 200 with success=False if nginx test fails (operator sees output).
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
 
     if not stream.enabled:
@@ -1250,7 +1290,7 @@ async def remove_stream_file(
     Does not delete the StreamConfig from the database — use DELETE for that.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc)
+    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     ssh = await _make_ssh_service(svc, redirector, db)
 

--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -1007,15 +1007,20 @@ async def check_port(
 async def deploy_all(
     redirector_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Enable and deploy all stream configs for this redirector:
     mark all as enabled, write configs, remove orphans, reload nginx.
+
+    Stream-level operation: open to any viewer (owner, admin, sponsor of
+    invitee, or anyone viewing a public row).
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     streams = await svc.list_streams(redirector_id)
 
     # Mark all streams as enabled before deploying
@@ -1062,15 +1067,19 @@ async def deploy_all(
 async def disable_all(
     redirector_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Disable all streams for this redirector:
     mark all as disabled, remove all config files, reload nginx.
+
+    Stream-level operation: open to any viewer.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     streams = await svc.list_streams(redirector_id)
 
     # Mark all streams as disabled before deploying
@@ -1137,12 +1146,17 @@ async def create_stream(
     redirector_id: str,
     payload: StreamConfigCreate,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a stream config for a redirector (does not deploy immediately)."""
+    """Create a stream config for a redirector (does not deploy immediately).
+
+    Stream-level operation: open to any viewer.
+    """
     svc = RedirectorService(db)
-    await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await svc.create_stream(redirector_id, payload.model_dump())
 
     audit = AuditService(db)
@@ -1169,8 +1183,11 @@ async def get_stream(
     current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get a single stream config."""
+    """Get a single stream config. Open to any viewer of the redirector."""
     svc = RedirectorService(db)
+    await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     return StreamConfigOut.model_validate(stream)
 
@@ -1181,11 +1198,17 @@ async def update_stream(
     stream_id: str,
     payload: StreamConfigUpdate,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update a stream config (does not redeploy automatically)."""
+    """Update a stream config (does not redeploy automatically).
+
+    Stream-level operation: open to any viewer of the redirector.
+    """
     svc = RedirectorService(db)
+    await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     stream = await svc.update_stream(stream, payload.model_dump(exclude_unset=True))
 
@@ -1209,12 +1232,17 @@ async def delete_stream(
     redirector_id: str,
     stream_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Delete a stream config from the database and remove the config file from the redirector."""
+    """Delete a stream config from the database and remove the config file from the redirector.
+
+    Stream-level operation: open to any viewer of the redirector.
+    """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     name = stream.name
 
@@ -1253,6 +1281,9 @@ async def preview_stream(
 ):
     """Return the generated nginx config text without performing any SSH operation."""
     svc = RedirectorService(db)
+    await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     content = generate_stream_config_preview(stream)
     return ConfigPreview(filename=stream.filename, content=content)
@@ -1263,16 +1294,20 @@ async def enable_stream(
     redirector_id: str,
     stream_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Mark a stream as enabled, write its config file to the redirector, and reload nginx.
     Rolls back (deletes the file) if nginx -t fails — stream stays enabled in DB on rollback
     so the operator can fix the config and retry.
+
+    Stream-level operation: open to any viewer of the redirector.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
 
     stream = await svc.update_stream(stream, {"enabled": True})
@@ -1312,16 +1347,20 @@ async def deploy_stream(
     redirector_id: str,
     stream_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Write a single stream config file to the redirector and reload nginx.
     Rolls back (deletes the file) if nginx -t fails.
     Returns HTTP 200 with success=False if nginx test fails (operator sees output).
+
+    Stream-level operation: open to any viewer of the redirector.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
 
     if not stream.enabled:
@@ -1366,15 +1405,19 @@ async def remove_stream_file(
     redirector_id: str,
     stream_id: str,
     request: Request,
-    current_user: User = Depends(require_permission("redirectors.manage")),
+    current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Remove a stream config file from the redirector and reload nginx.
     Does not delete the StreamConfig from the database — use DELETE for that.
+
+    Stream-level operation: open to any viewer of the redirector.
     """
     svc = RedirectorService(db)
-    redirector = await _get_authorized_redirector(redirector_id, current_user, svc, db=db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     ssh = await _make_ssh_service(svc, redirector, db)
 

--- a/backend/app/api/routes/redirectors_pages.py
+++ b/backend/app/api/routes/redirectors_pages.py
@@ -54,7 +54,11 @@ async def redirector_detail_page(
     if not redirector:
         raise HTTPException(status_code=404, detail="Redirector not found.")
     # Owner check: non-admins can only view their own redirectors
-    if not current_user.has_permission("redirectors.view_all") and redirector.owner_id != current_user.id:
+    if (
+        not current_user.has_permission("redirectors.view_all")
+        and redirector.owner_id != current_user.id
+        and redirector.visibility != "public"
+    ):
         raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
     return templates.TemplateResponse(
@@ -81,7 +85,11 @@ async def participant_redirector_detail_page(
     redirector = await svc.get_redirector(redirector_id)
     if not redirector:
         raise HTTPException(status_code=404, detail="Redirector not found.")
-    if not current_user.has_permission("redirectors.view_all") and redirector.owner_id != current_user.id:
+    if (
+        not current_user.has_permission("redirectors.view_all")
+        and redirector.owner_id != current_user.id
+        and redirector.visibility != "public"
+    ):
         raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
     return templates.TemplateResponse(

--- a/backend/app/api/routes/redirectors_pages.py
+++ b/backend/app/api/routes/redirectors_pages.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from app.dependencies import get_db, require_permission
+from app.models.instance import Instance
 from app.models.redirector import Redirector
 from app.models.user import User
 from app.services.redirector_service import RedirectorService
@@ -79,6 +80,11 @@ async def redirector_detail_page(
     if not await _can_view_redirector(current_user, redirector, db):
         raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
+    instance_visibility = None
+    if redirector.instance_id:
+        linked = await db.get(Instance, redirector.instance_id)
+        instance_visibility = linked.visibility if linked else None
+
     return templates.TemplateResponse(
         "pages/redirectors/detail.html",
         {
@@ -86,6 +92,7 @@ async def redirector_detail_page(
             "current_user": current_user,
             "active_page": "redirectors",
             "redirector": redirector,
+            "instance_visibility": instance_visibility,
             "now": datetime.now(),
         },
     )
@@ -106,12 +113,18 @@ async def participant_redirector_detail_page(
     if not await _can_view_redirector(current_user, redirector, db):
         raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
+    instance_visibility = None
+    if redirector.instance_id:
+        linked = await db.get(Instance, redirector.instance_id)
+        instance_visibility = linked.visibility if linked else None
+
     return templates.TemplateResponse(
         "pages/participant/redirector_detail.html",
         {
             "request": request,
             "current_user": current_user,
             "redirector": redirector,
+            "instance_visibility": instance_visibility,
             "now": datetime.now(),
         },
     )

--- a/backend/app/api/routes/redirectors_pages.py
+++ b/backend/app/api/routes/redirectors_pages.py
@@ -16,12 +16,35 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from app.dependencies import get_db, require_permission
+from app.models.redirector import Redirector
 from app.models.user import User
 from app.services.redirector_service import RedirectorService
 from app.api.routes.views import templates
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter(tags=["Redirector Pages"])
+
+
+async def _can_view_redirector(
+    user: User, redirector: Redirector, db: AsyncSession
+) -> bool:
+    """Return True when the user may view the given redirector detail page.
+
+    Mirrors the API-side rule: admins always; owners always; sponsors for
+    any row owned by one of their invitees; anyone else only when the row
+    is marked public.
+    """
+    if user.has_permission("redirectors.view_all"):
+        return True
+    if redirector.owner_id == user.id:
+        return True
+    if redirector.visibility == "public":
+        return True
+    if getattr(user, "is_sponsor_role", False) and redirector.owner_id:
+        owner = await db.get(User, redirector.owner_id)
+        if owner is not None and owner.sponsor_id == user.id:
+            return True
+    return False
 
 
 @router.get("/admin/redirectors", response_class=HTMLResponse)
@@ -53,12 +76,7 @@ async def redirector_detail_page(
     redirector = await svc.get_redirector(redirector_id)
     if not redirector:
         raise HTTPException(status_code=404, detail="Redirector not found.")
-    # Owner check: non-admins can only view their own redirectors
-    if (
-        not current_user.has_permission("redirectors.view_all")
-        and redirector.owner_id != current_user.id
-        and redirector.visibility != "public"
-    ):
+    if not await _can_view_redirector(current_user, redirector, db):
         raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
     return templates.TemplateResponse(
@@ -85,11 +103,7 @@ async def participant_redirector_detail_page(
     redirector = await svc.get_redirector(redirector_id)
     if not redirector:
         raise HTTPException(status_code=404, detail="Redirector not found.")
-    if (
-        not current_user.has_permission("redirectors.view_all")
-        and redirector.owner_id != current_user.id
-        and redirector.visibility != "public"
-    ):
+    if not await _can_view_redirector(current_user, redirector, db):
         raise HTTPException(status_code=403, detail="Not authorized to access this redirector.")
 
     return templates.TemplateResponse(

--- a/backend/app/models/redirector.py
+++ b/backend/app/models/redirector.py
@@ -77,6 +77,9 @@ class Redirector(Base):
     owner_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
     owner = relationship("User", foreign_keys=[owner_id])
 
+    # Visibility — "private" (owner only) or "public" (visible to all participants)
+    visibility = Column(String(20), nullable=False, default="private", index=True)
+
     # Updated by test-connection and deploy operations
     status = Column(String(20), nullable=False, default=RedirectorStatus.UNKNOWN.value)
     os_info = Column(JSON, nullable=True)  # Populated by test-connection: {os, arch, kernel, uptime, ...}

--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -202,6 +202,7 @@ class RedirectorOut(BaseModel):
     owner_id: Optional[int] = None
     owner_username: Optional[str] = None
     visibility: str = "private"
+    instance_visibility: Optional[str] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -20,39 +20,30 @@ _SAFE_USERNAME_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
 _SAFE_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 _SAFE_CIPHER_RE = re.compile(r"^[a-zA-Z0-9_:!+\-@.]+$")
 
-# RFC 1918 / RFC 6598 / link-local / loopback private ranges
-_PRIVATE_NETWORKS = [
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("100.64.0.0/10"),   # Carrier-grade NAT
-    ipaddress.ip_network("169.254.0.0/16"),   # Link-local
-    ipaddress.ip_network("127.0.0.0/8"),      # Loopback
-    ipaddress.ip_network("::1/128"),           # IPv6 loopback
-    ipaddress.ip_network("fc00::/7"),          # IPv6 ULA
-    ipaddress.ip_network("fe80::/10"),         # IPv6 link-local
-]
-
-
-def _validate_public_ip(v: str) -> str:
-    """Validate that a string is a publicly routable IP address (not an FQDN, not private)."""
-    try:
-        addr = ipaddress.ip_address(v)
-    except ValueError:
-        raise ValueError(
-            f"'{v}' is not a valid IP address. Enter a publicly routable IPv4 or IPv6 address "
-            "(e.g. 203.0.113.10). Domain names and FQDNs are not accepted."
-        )
-    for net in _PRIVATE_NETWORKS:
-        if addr in net:
-            raise ValueError(
-                f"'{v}' is a private/non-routable address. "
-                "The redirector must be reachable over the internet. "
-                "Enter a publicly routable IP address (e.g. 203.0.113.10)."
-            )
-    return v
 _ALLOWED_SSL_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}
 _UNSAFE_NGINX_CHARS = re.compile(r"[;\n\r{}]")
+
+
+def _validate_host(v: str) -> str:
+    """Validate a redirector host: any valid IPv4/IPv6 address or safe hostname.
+
+    Redirectors may live on the public internet, in a private lab network,
+    or behind an internal DNS name — so we only enforce basic character
+    safety here. The SSH connection itself will fail later if the host is
+    unreachable.
+    """
+    try:
+        ipaddress.ip_address(v)
+        return v
+    except ValueError:
+        pass
+    if not _SAFE_HOSTNAME_RE.match(v):
+        raise ValueError(
+            f"'{v}' is not a valid IP address or hostname. "
+            "Enter an IPv4/IPv6 address (e.g. 203.0.113.10) or a hostname "
+            "containing only letters, digits, dots, dashes, and underscores."
+        )
+    return v
 
 
 # ---------------------------------------------------------------------------
@@ -69,11 +60,12 @@ class RedirectorCreate(BaseModel):
     ssh_key_passphrase: Optional[str] = None
     nginx_stream_dir: str = Field(default="/etc/nginx/stream.d", max_length=500)
     notes: Optional[str] = Field(None, max_length=2000)
+    visibility: str = Field(default="private", pattern="^(private|public)$")
 
     @field_validator("current_ip")
     @classmethod
     def validate_ip(cls, v: str) -> str:
-        return _validate_public_ip(v)
+        return _validate_host(v)
 
     @field_validator("ssh_username")
     @classmethod
@@ -96,6 +88,7 @@ class RedirectorFromInstance(BaseModel):
     name: Optional[str] = Field(None, max_length=255)
     nginx_stream_dir: str = Field(default="/etc/nginx/stream.d", max_length=500)
     notes: Optional[str] = Field(None, max_length=2000)
+    visibility: str = Field(default="private", pattern="^(private|public)$")
 
     @field_validator("nginx_stream_dir")
     @classmethod
@@ -163,12 +156,13 @@ class RedirectorUpdate(BaseModel):
     ssh_key_passphrase: Optional[str] = None
     nginx_stream_dir: Optional[str] = Field(None, max_length=500)
     notes: Optional[str] = Field(None, max_length=2000)
+    visibility: Optional[str] = Field(None, pattern="^(private|public)$")
 
     @field_validator("current_ip")
     @classmethod
     def validate_ip(cls, v: Optional[str]) -> Optional[str]:
         if v is not None:
-            return _validate_public_ip(v)
+            return _validate_host(v)
         return v
 
     @field_validator("ssh_username")
@@ -206,6 +200,8 @@ class RedirectorOut(BaseModel):
     created_at: datetime
     updated_at: Optional[datetime]
     owner_id: Optional[int] = None
+    owner_username: Optional[str] = None
+    visibility: str = "private"
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -121,6 +121,7 @@ class AvailableInstanceOut(BaseModel):
     ip_address: Optional[str] = None
     provider: str
     status: str
+    visibility: str = "private"
     created_at: datetime
 
     model_config = {"from_attributes": True}
@@ -132,6 +133,7 @@ class InstanceStatusOut(BaseModel):
     name: str
     ip_address: Optional[str] = None
     status: str
+    visibility: str = "private"
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/redirector_service.py
+++ b/backend/app/services/redirector_service.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional, List
 
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -27,26 +27,47 @@ class RedirectorService:
     # Redirectors
     # -------------------------------------------------------------------------
 
-    async def list_redirectors(self, owner_id: int = None) -> List[Redirector]:
-        """Return redirectors ordered by name, with stream_configs eager-loaded.
+    async def list_redirectors(
+        self,
+        owner_id: int = None,
+        include_public: bool = False,
+    ) -> List[Redirector]:
+        """Return redirectors ordered by name, with stream_configs and owner eager-loaded.
 
-        If owner_id is provided, only return redirectors owned by that user.
+        Scoping:
+          - owner_id=None → all redirectors (admin view).
+          - owner_id set, include_public=False → only this user's redirectors.
+          - owner_id set, include_public=True → user's own + visibility='public'.
         """
         query = (
             select(Redirector)
-            .options(selectinload(Redirector.stream_configs))
+            .options(
+                selectinload(Redirector.stream_configs),
+                selectinload(Redirector.owner),
+            )
             .order_by(Redirector.name)
         )
         if owner_id is not None:
-            query = query.where(Redirector.owner_id == owner_id)
+            if include_public:
+                query = query.where(
+                    or_(
+                        Redirector.owner_id == owner_id,
+                        Redirector.visibility == "public",
+                    )
+                )
+            else:
+                query = query.where(Redirector.owner_id == owner_id)
         result = await self.session.execute(query)
         return list(result.scalars().all())
 
     async def get_redirector(self, redirector_id: str) -> Optional[Redirector]:
-        """Return a redirector by ID with stream_configs eager-loaded, or None."""
+        """Return a redirector by ID with stream_configs and owner eager-loaded, or None."""
         result = await self.session.execute(
             select(Redirector)
-            .options(selectinload(Redirector.stream_configs))
+            .options(
+                selectinload(Redirector.stream_configs),
+                selectinload(Redirector.owner),
+            )
             .where(Redirector.id == redirector_id)
         )
         return result.scalar_one_or_none()
@@ -81,12 +102,15 @@ class RedirectorService:
             notes=data.get("notes"),
             owner_id=data.get("owner_id"),
             instance_id=data.get("instance_id"),
+            visibility=data.get("visibility", "private"),
         )
         self.session.add(redirector)
         await self.session.commit()
         await self.session.refresh(redirector)
-        # Refresh with stream_configs loaded so stream_count property works
-        await self.session.refresh(redirector, attribute_names=["stream_configs"])
+        # Refresh relationships so stream_count and owner are available
+        await self.session.refresh(
+            redirector, attribute_names=["stream_configs", "owner"]
+        )
         return redirector
 
     async def clear_byod_key(self, redirector: Redirector) -> Redirector:
@@ -106,7 +130,10 @@ class RedirectorService:
         Update a redirector from a dict of changed fields (from model_dump(exclude_unset=True)).
         SSH key fields: only updated when non-empty string is provided.
         """
-        simple_fields = ("name", "current_ip", "ssh_port", "ssh_username", "nginx_stream_dir", "notes")
+        simple_fields = (
+            "name", "current_ip", "ssh_port", "ssh_username",
+            "nginx_stream_dir", "notes", "visibility",
+        )
         for field in simple_fields:
             if field in data and data[field] is not None:
                 setattr(redirector, field, data[field])
@@ -125,7 +152,9 @@ class RedirectorService:
 
         await self.session.commit()
         await self.session.refresh(redirector)
-        await self.session.refresh(redirector, attribute_names=["stream_configs"])
+        await self.session.refresh(
+            redirector, attribute_names=["stream_configs", "owner"]
+        )
         return redirector
 
     async def delete_redirector(self, redirector: Redirector) -> None:

--- a/backend/app/services/redirector_service.py
+++ b/backend/app/services/redirector_service.py
@@ -31,6 +31,7 @@ class RedirectorService:
         self,
         owner_id: int = None,
         include_public: bool = False,
+        sponsored_owner_ids: Optional[List[int]] = None,
     ) -> List[Redirector]:
         """Return redirectors ordered by name, with stream_configs and owner eager-loaded.
 
@@ -38,6 +39,8 @@ class RedirectorService:
           - owner_id=None → all redirectors (admin view).
           - owner_id set, include_public=False → only this user's redirectors.
           - owner_id set, include_public=True → user's own + visibility='public'.
+          - sponsored_owner_ids provided → also include redirectors owned by
+            those users (used for sponsors who see all their invitees' rows).
         """
         query = (
             select(Redirector)
@@ -48,15 +51,12 @@ class RedirectorService:
             .order_by(Redirector.name)
         )
         if owner_id is not None:
+            clauses = [Redirector.owner_id == owner_id]
             if include_public:
-                query = query.where(
-                    or_(
-                        Redirector.owner_id == owner_id,
-                        Redirector.visibility == "public",
-                    )
-                )
-            else:
-                query = query.where(Redirector.owner_id == owner_id)
+                clauses.append(Redirector.visibility == "public")
+            if sponsored_owner_ids:
+                clauses.append(Redirector.owner_id.in_(sponsored_owner_ids))
+            query = query.where(or_(*clauses))
         result = await self.session.execute(query)
         return list(result.scalars().all())
 

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -926,6 +926,23 @@ class SSHService:
                           else "No stream block in nginx config — auto-fix will add it.",
             })
 
+            # 3c. Default HTTP site disabled (sites-enabled/default absent).
+            # A default HTTP server occupies port 80 and can interfere with
+            # stream configs that expect the port to be free.
+            _, _, def_code = self._exec(
+                client, "test -e /etc/nginx/sites-enabled/default"
+            )
+            default_site_disabled = def_code != 0
+            checks.append({
+                "id": "default_site",
+                "label": "Default HTTP site disabled",
+                "ok": default_site_disabled,
+                "detail": "sites-enabled/default is not active."
+                          if default_site_disabled
+                          else "nginx is serving a default HTTP site on port 80 "
+                               "via sites-enabled/default — auto-fix will remove it.",
+            })
+
             # 4. nginx -t (runs nginx config test — safe, read-only)
             sudo_n = "" if self.username == "root" else "sudo -n "
             out4, _, code = self._exec(
@@ -1070,6 +1087,8 @@ class SSHService:
             f"    printf '\\nstream {{\\n    include {safe_dir}/*.conf;\\n}}\\n'"
             " >> /etc/nginx/nginx.conf\n"
             "fi\n"
+            "# Remove default HTTP site so nginx doesn't hold port 80\n"
+            "rm -f /etc/nginx/sites-enabled/default\n"
             "# Disable systemd-resolved stub listener if it holds port 53\n"
             "if ss -tulnp 2>/dev/null | grep ':53 ' | grep -q 'systemd-resolve\\|resolved'; then\n"
             "    # Extract real DNS servers from netplan or resolv.conf\n"

--- a/backend/app/tasks/redirector_status_sync.py
+++ b/backend/app/tasks/redirector_status_sync.py
@@ -1,0 +1,139 @@
+"""Redirector status sync background job.
+
+Periodically SSH-tests every non-isolated redirector and updates its
+connectivity status (online/offline/unknown). Mirrors the instance status
+sync pattern but uses SSHService.run_test_connection instead of a cloud API.
+
+Runs less frequently than instance sync (every 2 minutes) because each
+check opens a real SSH connection and is considerably heavier than an
+HTTP call to a cloud provider API.
+"""
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from app.database import AsyncSessionLocal
+from app.models.redirector import Redirector, RedirectorStatus
+from app.services.redirector_service import RedirectorService
+from app.services.event_service import EventService
+from app.services.ssh_service import (
+    SSHService,
+    SSHConnectionError,
+    SSHAuthError,
+    SSHCommandError,
+    NginxReloadError,
+    run_test_connection,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _build_ssh(
+    svc: RedirectorService, redirector: Redirector, session
+) -> SSHService | None:
+    """Decrypt credentials and build an SSHService for the redirector.
+
+    Returns None when the redirector uses the infrastructure key but the
+    active event has no key pair — the redirector can't be reached and
+    its status cannot be determined, so we skip it.
+    """
+    if redirector.use_infrastructure_key:
+        event_svc = EventService(session)
+        event = await event_svc.get_active_event()
+        if not event or not event.ssh_private_key:
+            return None
+        private_key_pem = event.ssh_private_key
+        passphrase = None
+    else:
+        if not redirector.ssh_private_key:
+            return None
+        private_key_pem = svc.get_decrypted_key(redirector)
+        passphrase = svc.get_decrypted_passphrase(redirector)
+
+    return SSHService(
+        hostname=redirector.current_ip,
+        port=redirector.ssh_port,
+        username=redirector.ssh_username,
+        private_key_pem=private_key_pem,
+        passphrase=passphrase,
+    )
+
+
+async def redirector_status_sync_job():
+    """SSH-test every non-isolated redirector and update its status."""
+    logger.info("Starting redirector status sync job...")
+    start_time = datetime.now(timezone.utc)
+    synced = 0
+    errors = 0
+
+    try:
+        async with AsyncSessionLocal() as session:
+            svc = RedirectorService(session)
+            result = await session.execute(
+                select(Redirector).where(
+                    Redirector.status != RedirectorStatus.ISOLATED.value
+                )
+            )
+            redirectors = list(result.scalars().all())
+
+            if not redirectors:
+                logger.debug("No redirectors to sync")
+                return
+
+            for redirector in redirectors:
+                try:
+                    ssh = await _build_ssh(svc, redirector, session)
+                    if ssh is None:
+                        continue
+
+                    try:
+                        check = await run_test_connection(ssh)
+                        new_status = "online" if check.get("success") else "offline"
+                        os_info = check.get("os_info")
+                    except (SSHConnectionError, SSHAuthError,
+                            SSHCommandError, NginxReloadError):
+                        new_status = "offline"
+                        os_info = None
+
+                    if (
+                        redirector.status != new_status
+                        or redirector.last_tested_at is None
+                        or os_info is not None
+                    ):
+                        await svc.update_status(
+                            redirector, new_status, os_info=os_info
+                        )
+                        synced += 1
+
+                except Exception as exc:
+                    errors += 1
+                    logger.error(
+                        "Failed to sync redirector %s (%s): %s",
+                        redirector.id, redirector.name, exc,
+                    )
+
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            logger.info(
+                "Redirector status sync completed: %d/%d updated, %d errors in %.2fs",
+                synced, len(redirectors), errors, duration,
+            )
+
+    except Exception as exc:
+        logger.error("Redirector status sync job failed: %s", exc)
+
+
+def schedule_redirector_status_sync_job(scheduler: AsyncIOScheduler):
+    """Register the redirector status sync job with the scheduler."""
+    scheduler.add_job(
+        redirector_status_sync_job,
+        "interval",
+        seconds=120,
+        id="redirector_status_sync",
+        name="Redirector Status Sync",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    logger.info("Scheduled redirector status sync job to run every 120 seconds")

--- a/backend/app/tasks/scheduler.py
+++ b/backend/app/tasks/scheduler.py
@@ -51,6 +51,7 @@ async def start_scheduler():
     from app.tasks.session_cleanup import schedule_session_cleanup_job
     from app.tasks.invitation_reminders import schedule_invitation_reminder_job
     from app.tasks.instance_status_sync import schedule_instance_status_sync_job
+    from app.tasks.redirector_status_sync import schedule_redirector_status_sync_job
     from app.tasks.license_slot_reaper import schedule_license_slot_reaper_job
     from app.tasks.keycloak_sync import schedule_keycloak_sync_job
     from app.tasks.agent_task_timeout import schedule_agent_task_timeout_job
@@ -70,6 +71,7 @@ async def start_scheduler():
     schedule_session_cleanup_job(sched)
     schedule_invitation_reminder_job(sched)
     schedule_instance_status_sync_job(sched)
+    schedule_redirector_status_sync_job(sched)
     schedule_license_slot_reaper_job(sched)
     schedule_keycloak_sync_job(sched)
     schedule_agent_task_timeout_job(sched)

--- a/backend/app/version.py
+++ b/backend/app/version.py
@@ -4,4 +4,4 @@
 # - MAJOR: Breaking changes or significant architectural changes
 # - MINOR: New features, functionality additions
 # - PATCH: Bug fixes, small improvements
-VERSION = "1.5.0"
+VERSION = "1.5.1"

--- a/backend/migrations/versions/20260413_000000_add_visibility_to_redirectors.py
+++ b/backend/migrations/versions/20260413_000000_add_visibility_to_redirectors.py
@@ -1,0 +1,40 @@
+"""Add visibility column to redirectors.
+
+Mirrors the public/private visibility model already used by instances:
+non-owners see a redirector only when visibility='public'; owners and
+admins always see their own (and all) rows.
+
+Revision ID: 20260413_000000
+Revises: 20260409_000001
+Create Date: 2026-04-13 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260413_000000"
+down_revision = "20260409_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "redirectors",
+        sa.Column(
+            "visibility",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'private'"),
+        ),
+    )
+    op.create_index(
+        "ix_redirectors_visibility",
+        "redirectors",
+        ["visibility"],
+    )
+
+
+def downgrade():
+    op.drop_index("ix_redirectors_visibility", table_name="redirectors")
+    op.drop_column("redirectors", "visibility")

--- a/backend/migrations/versions/20260414_000000_backfill_redirector_visibility_parity.py
+++ b/backend/migrations/versions/20260414_000000_backfill_redirector_visibility_parity.py
@@ -1,0 +1,44 @@
+"""Backfill redirector visibility to match linked public instances.
+
+Revision 20260413_000000 added the visibility column with a server
+default of 'private'. Any redirector already linked to a public
+instance is now in a state the new parity rules consider invalid:
+non-owners lose visibility on a row whose parent instance is public,
+and the row stays hidden until an owner manually flips it.
+
+This backfill restores parity by promoting those rows to 'public'.
+BYO redirectors (no linked instance) and rows linked to private
+instances are left alone — their correct visibility is the owner's
+explicit choice, not something we can infer.
+
+Revision ID: 20260414_000000
+Revises: 20260413_000000
+Create Date: 2026-04-14 00:00:00
+"""
+from alembic import op
+
+
+revision = "20260414_000000"
+down_revision = "20260413_000000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE redirectors
+        SET visibility = 'public'
+        WHERE visibility = 'private'
+          AND instance_id IS NOT NULL
+          AND instance_id IN (
+              SELECT id FROM instances WHERE visibility = 'public'
+          )
+        """
+    )
+
+
+def downgrade():
+    # Intentional no-op: we cannot distinguish rows the backfill
+    # promoted from rows a user later set to 'public' on purpose.
+    pass

--- a/backend/tests/unit/test_redirector_schemas.py
+++ b/backend/tests/unit/test_redirector_schemas.py
@@ -38,33 +38,37 @@ class TestRedirectorCreate:
                 ssh_username="debian",
             )
 
-    def test_invalid_ip_rejected(self):
-        with pytest.raises(ValidationError, match="not a valid IP address"):
-            RedirectorCreate(
-                name="redir-05",
-                current_ip="not-an-ip",
-                ssh_username="debian",
-                ssh_private_key=VALID_PEM,
-            )
-
-    def test_fqdn_rejected(self):
-        with pytest.raises(ValidationError, match="not a valid IP address"):
-            RedirectorCreate(
-                name="redir-fqdn",
-                current_ip="escape.golearn.us",
-                ssh_username="root",
-                ssh_private_key=VALID_PEM,
-            )
-
-    def test_private_ip_rejected(self):
-        for ip in ("10.0.0.1", "192.168.1.1", "172.16.0.1", "127.0.0.1"):
-            with pytest.raises(ValidationError, match="private/non-routable"):
+    def test_invalid_host_rejected(self):
+        """Hosts with whitespace or shell metacharacters must be rejected."""
+        for bad in ("not an ip", "host;rm", "10.0.0.1 | whoami", "bad$host"):
+            with pytest.raises(ValidationError, match="not a valid IP address or hostname"):
                 RedirectorCreate(
-                    name="redir-priv",
-                    current_ip=ip,
+                    name="redir-05",
+                    current_ip=bad,
                     ssh_username="debian",
                     ssh_private_key=VALID_PEM,
                 )
+
+    def test_fqdn_accepted(self):
+        """FQDNs are allowed so redirectors can be reached via DNS."""
+        schema = RedirectorCreate(
+            name="redir-fqdn",
+            current_ip="redir.lab.example.com",
+            ssh_username="root",
+            ssh_private_key=VALID_PEM,
+        )
+        assert schema.current_ip == "redir.lab.example.com"
+
+    def test_private_ip_accepted(self):
+        """RFC 1918 and loopback addresses are allowed for lab/internal use."""
+        for ip in ("10.0.0.1", "192.168.1.1", "172.16.0.1", "127.0.0.1"):
+            schema = RedirectorCreate(
+                name="redir-priv",
+                current_ip=ip,
+                ssh_username="debian",
+                ssh_private_key=VALID_PEM,
+            )
+            assert schema.current_ip == ip
 
     def test_unsafe_username_rejected(self):
         with pytest.raises(ValidationError, match="invalid characters"):
@@ -130,7 +134,7 @@ class TestRedirectorUpdate:
 
     def test_invalid_ip_rejected(self):
         with pytest.raises(ValidationError):
-            RedirectorUpdate(current_ip="bad-ip")
+            RedirectorUpdate(current_ip="bad ip with space")
 
     def test_update_key_ok(self):
         schema = RedirectorUpdate(ssh_private_key=VALID_PEM)

--- a/frontend/templates/pages/participant/portal.html
+++ b/frontend/templates/pages/participant/portal.html
@@ -918,9 +918,20 @@
                                             <label class="form-label fw-semibold">IP Address</label>
                                             <input type="text" class="form-control" id="cx_redir_ip" readonly>
                                         </div>
-                                        <div class="col-12">
+                                        <div class="col-md-8">
                                             <label class="form-label fw-semibold">nginx Stream Directory</label>
                                             <input type="text" class="form-control" id="cx_stream_dir" value="/etc/nginx/stream.d">
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label class="form-label fw-semibold">Visibility</label>
+                                            <select class="form-select" id="cx_visibility">
+                                                <option value="private">Private (only I can see it)</option>
+                                                <option value="public">Public (visible to all participants)</option>
+                                            </select>
+                                            <div class="form-text text-warning d-none" id="cx_visibility_locked_hint">
+                                                The source instance is public, so the redirector management row must also be public.
+                                                Make the instance private first before setting this to private.
+                                            </div>
                                         </div>
                                         <div class="col-12">
                                             <label class="form-label fw-semibold">Notes <span class="text-muted small">(optional)</span></label>
@@ -928,6 +939,7 @@
                                         </div>
                                     </div>
                                     <input type="hidden" id="cx_selected_instance_id">
+                                    <input type="hidden" id="cx_selected_instance_visibility" value="private">
                                 </div>
                             </div>
                             <div id="addCyberXError" class="alert alert-danger mt-3 d-none"></div>
@@ -2434,14 +2446,18 @@ async function openAddCyberX() {
         if (instances.length > 0) {
             var container = document.getElementById('cx_instances_container');
             container.innerHTML = instances.map(function(inst, i) {
+                var visibility = inst.visibility || 'private';
+                var publicBadge = visibility === 'public' ? '<span class="badge bg-success ms-1">public</span>' : '';
                 return '<div class="form-check mb-2">' +
                     '<input class="form-check-input" type="radio" name="cx_choice" id="cx_inst_' + inst.id + '" value="' + inst.id + '"' +
+                    ' data-visibility="' + escapeHtml(visibility) + '"' +
                     ' onchange="document.getElementById(\'cx_provision_section\').classList.add(\'d-none\');"' +
                     (i === 0 ? ' checked' : '') + '>' +
                     '<label class="form-check-label" for="cx_inst_' + inst.id + '">' +
                     '<strong>' + escapeHtml(inst.name) + '</strong>' +
                     '<span class="text-muted ms-2">' + escapeHtml(inst.ip_address || 'IP pending') + '</span>' +
                     '<span class="badge bg-success ms-1">' + escapeHtml(inst.status) + '</span>' +
+                    publicBadge +
                     '</label></div>';
             }).join('');
             document.getElementById('cx_provision_new').addEventListener('change', function() {
@@ -2509,7 +2525,13 @@ async function cyberXNext() {
         // is only reachable when noInstancesMode is false.
         _cxSelectedInstanceId = parseInt(selected.value);
         var label = selected.closest('.form-check').querySelector('label');
-        _cxShowConfirm(_cxSelectedInstanceId, label.querySelector('strong').textContent, label.querySelector('.text-muted').textContent.trim());
+        var instVisibility = selected.dataset.visibility || 'private';
+        _cxShowConfirm(
+            _cxSelectedInstanceId,
+            label.querySelector('strong').textContent,
+            label.querySelector('.text-muted').textContent.trim(),
+            instVisibility,
+        );
     }
 }
 
@@ -2525,7 +2547,7 @@ function _cxPollInstance(instanceId) {
                 clearInterval(_cxPollTimer); _cxPollTimer = null;
                 _cxSelectedInstanceId = data.id;
                 document.getElementById('cx_provisioning').classList.add('d-none');
-                _cxShowConfirm(data.id, data.name, data.ip_address || '');
+                _cxShowConfirm(data.id, data.name, data.ip_address || '', data.visibility || 'private');
             } else if (data.status === 'ERROR') {
                 clearInterval(_cxPollTimer); _cxPollTimer = null;
                 var errEl = document.getElementById('addCyberXError');
@@ -2536,12 +2558,28 @@ function _cxPollInstance(instanceId) {
     }, 5000);
 }
 
-function _cxShowConfirm(instanceId, name, ip) {
+function _cxShowConfirm(instanceId, name, ip, instanceVisibility) {
+    instanceVisibility = instanceVisibility || 'private';
     document.getElementById('cx_selected_instance_id').value = instanceId;
+    document.getElementById('cx_selected_instance_visibility').value = instanceVisibility;
     document.getElementById('cx_redir_name').value = name;
     document.getElementById('cx_redir_ip').value = ip;
     document.getElementById('cx_stream_dir').value = '/etc/nginx/stream.d';
     document.getElementById('cx_notes').value = '';
+
+    // Visibility parity: a public instance forces the redirector to public.
+    var visSelect = document.getElementById('cx_visibility');
+    var visHint = document.getElementById('cx_visibility_locked_hint');
+    if (instanceVisibility === 'public') {
+        visSelect.value = 'public';
+        visSelect.disabled = true;
+        visHint.classList.remove('d-none');
+    } else {
+        visSelect.value = 'private';
+        visSelect.disabled = false;
+        visHint.classList.add('d-none');
+    }
+
     document.getElementById('cx_confirm_form').classList.remove('d-none');
     document.getElementById('cx_submit_btn').classList.remove('d-none');
     refreshFeatherIcons();
@@ -2567,6 +2605,7 @@ async function submitCyberX() {
         name: document.getElementById('cx_redir_name').value.trim() || null,
         nginx_stream_dir: document.getElementById('cx_stream_dir').value.trim(),
         notes: document.getElementById('cx_notes').value.trim() || null,
+        visibility: document.getElementById('cx_visibility').value,
     };
     try {
         var resp = await csrfFetch('/api/redirectors/from-instance', {

--- a/frontend/templates/pages/participant/portal.html
+++ b/frontend/templates/pages/participant/portal.html
@@ -2468,13 +2468,23 @@ async function openAddCyberX() {
 async function cyberXNext() {
     var errEl = document.getElementById('addCyberXError');
     errEl.classList.add('d-none');
-    var selected = document.querySelector('input[name="cx_choice"]:checked');
-    if (!selected) { errEl.textContent = 'Please select an instance or choose to provision a new one.'; errEl.classList.remove('d-none'); return; }
+    // Two entry points: the instance-list view with radios, or the no-instances
+    // fallback that only offers the provision-new form.
+    var noInstancesMode = !document.getElementById('cx_no_instances').classList.contains('d-none');
+    var selected = null;
+    var selectedValue = null;
+    if (noInstancesMode) {
+        selectedValue = 'new';
+    } else {
+        selected = document.querySelector('input[name="cx_choice"]:checked');
+        if (!selected) { errEl.textContent = 'Please select an instance or choose to provision a new one.'; errEl.classList.remove('d-none'); return; }
+        selectedValue = selected.value;
+    }
     document.getElementById('cx_step1').classList.add('d-none');
     document.getElementById('cx_step2').classList.remove('d-none');
     document.getElementById('cx_next_btn').classList.add('d-none');
     document.getElementById('cx_back_btn').classList.remove('d-none');
-    if (selected.value === 'new') {
+    if (selectedValue === 'new') {
         var templateId = document.getElementById('cx_template_id').value || document.getElementById('cx_template_id_alt').value;
         var instName = (document.getElementById('cx_instance_name').value || document.getElementById('cx_instance_name_alt').value).trim();
         if (!templateId || !instName) {
@@ -2495,6 +2505,8 @@ async function cyberXNext() {
             _cxPollInstance(data.id, instName);
         } catch (err) { errEl.textContent = 'Provision failed: ' + err.message; errEl.classList.remove('d-none'); document.getElementById('cx_provisioning').classList.add('d-none'); }
     } else {
+        // selected is always set here because the existing-instance branch
+        // is only reachable when noInstancesMode is false.
         _cxSelectedInstanceId = parseInt(selected.value);
         var label = selected.closest('.form-check').querySelector('label');
         _cxShowConfirm(_cxSelectedInstanceId, label.querySelector('strong').textContent, label.querySelector('.text-muted').textContent.trim());

--- a/frontend/templates/pages/participant/portal.html
+++ b/frontend/templates/pages/participant/portal.html
@@ -716,9 +716,16 @@
             <!-- Redirectors Card -->
             <div id="redirectorsCard" style="display: none;">
                 <div class="card shadow-sm mb-4">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0"><i data-feather="shuffle" class="me-2"></i>Redirectors</h5>
-                        <span class="badge bg-primary" id="redirectorCountBadge">0</span>
+                    <div class="card-header">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center gap-3 flex-grow-1">
+                                <h5 class="mb-0"><i data-feather="shuffle" class="me-2"></i>Redirectors</h5>
+                                <span class="badge bg-primary" id="redirectorCountBadge">0</span>
+                            </div>
+                            <button class="btn btn-sm btn-outline-primary ms-3" onclick="refreshRedirectors()">
+                                <i data-feather="refresh-cw" class="me-1"></i> Refresh
+                            </button>
+                        </div>
                     </div>
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-3" id="redirectorAddRow">
@@ -750,6 +757,7 @@
                                             <th>IP</th>
                                             <th>Status</th>
                                             <th>Streams</th>
+                                            <th>Visibility</th>
                                             <th></th>
                                         </tr>
                                     </thead>
@@ -784,15 +792,13 @@
                                         <input type="text" class="form-control" id="redir_add_name" placeholder="e.g. prod-redirector-01" required>
                                     </div>
                                     <div class="col-md-6">
-                                        <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span>
+                                        <label class="form-label fw-semibold">IP Address or Hostname <span class="text-danger">*</span>
                                             <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
                                                data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
-                                               title="IP Address Requirements"
-                                               data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                                               title="Host"
+                                               data-bs-content="Enter an IPv4/IPv6 address or a hostname the CyberX server can reach over SSH. Public, private (10.x, 172.16-31.x, 192.168.x), and DNS names are all accepted."></i>
                                         </label>
-                                        <input type="text" class="form-control" id="redir_add_ip" placeholder="203.0.113.10" required
-                                               onblur="checkIPField(this, 'redirAddIpWarn')">
-                                        <div id="redirAddIpWarn" class="form-text text-warning d-none"></div>
+                                        <input type="text" class="form-control" id="redir_add_ip" placeholder="203.0.113.10 or redir.lab.example.com" required>
                                     </div>
                                     <div class="col-md-4">
                                         <label class="form-label fw-semibold">SSH Port</label>
@@ -2026,40 +2032,6 @@ function parseApiError(detail, fallback) {
     return String(detail);
 }
 
-function isPrivateIP(ip) {
-    var parts = ip.split('.');
-    if (parts.length === 4 && parts.every(function(p) { return /^\d{1,3}$/.test(p); })) {
-        var a = Number(parts[0]), b = Number(parts[1]);
-        if (a === 10) return true;
-        if (a === 172 && b >= 16 && b <= 31) return true;
-        if (a === 192 && b === 168) return true;
-        if (a === 100 && b >= 64 && b <= 127) return true;
-        if (a === 169 && b === 254) return true;
-        if (a === 127) return true;
-    }
-    if (ip === '::1') return true;
-    var lower = ip.toLowerCase();
-    if (lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80')) return true;
-    return false;
-}
-
-function looksLikeFQDN(val) { return /[a-zA-Z]/.test(val) && val.includes('.'); }
-
-function checkIPField(input, warnId) {
-    var val = input.value.trim();
-    var warnEl = document.getElementById(warnId);
-    if (!val) { warnEl.classList.add('d-none'); return; }
-    if (looksLikeFQDN(val)) {
-        warnEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
-        warnEl.classList.remove('d-none');
-    } else if (isPrivateIP(val)) {
-        warnEl.textContent = 'This is a private/non-routable address. The redirector must be reachable over the internet.';
-        warnEl.classList.remove('d-none');
-    } else {
-        warnEl.classList.add('d-none');
-    }
-}
-
 // =============================================================================
 // CPE Certificates Functions
 // =============================================================================
@@ -2313,6 +2285,29 @@ var _cyberXModal = null;
 var _cxPollTimer = null;
 var _cxSelectedInstanceId = null;
 
+async function refreshRedirectors() {
+    var refreshBtn = document.querySelector('[onclick="refreshRedirectors()"]');
+    var originalHtml = refreshBtn ? refreshBtn.innerHTML : '';
+    try {
+        if (refreshBtn) {
+            refreshBtn.disabled = true;
+            refreshBtn.innerHTML = '<i data-feather="refresh-cw" class="me-1 rotating"></i> Refreshing...';
+            refreshFeatherIcons();
+        }
+        // Background sync task handles SSH status updates every 2 minutes;
+        // this just re-reads the list from the database.
+        await loadRedirectors();
+    } catch (error) {
+        console.error('Failed to refresh redirectors:', error);
+    } finally {
+        if (refreshBtn) {
+            refreshBtn.disabled = false;
+            refreshBtn.innerHTML = originalHtml;
+            refreshFeatherIcons();
+        }
+    }
+}
+
 async function loadRedirectors() {
     try {
         var resp = await csrfFetch('/api/redirectors/');
@@ -2344,14 +2339,22 @@ function renderRedirectors(redirectors) {
         var typeBadge = r.instance_id
             ? '<span class="badge bg-info ms-1">CyberX</span>'
             : '<span class="badge bg-secondary ms-1">BYOD</span>';
+        var visibility = r.visibility || 'private';
+        var visBadge = visibility === 'public' ? 'bg-success' : 'bg-secondary';
+        var isOwner = r.owner_id === currentUser.id;
+        var canManage = isOwner || hasPermission('redirectors.view_all');
+        var ownerSuffix = (visibility !== 'private' && r.owner_username && !isOwner)
+            ? '<br><small>by ' + escapeHtml(r.owner_username) + '</small>'
+            : '';
         return '<tr>' +
             '<td><a href="/portal/redirectors/' + escapeHtml(r.id) + '" class="fw-semibold text-decoration-none" style="color:var(--bs-danger,#dc3545);">' + escapeHtml(r.name) + '</a>' + typeBadge + '</td>' +
             '<td class="text-muted">' + escapeHtml(r.current_ip) + '</td>' +
             '<td><span class="badge ' + cls + '">' + escapeHtml(r.status) + '</span></td>' +
             '<td><span class="badge bg-secondary rounded-pill">' + r.stream_count + '</span></td>' +
+            '<td><span class="badge ' + visBadge + '">' + escapeHtml(visibility) + '</span>' + ownerSuffix + '</td>' +
             '<td class="text-end">' +
                 '<a href="/portal/redirectors/' + escapeHtml(r.id) + '" class="btn btn-sm btn-outline-secondary me-1" title="Manage"><i data-feather="settings"></i></a>' +
-                '<button class="btn btn-sm btn-outline-danger" title="Delete" onclick="deleteRedirector(\'' + escapeHtml(r.id) + '\', \'' + escapeHtml(r.name) + '\')"><i data-feather="trash-2"></i></button>' +
+                (canManage ? '<button class="btn btn-sm btn-outline-danger" title="Delete" onclick="deleteRedirector(\'' + escapeHtml(r.id) + '\', \'' + escapeHtml(r.name) + '\')"><i data-feather="trash-2"></i></button>' : '') +
             '</td>' +
         '</tr>';
     }).join('');
@@ -2385,12 +2388,6 @@ async function submitAddBYOD() {
     }
     if (!payload.ssh_private_key) {
         errEl.textContent = 'SSH private key is required.'; errEl.classList.remove('d-none'); return;
-    }
-    if (looksLikeFQDN(payload.current_ip)) {
-        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).'; errEl.classList.remove('d-none'); return;
-    }
-    if (isPrivateIP(payload.current_ip)) {
-        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.'; errEl.classList.remove('d-none'); return;
     }
     try {
         var resp = await csrfFetch('/api/redirectors/', {

--- a/frontend/templates/pages/participant/redirector_detail.html
+++ b/frontend/templates/pages/participant/redirector_detail.html
@@ -268,10 +268,17 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
                     </div>
                     <div class="col-md-4">
                         <label class="form-label fw-semibold">Visibility</label>
-                        <select class="form-select" id="er_visibility">
+                        <select class="form-select" id="er_visibility"
+                            {% if instance_visibility == 'public' %}disabled{% endif %}>
                             <option value="private"{% if redirector.visibility != 'public' %} selected{% endif %}>Private (only I can see it)</option>
                             <option value="public"{% if redirector.visibility == 'public' %} selected{% endif %}>Public (visible to all participants)</option>
                         </select>
+                        {% if instance_visibility == 'public' %}
+                        <div class="form-text text-warning">
+                            The linked instance is public, so this redirector must also be public.
+                            Make the instance private first (delete the redirector to unblock the change) before setting this to private.
+                        </div>
+                        {% endif %}
                     </div>
                     <div class="col-12">
                         <label class="form-label fw-semibold">Notes</label>

--- a/frontend/templates/pages/participant/redirector_detail.html
+++ b/frontend/templates/pages/participant/redirector_detail.html
@@ -8,6 +8,9 @@ tr.stream-conflict > td { background-color: rgba(220,53,69,0.15) !important; }
 tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !important; }
 [data-theme="dark"] tr.stream-conflict > td { background-color: rgba(220,53,69,0.25) !important; }
 [data-theme="dark"] tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.35) !important; }
+.prereq-header { cursor: pointer; user-select: none; }
+.prereq-chevron { transition: transform 0.2s ease-in-out; width: 18px; height: 18px; }
+.prereq-header[aria-expanded="true"] .prereq-chevron { transform: rotate(180deg); }
 </style>
 {% endblock %}
 
@@ -137,64 +140,41 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
     {% endif %}
 
     <!-- Prerequisites (collapsible) -->
-    <div class="accordion mb-4" id="setupGuide">
-        <div class="accordion-item border">
-            <h2 class="accordion-header">
-                <button class="accordion-button collapsed fw-semibold" type="button"
-                    data-bs-toggle="collapse" data-bs-target="#setupGuideBody">
-                    <i data-feather="check-square" class="me-2"></i>Prerequisites
-                    <span id="prereqBadge" class="badge bg-secondary ms-2 d-none">?</span>
+    <div class="card border mb-4" id="setupGuide">
+        <div class="card-header d-flex align-items-center justify-content-between gap-2 flex-wrap prereq-header"
+             role="button" data-bs-toggle="collapse" data-bs-target="#setupGuideBody"
+             aria-expanded="false" aria-controls="setupGuideBody">
+            <div class="d-flex align-items-center flex-grow-1">
+                <i data-feather="check-square" class="me-2"></i>
+                <span class="fw-semibold">Prerequisites</span>
+                <span id="prereqBadge" class="badge bg-secondary ms-2 d-none">?</span>
+            </div>
+            <div class="d-flex align-items-center gap-2" onclick="event.stopPropagation();">
+                <button class="btn btn-sm btn-outline-secondary" type="button" onclick="event.stopPropagation(); checkPrereqs();">
+                    <i data-feather="refresh-cw" class="me-1"></i>Re-check
                 </button>
-            </h2>
-            <div id="setupGuideBody" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                    <div class="d-flex justify-content-between align-items-center mb-3">
-                        <span class="small text-muted">Required on <code>{{ redirector.current_ip }}</code> for CyberX to operate.</span>
-                        <div class="d-flex gap-2">
-                            <button class="btn btn-sm btn-outline-secondary" onclick="checkPrereqs()">
-                                <i data-feather="refresh-cw" class="me-1"></i>Re-check
-                            </button>
-                            <button class="btn btn-sm btn-warning d-none" id="fixPrereqsBtn" onclick="fixPrereqs()">
-                                <i data-feather="tool" class="me-1"></i>Auto-fix
-                            </button>
-                        </div>
-                    </div>
-                    <div id="prereqResults">
-                        <!-- populated by checkPrereqs() -->
-                        <div class="text-muted small fst-italic">Click "Re-check" or expand to run live check.</div>
-                    </div>
-                    <div id="fixPrereqStatus" class="mt-2 small d-none"></div>
-                    <hr class="my-3">
-                    <p class="small mb-2 fw-semibold">Manual setup reference:</p>
-                    <div class="small text-muted mb-1">sudoers (<code>/etc/sudoers.d/cyberx</code>):</div>
-                    <pre class="bg-dark text-light rounded p-2 mb-2 small">{{ redirector.ssh_username | e }} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/systemctl restart nginx, /bin/bash /var/lib/cyberx/scripts/.cyberx_nginx_fix_*.sh</pre>
-                    <div class="small text-muted mb-1">nginx.conf stream block:</div>
-                    <pre class="bg-dark text-light rounded p-2 mb-0 small">stream {
-    include {{ redirector.nginx_stream_dir | e }}/*.conf;
-}</pre>
-                </div>
+                <button class="btn btn-sm btn-warning d-none" id="fixPrereqsBtn" type="button" onclick="event.stopPropagation(); fixPrereqs();">
+                    <i data-feather="tool" class="me-1"></i>Auto-fix
+                </button>
+                <i data-feather="chevron-down" class="prereq-chevron ms-1"></i>
             </div>
         </div>
-    </div>
-
-    <!-- nginx Setup Warning Banner (shown when setup issues detected) -->
-    <div id="nginxSetupBanner" class="alert alert-warning d-none mb-4" role="alert">
-        <div class="d-flex align-items-start gap-3">
-            <i data-feather="alert-triangle" style="flex-shrink:0;margin-top:2px;width:20px;height:20px;"></i>
-            <div class="flex-grow-1">
-                <strong>nginx Configuration Issues Detected</strong>
-                <ul id="nginxSetupIssues" class="mb-2 mt-1 ps-3 small"></ul>
-                <div class="d-flex align-items-center gap-2 flex-wrap">
-                    <button class="btn btn-sm btn-warning" id="fixNginxBtn" onclick="fixNginxSetup()">
-                        <i data-feather="tool" class="me-1"></i>Fix nginx.conf
-                    </button>
-                    <span id="fixNginxStatus" class="small d-none"></span>
+        <div id="setupGuideBody" class="collapse">
+            <div class="card-body">
+                <div class="small text-muted mb-3">Required on <code>{{ redirector.current_ip }}</code> for CyberX to operate.</div>
+                <div id="prereqResults">
+                    <!-- populated by checkPrereqs() -->
+                    <div class="text-muted small fst-italic">Click "Re-check" or expand to run live check.</div>
                 </div>
-                <p class="mb-0 mt-2 small text-muted">
-                    The fix will: remove <code>sites-enabled/default</code>, load the stream module,
-                    add a stream block to <code>nginx.conf</code>, and reload nginx.
-                    {% if redirector.ssh_username != 'root' %}Requires sudoers access for the SSH user.{% endif %}
-                </p>
+                <div id="fixPrereqStatus" class="mt-2 small d-none"></div>
+                <hr class="my-3">
+                <p class="small mb-2 fw-semibold">Manual setup reference:</p>
+                <div class="small text-muted mb-1">sudoers (<code>/etc/sudoers.d/cyberx</code>):</div>
+                <pre class="bg-dark text-light rounded p-2 mb-2 small">{{ redirector.ssh_username | e }} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/systemctl restart nginx, /bin/bash /var/lib/cyberx/scripts/.cyberx_nginx_fix_*.sh</pre>
+                <div class="small text-muted mb-1">nginx.conf stream block:</div>
+                <pre class="bg-dark text-light rounded p-2 mb-0 small">stream {
+    include {{ redirector.nginx_stream_dir | e }}/*.conf;
+}</pre>
             </div>
         </div>
     </div>
@@ -253,15 +233,13 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
                         <input type="text" class="form-control" id="er_name" value="{{ redirector.name | e }}">
                     </div>
                     <div class="col-md-6">
-                        <label class="form-label fw-semibold">IP Address
+                        <label class="form-label fw-semibold">IP Address or Hostname
                             <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
                                data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
-                               title="IP Address Requirements"
-                               data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                               title="Host"
+                               data-bs-content="IPv4/IPv6 address or hostname the CyberX server can reach over SSH. Public, private, and DNS names are all accepted."></i>
                         </label>
-                        <input type="text" class="form-control" id="er_ip" value="{{ redirector.current_ip | e }}"
-                               onblur="checkIPField(this, 'erIpWarn')">
-                        <div id="erIpWarn" class="form-text text-warning d-none"></div>
+                        <input type="text" class="form-control" id="er_ip" value="{{ redirector.current_ip | e }}">
                     </div>
                     <div class="col-md-4">
                         <label class="form-label fw-semibold">SSH Port</label>
@@ -284,9 +262,16 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
                         <input type="password" class="form-control" id="er_pass"
                             placeholder="Leave blank to keep existing passphrase">
                     </div>
-                    <div class="col-12">
+                    <div class="col-md-8">
                         <label class="form-label fw-semibold">nginx Stream Directory</label>
                         <input type="text" class="form-control" id="er_dir" value="{{ redirector.nginx_stream_dir | e }}">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold">Visibility</label>
+                        <select class="form-select" id="er_visibility">
+                            <option value="private"{% if redirector.visibility != 'public' %} selected{% endif %}>Private (only I can see it)</option>
+                            <option value="public"{% if redirector.visibility == 'public' %} selected{% endif %}>Public (visible to all participants)</option>
+                        </select>
                     </div>
                     <div class="col-12">
                         <label class="form-label fw-semibold">Notes</label>
@@ -596,7 +581,6 @@ document.addEventListener('DOMContentLoaded', () => {
         new bootstrap.Popover(el, { html: false });
     });
     loadStreams().then(startPolling);
-    checkNginxSetup();
     checkPrereqs();
 });
 
@@ -1006,19 +990,8 @@ async function submitEditRedirector() {
     if (v('er_key').trim())   payload.ssh_private_key = v('er_key').trim();
     if (v('er_pass'))         payload.ssh_key_passphrase = v('er_pass');
     if (v('er_dir').trim())   payload.nginx_stream_dir = v('er_dir').trim();
+    payload.visibility = v('er_visibility');
     payload.notes = v('er_notes').trim() || null;
-
-    const ip = payload.current_ip;
-    if (ip && looksLikeFQDN(ip)) {
-        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
-        errEl.classList.remove('d-none');
-        return;
-    }
-    if (ip && isPrivateIP(ip)) {
-        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.';
-        errEl.classList.remove('d-none');
-        return;
-    }
 
     try {
         const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}`, {
@@ -1289,7 +1262,6 @@ async function fixPrereqs() {
 
         // 3. Update the UI with the fresh check results
         await checkPrereqs();
-        await checkNginxSetup();
     } catch (err) {
         showToast(`Fix failed: ${escHtml(err.message)}`, 'danger');
         statusEl.textContent = `Failed: ${err.message}`;
@@ -1298,66 +1270,6 @@ async function fixPrereqs() {
     } finally {
         btn.disabled = false;
         btn.innerHTML = '<i data-feather="tool" class="me-1"></i>Auto-fix';
-        refreshUI();
-    }
-}
-
-// ============================================================
-// nginx setup check + fix
-// ============================================================
-async function checkNginxSetup() {
-    try {
-        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/check-nginx-setup`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-        });
-        if (!resp.ok) return;
-        const data = await resp.json();
-        const banner = document.getElementById('nginxSetupBanner');
-        if (data.nginx_conf_ok) {
-            banner.classList.add('d-none');
-        } else {
-            document.getElementById('nginxSetupIssues').innerHTML =
-                data.issues.map(i => `<li>${escHtml(i)}</li>`).join('');
-            banner.classList.remove('d-none');
-            refreshUI();
-        }
-    } catch (_) { /* SSH unreachable — skip silently */ }
-}
-
-async function fixNginxSetup() {
-    const btn = document.getElementById('fixNginxBtn');
-    const status = document.getElementById('fixNginxStatus');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Fixing…';
-    status.classList.add('d-none');
-
-    try {
-        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/fix-nginx-setup`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-        });
-        const data = await resp.json();
-        if (resp.ok && data.success) {
-            showToast('nginx configuration fixed successfully.', 'success');
-            await checkNginxSetup();
-            await checkPrereqs();
-        } else {
-            const msg = data.message || data.detail || 'Fix failed.';
-            const hint = msg.toLowerCase().includes('sudo') || msg.toLowerCase().includes('permission')
-                ? '\nEnsure the SSH user has passwordless sudo access. Run auto-fix in Prerequisites first to configure sudoers.'
-                : '';
-            status.textContent = msg + hint;
-            status.className = 'small text-danger';
-            status.classList.remove('d-none');
-        }
-    } catch (err) {
-        status.textContent = `Failed: ${err.message}`;
-        status.className = 'small text-danger';
-        status.classList.remove('d-none');
-    } finally {
-        btn.disabled = false;
-        btn.innerHTML = '<i data-feather="tool" class="me-1"></i>Fix nginx.conf';
         refreshUI();
     }
 }
@@ -1381,40 +1293,6 @@ function parseApiError(detail, fallback) {
     if (typeof detail === 'string') return detail;
     if (Array.isArray(detail)) return detail.map(e => e.msg || JSON.stringify(e)).join('; ');
     return String(detail);
-}
-
-function isPrivateIP(ip) {
-    const parts = ip.split('.');
-    if (parts.length === 4 && parts.every(p => /^\d{1,3}$/.test(p))) {
-        const [a, b] = parts.map(Number);
-        if (a === 10) return true;
-        if (a === 172 && b >= 16 && b <= 31) return true;
-        if (a === 192 && b === 168) return true;
-        if (a === 100 && b >= 64 && b <= 127) return true;
-        if (a === 169 && b === 254) return true;
-        if (a === 127) return true;
-    }
-    if (ip === '::1') return true;
-    const lower = ip.toLowerCase();
-    if (lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80')) return true;
-    return false;
-}
-
-function looksLikeFQDN(val) { return /[a-zA-Z]/.test(val) && val.includes('.'); }
-
-function checkIPField(input, warnId) {
-    const val = input.value.trim();
-    const warnEl = document.getElementById(warnId);
-    if (!val) { warnEl.classList.add('d-none'); return; }
-    if (looksLikeFQDN(val)) {
-        warnEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
-        warnEl.classList.remove('d-none');
-    } else if (isPrivateIP(val)) {
-        warnEl.textContent = 'This is a private/non-routable address. The redirector must be reachable over the internet.';
-        warnEl.classList.remove('d-none');
-    } else {
-        warnEl.classList.add('d-none');
-    }
 }
 
 function escHtml(str) {

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -227,10 +227,17 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
                     </div>
                     <div class="col-md-4">
                         <label class="form-label fw-semibold">Visibility</label>
-                        <select class="form-select" id="er_visibility">
+                        <select class="form-select" id="er_visibility"
+                            {% if instance_visibility == 'public' %}disabled{% endif %}>
                             <option value="private"{% if redirector.visibility != 'public' %} selected{% endif %}>Private (only I can see it)</option>
                             <option value="public"{% if redirector.visibility == 'public' %} selected{% endif %}>Public (visible to all participants)</option>
                         </select>
+                        {% if instance_visibility == 'public' %}
+                        <div class="form-text text-warning">
+                            The linked instance is public, so this redirector must also be public.
+                            Make the instance private first (delete the redirector to unblock the change) before setting this to private.
+                        </div>
+                        {% endif %}
                     </div>
                     <div class="col-12">
                         <label class="form-label fw-semibold">Notes</label>

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -8,6 +8,9 @@ tr.stream-conflict > td { background-color: rgba(220,53,69,0.15) !important; }
 tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !important; }
 [data-theme="dark"] tr.stream-conflict > td { background-color: rgba(220,53,69,0.25) !important; }
 [data-theme="dark"] tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.35) !important; }
+.prereq-header { cursor: pointer; user-select: none; }
+.prereq-chevron { transition: transform 0.2s ease-in-out; width: 18px; height: 18px; }
+.prereq-header[aria-expanded="true"] .prereq-chevron { transform: rotate(180deg); }
 </style>
 {% endblock %}
 
@@ -101,64 +104,41 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
     {% endif %}
 
     <!-- Prerequisites (collapsible) -->
-    <div class="accordion mb-4" id="setupGuide">
-        <div class="accordion-item border">
-            <h2 class="accordion-header">
-                <button class="accordion-button collapsed fw-semibold" type="button"
-                    data-bs-toggle="collapse" data-bs-target="#setupGuideBody">
-                    <i data-feather="check-square" class="me-2"></i>Prerequisites
-                    <span id="prereqBadge" class="badge bg-secondary ms-2 d-none">?</span>
+    <div class="card border mb-4" id="setupGuide">
+        <div class="card-header d-flex align-items-center justify-content-between gap-2 flex-wrap prereq-header"
+             role="button" data-bs-toggle="collapse" data-bs-target="#setupGuideBody"
+             aria-expanded="false" aria-controls="setupGuideBody">
+            <div class="d-flex align-items-center flex-grow-1">
+                <i data-feather="check-square" class="me-2"></i>
+                <span class="fw-semibold">Prerequisites</span>
+                <span id="prereqBadge" class="badge bg-secondary ms-2 d-none">?</span>
+            </div>
+            <div class="d-flex align-items-center gap-2" onclick="event.stopPropagation();">
+                <button class="btn btn-sm btn-outline-secondary" type="button" onclick="event.stopPropagation(); checkPrereqs();">
+                    <i data-feather="refresh-cw" class="me-1"></i>Re-check
                 </button>
-            </h2>
-            <div id="setupGuideBody" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                    <div class="d-flex justify-content-between align-items-center mb-3">
-                        <span class="small text-muted">Required on <code>{{ redirector.current_ip }}</code> for CyberX to operate.</span>
-                        <div class="d-flex gap-2">
-                            <button class="btn btn-sm btn-outline-secondary" onclick="checkPrereqs()">
-                                <i data-feather="refresh-cw" class="me-1"></i>Re-check
-                            </button>
-                            <button class="btn btn-sm btn-warning d-none" id="fixPrereqsBtn" onclick="fixPrereqs()">
-                                <i data-feather="tool" class="me-1"></i>Auto-fix
-                            </button>
-                        </div>
-                    </div>
-                    <div id="prereqResults">
-                        <!-- populated by checkPrereqs() -->
-                        <div class="text-muted small fst-italic">Click "Re-check" or expand to run live check.</div>
-                    </div>
-                    <div id="fixPrereqStatus" class="mt-2 small d-none"></div>
-                    <hr class="my-3">
-                    <p class="small mb-2 fw-semibold">Manual setup reference:</p>
-                    <div class="small text-muted mb-1">sudoers (<code>/etc/sudoers.d/cyberx</code>):</div>
-                    <pre class="bg-dark text-light rounded p-2 mb-2 small">{{ redirector.ssh_username | e }} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/systemctl restart nginx, /bin/bash /var/lib/cyberx/scripts/.cyberx_nginx_fix_*.sh</pre>
-                    <div class="small text-muted mb-1">nginx.conf stream block:</div>
-                    <pre class="bg-dark text-light rounded p-2 mb-0 small">stream {
-    include {{ redirector.nginx_stream_dir | e }}/*.conf;
-}</pre>
-                </div>
+                <button class="btn btn-sm btn-warning d-none" id="fixPrereqsBtn" type="button" onclick="event.stopPropagation(); fixPrereqs();">
+                    <i data-feather="tool" class="me-1"></i>Auto-fix
+                </button>
+                <i data-feather="chevron-down" class="prereq-chevron ms-1"></i>
             </div>
         </div>
-    </div>
-
-    <!-- nginx Setup Warning Banner (shown when setup issues detected) -->
-    <div id="nginxSetupBanner" class="alert alert-warning d-none mb-4" role="alert">
-        <div class="d-flex align-items-start gap-3">
-            <i data-feather="alert-triangle" style="flex-shrink:0;margin-top:2px;width:20px;height:20px;"></i>
-            <div class="flex-grow-1">
-                <strong>nginx Configuration Issues Detected</strong>
-                <ul id="nginxSetupIssues" class="mb-2 mt-1 ps-3 small"></ul>
-                <div class="d-flex align-items-center gap-2 flex-wrap">
-                    <button class="btn btn-sm btn-warning" id="fixNginxBtn" onclick="fixNginxSetup()">
-                        <i data-feather="tool" class="me-1"></i>Fix nginx.conf
-                    </button>
-                    <span id="fixNginxStatus" class="small d-none"></span>
+        <div id="setupGuideBody" class="collapse">
+            <div class="card-body">
+                <div class="small text-muted mb-3">Required on <code>{{ redirector.current_ip }}</code> for CyberX to operate.</div>
+                <div id="prereqResults">
+                    <!-- populated by checkPrereqs() -->
+                    <div class="text-muted small fst-italic">Click "Re-check" or expand to run live check.</div>
                 </div>
-                <p class="mb-0 mt-2 small text-muted">
-                    The fix will: remove <code>sites-enabled/default</code>, load the stream module,
-                    add a stream block to <code>nginx.conf</code>, and reload nginx.
-                    {% if redirector.ssh_username != 'root' %}Requires sudoers access for the SSH user.{% endif %}
-                </p>
+                <div id="fixPrereqStatus" class="mt-2 small d-none"></div>
+                <hr class="my-3">
+                <p class="small mb-2 fw-semibold">Manual setup reference:</p>
+                <div class="small text-muted mb-1">sudoers (<code>/etc/sudoers.d/cyberx</code>):</div>
+                <pre class="bg-dark text-light rounded p-2 mb-2 small">{{ redirector.ssh_username | e }} ALL=(ALL) NOPASSWD: /usr/sbin/nginx, /bin/systemctl reload nginx, /bin/systemctl restart nginx, /bin/bash /var/lib/cyberx/scripts/.cyberx_nginx_fix_*.sh</pre>
+                <div class="small text-muted mb-1">nginx.conf stream block:</div>
+                <pre class="bg-dark text-light rounded p-2 mb-0 small">stream {
+    include {{ redirector.nginx_stream_dir | e }}/*.conf;
+}</pre>
             </div>
         </div>
     </div>
@@ -241,9 +221,16 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
                         <input type="password" class="form-control" id="er_pass"
                             placeholder="Leave blank to keep existing passphrase">
                     </div>
-                    <div class="col-12">
+                    <div class="col-md-8">
                         <label class="form-label fw-semibold">nginx Stream Directory</label>
                         <input type="text" class="form-control" id="er_dir" value="{{ redirector.nginx_stream_dir | e }}">
+                    </div>
+                    <div class="col-md-4">
+                        <label class="form-label fw-semibold">Visibility</label>
+                        <select class="form-select" id="er_visibility">
+                            <option value="private"{% if redirector.visibility != 'public' %} selected{% endif %}>Private (only I can see it)</option>
+                            <option value="public"{% if redirector.visibility == 'public' %} selected{% endif %}>Public (visible to all participants)</option>
+                        </select>
                     </div>
                     <div class="col-12">
                         <label class="form-label fw-semibold">Notes</label>
@@ -508,7 +495,6 @@ document.addEventListener('DOMContentLoaded', () => {
         el.textContent = formatDateTime(el.textContent);
     });
     loadStreams().then(startPolling);
-    checkNginxSetup();
     checkPrereqs();
 });
 
@@ -918,6 +904,7 @@ async function submitEditRedirector() {
     if (v('er_key').trim())   payload.ssh_private_key = v('er_key').trim();
     if (v('er_pass'))         payload.ssh_key_passphrase = v('er_pass');
     if (v('er_dir').trim())   payload.nginx_stream_dir = v('er_dir').trim();
+    payload.visibility = v('er_visibility');
     payload.notes = v('er_notes').trim() || null;
 
     try {
@@ -1189,7 +1176,6 @@ async function fixPrereqs() {
 
         // 3. Update the UI with the fresh check results
         await checkPrereqs();
-        await checkNginxSetup();
     } catch (err) {
         showToast(`Fix failed: ${escHtml(err.message)}`, 'danger');
         statusEl.textContent = `Failed: ${err.message}`;
@@ -1198,66 +1184,6 @@ async function fixPrereqs() {
     } finally {
         btn.disabled = false;
         btn.innerHTML = '<i data-feather="tool" class="me-1"></i>Auto-fix';
-        refreshUI();
-    }
-}
-
-// ============================================================
-// nginx setup check + fix
-// ============================================================
-async function checkNginxSetup() {
-    try {
-        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/check-nginx-setup`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-        });
-        if (!resp.ok) return;
-        const data = await resp.json();
-        const banner = document.getElementById('nginxSetupBanner');
-        if (data.nginx_conf_ok) {
-            banner.classList.add('d-none');
-        } else {
-            document.getElementById('nginxSetupIssues').innerHTML =
-                data.issues.map(i => `<li>${escHtml(i)}</li>`).join('');
-            banner.classList.remove('d-none');
-            refreshUI();
-        }
-    } catch (_) { /* SSH unreachable — skip silently */ }
-}
-
-async function fixNginxSetup() {
-    const btn = document.getElementById('fixNginxBtn');
-    const status = document.getElementById('fixNginxStatus');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status"></span>Fixing…';
-    status.classList.add('d-none');
-
-    try {
-        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/fix-nginx-setup`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-        });
-        const data = await resp.json();
-        if (resp.ok && data.success) {
-            showToast('nginx configuration fixed successfully.', 'success');
-            await checkNginxSetup();
-            await checkPrereqs();
-        } else {
-            const msg = data.message || data.detail || 'Fix failed.';
-            const hint = msg.toLowerCase().includes('sudo') || msg.toLowerCase().includes('permission')
-                ? '\nEnsure the SSH user has passwordless sudo access. Run auto-fix in Prerequisites first to configure sudoers.'
-                : '';
-            status.textContent = msg + hint;
-            status.className = 'small text-danger';
-            status.classList.remove('d-none');
-        }
-    } catch (err) {
-        status.textContent = `Failed: ${err.message}`;
-        status.className = 'small text-danger';
-        status.classList.remove('d-none');
-    } finally {
-        btn.disabled = false;
-        btn.innerHTML = '<i data-feather="tool" class="me-1"></i>Fix nginx.conf';
         refreshUI();
     }
 }

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -53,13 +53,14 @@
                             <th>SSH User:Port</th>
                             <th>Status</th>
                             <th>Streams</th>
+                            <th>Visibility</th>
                             <th>Last Deployed</th>
                             <th class="text-end">Actions</th>
                         </tr>
                     </thead>
                     <tbody id="redirectorsBody">
                         <tr id="loadingRow">
-                            <td colspan="7" class="text-center text-muted py-4">
+                            <td colspan="8" class="text-center text-muted py-4">
                                 <div class="spinner-border spinner-border-sm me-2" role="status"></div>
                                 Loading redirectors...
                             </td>
@@ -95,15 +96,13 @@
                             <input type="text" class="form-control" id="add_name" placeholder="e.g. prod-redirector-01" required>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label fw-semibold">IP Address <span class="text-danger">*</span>
+                            <label class="form-label fw-semibold">IP Address or Hostname <span class="text-danger">*</span>
                                 <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
                                    data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
-                                   title="IP Address Requirements"
-                                   data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                                   title="Host"
+                                   data-bs-content="IPv4/IPv6 address or hostname the CyberX server can reach over SSH. Public, private, and DNS names are all accepted."></i>
                             </label>
-                            <input type="text" class="form-control" id="add_ip" placeholder="203.0.113.10" required
-                                   onblur="checkIPField(this, 'addBYODIpWarn')">
-                            <div id="addBYODIpWarn" class="form-text text-warning d-none"></div>
+                            <input type="text" class="form-control" id="add_ip" placeholder="203.0.113.10 or redir.lab.example.com" required>
                         </div>
                         <div class="col-md-4">
                             <label class="form-label fw-semibold">SSH Port</label>
@@ -283,15 +282,13 @@
                             <input type="text" class="form-control" id="edit_name" required>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label fw-semibold">IP Address
+                            <label class="form-label fw-semibold">IP Address or Hostname
                                 <i data-feather="info" class="ms-1 text-info" style="width:14px;height:14px;cursor:pointer;"
                                    data-bs-toggle="popover" data-bs-trigger="hover focus" data-bs-placement="top"
-                                   title="IP Address Requirements"
-                                   data-bs-content="Enter a publicly routable IPv4 or IPv6 address (e.g. 203.0.113.10). Domain names and FQDNs are not accepted. Private/non-routable addresses (10.x, 172.16-31.x, 192.168.x) will be rejected."></i>
+                                   title="Host"
+                                   data-bs-content="IPv4/IPv6 address or hostname the CyberX server can reach over SSH. Public, private, and DNS names are all accepted."></i>
                             </label>
-                            <input type="text" class="form-control" id="edit_ip" required
-                                   onblur="checkIPField(this, 'editIpWarn')">
-                            <div id="editIpWarn" class="form-text text-warning d-none"></div>
+                            <input type="text" class="form-control" id="edit_ip" required>
                         </div>
                         <div class="col-md-4">
                             <label class="form-label fw-semibold">SSH Port</label>
@@ -317,9 +314,16 @@
                                 <div class="form-text">Leave blank to keep existing. Send a space to clear the passphrase.</div>
                             </div>
                         </div>
-                        <div class="col-12">
+                        <div class="col-md-8">
                             <label class="form-label fw-semibold">nginx Stream Directory</label>
                             <input type="text" class="form-control" id="edit_stream_dir">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label fw-semibold">Visibility</label>
+                            <select class="form-select" id="edit_visibility">
+                                <option value="private">Private (only I can see it)</option>
+                                <option value="public">Public (visible to all participants)</option>
+                            </select>
                         </div>
                         <div class="col-12">
                             <label class="form-label fw-semibold">Notes</label>
@@ -417,14 +421,14 @@ async function loadRedirectors() {
         renderTable(_redirectors);
     } catch (err) {
         document.getElementById('redirectorsBody').innerHTML =
-            `<tr><td colspan="7" class="text-center text-danger py-4">Failed to load redirectors: ${escHtml(err.message)}</td></tr>`;
+            `<tr><td colspan="8" class="text-center text-danger py-4">Failed to load redirectors: ${escHtml(err.message)}</td></tr>`;
     }
 }
 
 function renderTable(redirectors) {
     const tbody = document.getElementById('redirectorsBody');
     if (!redirectors.length) {
-        tbody.innerHTML = `<tr><td colspan="7" class="text-center text-muted py-5">
+        tbody.innerHTML = `<tr><td colspan="8" class="text-center text-muted py-5">
             No redirectors yet. Click <strong>Add Redirector</strong> to get started.
         </td></tr>`;
         feather.replace();
@@ -434,6 +438,11 @@ function renderTable(redirectors) {
         const typeBadge = r.instance_id
             ? '<span class="badge bg-info ms-1" title="CyberX provisioned">CyberX</span>'
             : '<span class="badge bg-secondary ms-1" title="Bring Your Own Device">BYOD</span>';
+        const visibility = r.visibility || 'private';
+        const visCls = visibility === 'public' ? 'bg-success' : 'bg-secondary';
+        const ownerSuffix = (visibility !== 'private' && r.owner_username)
+            ? `<br><small class="text-muted">by ${escHtml(r.owner_username)}</small>`
+            : '';
         return `
         <tr>
             <td>
@@ -448,6 +457,7 @@ function renderTable(redirectors) {
             </td>
             <td>${statusBadge(r.status)}</td>
             <td><span class="badge bg-secondary rounded-pill">${r.stream_count}</span></td>
+            <td><span class="badge ${visCls}">${escHtml(visibility)}</span>${ownerSuffix}</td>
             <td class="text-muted">${r.last_deployed_at ? formatDateTime(r.last_deployed_at) : '—'}</td>
             <td class="text-end">
                 <button class="btn btn-sm btn-outline-secondary me-1" title="Edit"
@@ -502,16 +512,6 @@ async function submitAddBYOD() {
     }
     if (!payload.ssh_private_key) {
         errEl.textContent = 'SSH private key is required.';
-        errEl.classList.remove('d-none');
-        return;
-    }
-    if (looksLikeFQDN(payload.current_ip)) {
-        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
-        errEl.classList.remove('d-none');
-        return;
-    }
-    if (isPrivateIP(payload.current_ip)) {
-        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.';
         errEl.classList.remove('d-none');
         return;
     }
@@ -785,6 +785,7 @@ function openEditModal(id) {
     document.getElementById('edit_ssh_key').value      = '';
     document.getElementById('edit_passphrase').value   = '';
     document.getElementById('edit_stream_dir').value   = r.nginx_stream_dir;
+    document.getElementById('edit_visibility').value   = r.visibility || 'private';
     document.getElementById('edit_notes').value        = r.notes || '';
     document.getElementById('editRedirectorError').classList.add('d-none');
 
@@ -818,6 +819,7 @@ async function submitEditRedirector() {
     if (port)  payload.ssh_port = port;
     if (user)  payload.ssh_username = user;
     if (dir)   payload.nginx_stream_dir = dir;
+    payload.visibility = document.getElementById('edit_visibility').value;
     payload.notes = notes || null;
 
     if (!isCyberX) {
@@ -825,17 +827,6 @@ async function submitEditRedirector() {
         const pass = document.getElementById('edit_passphrase').value;
         if (key)  payload.ssh_private_key = key;
         if (pass) payload.ssh_key_passphrase = pass;
-    }
-
-    if (ip && looksLikeFQDN(ip)) {
-        errEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
-        errEl.classList.remove('d-none');
-        return;
-    }
-    if (ip && isPrivateIP(ip)) {
-        errEl.textContent = 'Private/non-routable IP addresses are not permitted. The redirector must be reachable over the internet.';
-        errEl.classList.remove('d-none');
-        return;
     }
 
     try {
@@ -889,22 +880,6 @@ async function confirmDeleteRedirector() {
 // ============================================================
 // Utility
 // ============================================================
-/** Inline warning for IP address fields (blur handler) */
-function checkIPField(input, warnId) {
-    const val = input.value.trim();
-    const warnEl = document.getElementById(warnId);
-    if (!val) { warnEl.classList.add('d-none'); return; }
-    if (looksLikeFQDN(val)) {
-        warnEl.textContent = 'Domain names are not accepted. Enter a publicly routable IP address (e.g. 203.0.113.10).';
-        warnEl.classList.remove('d-none');
-    } else if (isPrivateIP(val)) {
-        warnEl.textContent = 'This is a private/non-routable address. The redirector must be reachable over the internet.';
-        warnEl.classList.remove('d-none');
-    } else {
-        warnEl.classList.add('d-none');
-    }
-}
-
 function escHtml(str) {
     if (!str) return '';
     return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
@@ -924,29 +899,5 @@ function parseApiError(detail, fallback) {
     return String(detail);
 }
 
-/** RFC 1918 / RFC 6598 / link-local / loopback check */
-function isPrivateIP(ip) {
-    // IPv4 check
-    const parts = ip.split('.');
-    if (parts.length === 4 && parts.every(p => /^\d{1,3}$/.test(p))) {
-        const [a, b] = parts.map(Number);
-        if (a === 10) return true;                          // 10.0.0.0/8
-        if (a === 172 && b >= 16 && b <= 31) return true;   // 172.16.0.0/12
-        if (a === 192 && b === 168) return true;            // 192.168.0.0/16
-        if (a === 100 && b >= 64 && b <= 127) return true;  // 100.64.0.0/10
-        if (a === 169 && b === 254) return true;            // 169.254.0.0/16
-        if (a === 127) return true;                         // 127.0.0.0/8
-    }
-    // IPv6 private/loopback
-    if (ip === '::1') return true;
-    const lower = ip.toLowerCase();
-    if (lower.startsWith('fc') || lower.startsWith('fd') || lower.startsWith('fe80')) return true;
-    return false;
-}
-
-/** Check if a value looks like a domain name rather than an IP */
-function looksLikeFQDN(val) {
-    return /[a-zA-Z]/.test(val) && val.includes('.');
-}
 </script>
 {% endblock %}

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -623,12 +623,19 @@ async function cyberXNext() {
     const errEl = document.getElementById('addCyberXError');
     errEl.classList.add('d-none');
 
-    // Determine user's choice
-    const selected = document.querySelector('input[name="cx_choice"]:checked');
-    if (!selected) {
-        errEl.textContent = 'Please select an instance or choose to provision a new one.';
-        errEl.classList.remove('d-none');
-        return;
+    // Determine user's choice. Two entry points:
+    //   1. Instance list visible → radio button selection (existing or "new")
+    //   2. No-instances fallback → form fields only, treat as provision-new
+    const noInstancesMode = !document.getElementById('cx_no_instances').classList.contains('d-none');
+    let selectedValue = noInstancesMode ? 'new' : null;
+    if (!noInstancesMode) {
+        const selected = document.querySelector('input[name="cx_choice"]:checked');
+        if (!selected) {
+            errEl.textContent = 'Please select an instance or choose to provision a new one.';
+            errEl.classList.remove('d-none');
+            return;
+        }
+        selectedValue = selected.value;
     }
 
     document.getElementById('cx_step1').classList.add('d-none');
@@ -636,7 +643,7 @@ async function cyberXNext() {
     document.getElementById('cx_next_btn').classList.add('d-none');
     document.getElementById('cx_back_btn').classList.remove('d-none');
 
-    if (selected.value === 'new') {
+    if (selectedValue === 'new') {
         // Provision a new instance
         const templateId = document.getElementById('cx_template_id').value
             || document.getElementById('cx_template_id_alt').value;
@@ -678,6 +685,7 @@ async function cyberXNext() {
         }
     } else {
         // Selected an existing instance
+        const selected = document.querySelector('input[name="cx_choice"]:checked');
         _cxSelectedInstanceId = parseInt(selected.value);
         const label = selected.closest('.form-check').querySelector('label');
         const instName = label.querySelector('strong').textContent;

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -233,9 +233,20 @@
                                 <label class="form-label fw-semibold">IP Address</label>
                                 <input type="text" class="form-control" id="cx_redir_ip" readonly>
                             </div>
-                            <div class="col-12">
+                            <div class="col-md-8">
                                 <label class="form-label fw-semibold">nginx Stream Directory</label>
                                 <input type="text" class="form-control" id="cx_stream_dir" value="/etc/nginx/stream.d">
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label fw-semibold">Visibility</label>
+                                <select class="form-select" id="cx_visibility">
+                                    <option value="private">Private (only I can see it)</option>
+                                    <option value="public">Public (visible to all participants)</option>
+                                </select>
+                                <div class="form-text text-warning d-none" id="cx_visibility_locked_hint">
+                                    The source instance is public, so the redirector management row must also be public.
+                                    Make the instance private first before setting this to private.
+                                </div>
                             </div>
                             <div class="col-12">
                                 <label class="form-label fw-semibold">Notes <span class="text-muted small">(optional)</span></label>
@@ -243,6 +254,7 @@
                             </div>
                         </div>
                         <input type="hidden" id="cx_selected_instance_id">
+                        <input type="hidden" id="cx_selected_instance_visibility" value="private">
                     </div>
                 </div>
 
@@ -576,12 +588,14 @@ async function openAddCyberX() {
                 <div class="form-check mb-2">
                     <input class="form-check-input" type="radio" name="cx_choice"
                            id="cx_inst_${inst.id}" value="${inst.id}"
+                           data-visibility="${escHtml(inst.visibility || 'private')}"
                            onchange="document.getElementById('cx_provision_section').classList.add('d-none');"
                            ${i === 0 ? 'checked' : ''}>
                     <label class="form-check-label" for="cx_inst_${inst.id}">
                         <strong>${escHtml(inst.name)}</strong>
                         <span class="text-muted ms-2">${escHtml(inst.ip_address || 'IP pending')}</span>
                         <span class="badge bg-success ms-1">${escHtml(inst.status)}</span>
+                        ${inst.visibility === 'public' ? '<span class="badge bg-success ms-1">public</span>' : ''}
                     </label>
                 </div>
             `).join('');
@@ -694,8 +708,9 @@ async function cyberXNext() {
         const label = selected.closest('.form-check').querySelector('label');
         const instName = label.querySelector('strong').textContent;
         const instIp = label.querySelector('.text-muted').textContent.trim();
+        const instVisibility = selected.dataset.visibility || 'private';
 
-        showCyberXConfirm(_cxSelectedInstanceId, instName, instIp);
+        showCyberXConfirm(_cxSelectedInstanceId, instName, instIp, instVisibility);
     }
 }
 
@@ -712,7 +727,7 @@ function pollInstanceStatus(instanceId, name) {
                 _cxPollTimer = null;
                 _cxSelectedInstanceId = data.id;
                 document.getElementById('cx_provisioning').classList.add('d-none');
-                showCyberXConfirm(data.id, data.name, data.ip_address || '');
+                showCyberXConfirm(data.id, data.name, data.ip_address || '', data.visibility || 'private');
             } else if (data.status === 'ERROR') {
                 clearInterval(_cxPollTimer);
                 _cxPollTimer = null;
@@ -725,12 +740,28 @@ function pollInstanceStatus(instanceId, name) {
     }, 5000);
 }
 
-function showCyberXConfirm(instanceId, name, ip) {
+function showCyberXConfirm(instanceId, name, ip, instanceVisibility) {
+    instanceVisibility = instanceVisibility || 'private';
     document.getElementById('cx_selected_instance_id').value = instanceId;
+    document.getElementById('cx_selected_instance_visibility').value = instanceVisibility;
     document.getElementById('cx_redir_name').value = name;
     document.getElementById('cx_redir_ip').value = ip;
     document.getElementById('cx_stream_dir').value = '/etc/nginx/stream.d';
     document.getElementById('cx_notes').value = '';
+
+    // Visibility parity: a public instance forces the redirector to public.
+    const visSelect = document.getElementById('cx_visibility');
+    const visHint = document.getElementById('cx_visibility_locked_hint');
+    if (instanceVisibility === 'public') {
+        visSelect.value = 'public';
+        visSelect.disabled = true;
+        visHint.classList.remove('d-none');
+    } else {
+        visSelect.value = 'private';
+        visSelect.disabled = false;
+        visHint.classList.add('d-none');
+    }
+
     document.getElementById('cx_confirm_form').classList.remove('d-none');
     document.getElementById('cx_submit_btn').classList.remove('d-none');
     feather.replace();
@@ -758,6 +789,7 @@ async function submitCyberX() {
         name:            document.getElementById('cx_redir_name').value.trim() || null,
         nginx_stream_dir: document.getElementById('cx_stream_dir').value.trim(),
         notes:           document.getElementById('cx_notes').value.trim() || null,
+        visibility:      document.getElementById('cx_visibility').value,
     };
 
     try {

--- a/frontend/templates/pages/redirectors/list.html
+++ b/frontend/templates/pages/redirectors/list.html
@@ -324,6 +324,10 @@
                                 <option value="private">Private (only I can see it)</option>
                                 <option value="public">Public (visible to all participants)</option>
                             </select>
+                            <div class="form-text text-warning d-none" id="edit_visibility_locked_hint">
+                                The linked instance is public, so this redirector must also be public.
+                                Make the instance private first (delete the redirector to unblock the change) before setting this to private.
+                            </div>
                         </div>
                         <div class="col-12">
                             <label class="form-label fw-semibold">Notes</label>
@@ -796,6 +800,19 @@ function openEditModal(id) {
     document.getElementById('edit_visibility').value   = r.visibility || 'private';
     document.getElementById('edit_notes').value        = r.notes || '';
     document.getElementById('editRedirectorError').classList.add('d-none');
+
+    // Lock visibility when the linked instance is public — the redirector
+    // row must stay public to keep stream config access consistent.
+    const visSelect = document.getElementById('edit_visibility');
+    const visHint = document.getElementById('edit_visibility_locked_hint');
+    if (r.instance_visibility === 'public') {
+        visSelect.value = 'public';
+        visSelect.disabled = true;
+        visHint.classList.remove('d-none');
+    } else {
+        visSelect.disabled = false;
+        visHint.classList.add('d-none');
+    }
 
     // Hide SSH key fields for CyberX redirectors (managed by infra key)
     const keySection = document.getElementById('edit_byod_key_section');

--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,17 @@
-# Render.com Blueprint for CyberX Event Management System - STAGING
+# Render.com Blueprint for CyberX Event Management System - PRODUCTION
 # Deploys: FastAPI app + Background Worker
 # Uses Supabase for PostgreSQL (configured via environment variables)
 # Estimated cost: ~$14/month (2x $7 services)
 # Trigger: DATABASE_URL will be injected via GitHub Actions
 
 services:
-  # FastAPI Web Application - STAGING
+  # FastAPI Web Application - PRODUCTION
   - type: web
-    name: cyberx-event-mgmt-staging
+    name: cyberx-event-mgmt-production
     runtime: python
     region: virginia  # US East
     plan: starter  # $7/month - 512MB RAM (sufficient for 100 users)
-    branch: staging  # Staging service watches staging branch
+    branch: main  # Production deploys from main branch
     autoDeploy: false  # Disable auto deploy - only deploy via GitHub Actions
     buildCommand: |
       cd backend
@@ -25,7 +25,7 @@ services:
       - key: PYTHON_VERSION
         value: 3.12.8
       - key: ENVIRONMENT
-        value: staging
+        value: production
       - key: DEBUG
         value: "false"
       # Database - Supabase connection string (set manually in Render dashboard)
@@ -46,7 +46,7 @@ services:
       - key: SENDGRID_FROM_NAME
         value: CyberX Red Team
       - key: SENDGRID_SANDBOX_MODE
-        value: "true"  # STAGING: Sandbox mode
+        value: "false"  # PRODUCTION: Send real emails
       # SendGrid webhook verification
       - key: SENDGRID_WEBHOOK_VERIFICATION_KEY
         sync: false
@@ -59,26 +59,30 @@ services:
         value: 10.20.200.1
       - key: VPN_ALLOWED_IPS
         value: 10.0.0.0/8,fd00:a::/32
-      # Application configuration - STAGING URLs
+      # Application configuration - PRODUCTION URLs
       - key: FRONTEND_URL
-        value: https://staging.events.cyberxredteam.org
+        value: https://events.cyberxredteam.org
       - key: ALLOWED_HOSTS
-        value: staging.events.cyberxredteam.org
+        value: events.cyberxredteam.org
       - key: SESSION_EXPIRY_HOURS
         value: 24
-      - key: CSRF_TOKEN_MAX_AGE
-        value: 30
       - key: BULK_EMAIL_INTERVAL_MINUTES
-        value: 45
+        value: 15
       # Reminder configuration
+      - key: REMINDER_1_ENABLED
+        value: "true"
       - key: REMINDER_1_DAYS_AFTER_INVITE
         value: 7
       - key: REMINDER_1_MIN_DAYS_BEFORE_EVENT
         value: 14
+      - key: REMINDER_2_ENABLED
+        value: "false"
       - key: REMINDER_2_DAYS_AFTER_INVITE
         value: 14
       - key: REMINDER_2_MIN_DAYS_BEFORE_EVENT
         value: 7
+      - key: REMINDER_3_ENABLED
+        value: "true"
       - key: REMINDER_3_DAYS_BEFORE_EVENT
         value: 3
       - key: REMINDER_CHECK_INTERVAL_HOURS
@@ -102,7 +106,7 @@ services:
       - key: DISCORD_BOT_TOKEN
         sync: false
       - key: DISCORD_INVITE_ENABLED
-        value: "false"
+        value: "true"
       # PowerDNS configuration
       - key: POWERDNS_API_URL
         sync: false
@@ -146,7 +150,7 @@ services:
       - key: CPE_SIGNER_2_NAME
         sync: false
       - key: GOTENBERG_URL
-        value: http://cyberx-gotenberg-staging:3000
+        value: http://cyberx-gotenberg-production:3000
       # Render API (for sidecar lifecycle management)
       - key: RENDER_API_KEY
         sync: false
@@ -167,7 +171,7 @@ services:
 
   # Gotenberg - DOCX to PDF conversion for CPE certificates
   - type: pserv
-    name: cyberx-gotenberg-staging
+    name: cyberx-gotenberg-production
     runtime: docker
     region: virginia
     plan: standard


### PR DESCRIPTION
## Summary

- **Redirector visibility model** — redirectors now have the same `public`/`private` visibility column as instances, with a background SSH status sync (every 2 min), parity enforcement against the linked instance, and collaborative stream editing for any viewer of a public redirector.
- **Parity backfill + guardrails** — the visibility migration defaults every existing row to `private`, which silently hides redirectors whose parent instance is already public. A follow-up backfill migration promotes those rows, and both instance PATCH routes now auto-promote a linked redirector when the instance is flipped `private → public` to prevent the same gap from reappearing at runtime.
- Bumps app version to **1.5.1**.

## What changed

### Backend — visibility model ([3091f95](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/3091f95))
- New `visibility` column on `redirectors` + index (migration `20260413_000000`)
- New `redirector_status_sync` scheduled task — SSH probes every 2 min, updates `status` and `last_synced_at` without requiring manual Re-check clicks
- Loosened host validation: any IPv4/IPv6 address or hostname is now accepted (still rejects shell metacharacters) so redirectors can run on lab/internal networks
- nginx default-site check folded into the consolidated prerequisites check

### Backend — scoping + parity ([e0007d3](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/e0007d3), [4101628](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/4101628))
- `list_redirectors`, `list_available_instances`, and `create_from_instance` honor visibility: non-admins see their own + public rows, sponsors also see every row owned by their invitees
- Visibility parity enforced: a public instance can only host a public redirector
  - `create_from_instance` forces new redirectors to `public` when the source instance is public
  - `PUT /api/redirectors/{id}` refuses to set `visibility=private` while the linked instance is public
  - Instance PATCH (admin + participant routes) refuses to flip `public → private` while a redirector is linked
- `RedirectorOut` exposes `instance_visibility` so the frontend can render the lock state without an extra round trip

### Backend — auth scope expansion ([87985ad](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/87985ad), [e8f6a0e](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/e8f6a0e))
- Read-only probe endpoints (`test-connection`, `check-prereqs`, `check-port`, `check-nginx-setup`, `list-streams`) downgraded from `redirectors.manage` + strict ownership to `redirectors.view` + visibility check, so sponsors and viewers can re-check a public redirector they don't own
- All 10 stream CRUD / deploy / enable / disable endpoints now use `_get_authorized_redirector(allow_public=True)` — collaborative stream editing for any viewer of a public redirector. Mutation of the redirector row itself (PUT, DELETE, fix-prereqs, fix-nginx-setup) stays strict to owner / admin / sponsor-of-owner.
- Closes a pre-existing auth gap: `get_stream`, `update_stream`, and `preview_stream` previously skipped the authorization helper and could be hit by any user with `redirectors.view` regardless of visibility.

### Backend — parity backfill + runtime guard ([9b26d30](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/9b26d30))
- New migration `20260414_000000` promotes existing redirectors linked to public instances from `private` to `public`. BYO redirectors (no linked instance) and rows linked to private instances are left alone — their visibility stays the owner's explicit choice.
- Instance PATCH (admin + participant routes) now auto-promotes a linked redirector to public when the instance is flipped `private → public`. The side-effect is logged under `redirector_visibility_auto_promoted` in the audit changes payload.

### Frontend ([5f53c57](https://github.com/CyberX-Red-Team/cyberx-event-mgmt/commit/5f53c57), and across all feature commits)
- CyberX "Add Redirector" wizard gains a Visibility select, defaulted from the source instance and force-locked to `public` (with warning hint) when the instance is public. Both the admin list and participant portal copies of the wizard are updated.
- Edit Redirector modals (admin list, admin detail, participant detail) disable the Visibility select and show a warning when the linked instance is public.
- Redirectors list gains a Refresh button mirroring My Instances UX.
- Prerequisites accordion replaced with a header bar surfacing Re-check + Auto-fix buttons and a rotating chevron for expand state; standalone nginx default-site banner removed.

## Migration order on deploy

`alembic upgrade head` will apply:
1. `20260413_000000_add_visibility_to_redirectors` (on top of `20260409_000001`) — adds the column with `server_default='private'`
2. `20260414_000000_backfill_redirector_visibility_parity` — promotes existing rows linked to public instances to `public`

## Test plan

- [ ] CI passes (alembic upgrade, 645 unit tests)
- [ ] After deploy, verify the scheduler logs show the 2-minute redirector status sync registered on startup
- [ ] On an environment with an existing redirector linked to a public instance, confirm the backfill promoted it to `public` (non-owners can see it in the list after deploy)
- [ ] Create a new redirector from a public instance — the wizard should default the Visibility select to `public` and lock it
- [ ] Try to flip the same instance `public → private` while the redirector is still linked — expect a 422 with the "delete the redirector management row first" message
- [ ] Create a private instance, provision a redirector against it, then flip the instance to `public` — confirm the linked redirector is auto-promoted to `public` and the audit log records `redirector_visibility_auto_promoted`
- [ ] As a user with `redirectors.view` (not owner), open a public redirector's detail page and hit Re-check — should succeed (previously returned "Not authorized")
- [ ] As the same non-owner viewer, add/edit/deploy a stream on the public redirector — should succeed
- [ ] As the same non-owner viewer, try to `PUT` the redirector row itself — should be refused (mutations stay strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)