### PR TITLE
feat: stream config override, drift fix, TLS bridging, apache2 prereq

### DIFF
--- a/backend/app/api/routes/redirectors.py
+++ b/backend/app/api/routes/redirectors.py
@@ -37,7 +37,8 @@ from app.schemas.redirector import (
     RedirectorCreate, RedirectorUpdate, RedirectorOut, RedirectorListOut,
     RedirectorFromInstance, ProvisionRedirectorRequest,
     AvailableInstanceOut, InstanceStatusOut, RedirectorTemplateOut,
-    StreamConfigCreate, StreamConfigUpdate, StreamConfigOut,
+    StreamConfigCreate, StreamConfigUpdate, StreamConfigContentUpdate,
+    StreamConfigOut,
     DeployResult, TestConnectionResult, ConfigPreview, CheckPortRequest,
 )
 from app.services.redirector_service import RedirectorService
@@ -57,7 +58,10 @@ from app.services.ssh_service import (
     run_check_port, run_check_nginx_setup, run_fix_nginx_setup,
     run_check_prereqs, run_fix_prereqs, run_deploy_infra_key,
 )
-from app.services.nginx_config_service import generate_stream_config_preview
+from app.services.nginx_config_service import (
+    generate_stream_config_preview,
+    validate_custom_override,
+)
 from app.services.audit_service import AuditService
 
 logger = logging.getLogger(__name__)
@@ -1192,6 +1196,17 @@ async def get_stream(
     return StreamConfigOut.model_validate(stream)
 
 
+# Fields on a stream whose change alters the generated nginx config and
+# therefore requires a redeploy to keep the redirector file in sync.
+_DEPLOY_SENSITIVE_FIELDS = frozenset({
+    "protocol", "listen_port", "cs_ip", "cs_port",
+    "access_control_enabled", "allowed_cidrs",
+    "ssl_enabled", "ssl_cert_path", "ssl_key_path",
+    "ssl_protocols", "ssl_ciphers",
+    "custom_config_override",
+})
+
+
 @router.put("/{redirector_id}/streams/{stream_id}", response_model=StreamConfigOut)
 async def update_stream(
     redirector_id: str,
@@ -1201,23 +1216,55 @@ async def update_stream(
     current_user: User = Depends(require_permission("redirectors.view")),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update a stream config (does not redeploy automatically).
+    """Update a stream config. Auto-redeploys when the change affects the
+    generated nginx file AND the stream is currently deployed — this keeps
+    the redirector's on-disk file in sync with the DB and avoids silent
+    drift. Renames and notes are cosmetic and skip the redeploy.
 
     Stream-level operation: open to any viewer of the redirector.
     """
     svc = RedirectorService(db)
-    await _get_authorized_redirector(
+    redirector = await _get_authorized_redirector(
         redirector_id, current_user, svc, allow_public=True, db=db
     )
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
-    stream = await svc.update_stream(stream, payload.model_dump(exclude_unset=True))
+    changes = payload.model_dump(exclude_unset=True)
+    was_deployed = bool(stream.deployed)
+    stream = await svc.update_stream(stream, changes)
+
+    # Redeploy if this edit touched a deploy-sensitive field and the stream
+    # is currently live on the redirector. Best-effort: on SSH or nginx -t
+    # failure, the DB update stays and the stream is marked not-deployed so
+    # the UI can prompt the operator to retry.
+    deploy_result = None
+    touched_sensitive = bool(_DEPLOY_SENSITIVE_FIELDS & set(changes.keys()))
+    if was_deployed and stream.enabled and touched_sensitive:
+        try:
+            ssh = await _make_ssh_service(svc, redirector, db)
+            deploy_result = await run_deploy_single(ssh, redirector.nginx_stream_dir, stream)
+            if deploy_result["success"]:
+                await svc.update_deployed_at(redirector)
+                await svc.update_stream(stream, {"deployed": True})
+            else:
+                await svc.update_stream(stream, {"deployed": False})
+        except (SSHConnectionError, SSHAuthError, NginxReloadError, SSHCommandError) as e:
+            logger.warning(
+                "Auto-redeploy after stream update failed for %s: %s", stream_id, e
+            )
+            await svc.update_stream(stream, {"deployed": False})
 
     audit = AuditService(db)
     await audit.log(
         action="STREAM_UPDATE",
         user_id=current_user.id,
         resource_type="STREAM_CONFIG",
-        details={"stream_id": stream_id, "redirector_id": redirector_id},
+        details={
+            "stream_id": stream_id,
+            "redirector_id": redirector_id,
+            "fields": sorted(changes.keys()),
+            "auto_redeployed": deploy_result is not None,
+            "redeploy_success": (deploy_result or {}).get("success"),
+        },
         ip_address=request.client.host if request.client else None,
     )
 
@@ -1287,6 +1334,140 @@ async def preview_stream(
     stream = await _get_stream_or_404(stream_id, redirector_id, svc)
     content = generate_stream_config_preview(stream)
     return ConfigPreview(filename=stream.filename, content=content)
+
+
+@router.put(
+    "/{redirector_id}/streams/{stream_id}/config",
+    response_model=DeployResult,
+)
+async def update_stream_config(
+    redirector_id: str,
+    stream_id: str,
+    payload: StreamConfigContentUpdate,
+    request: Request,
+    current_user: User = Depends(require_permission("redirectors.view")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Install a hand-edited nginx config as a custom override and immediately
+    deploy it to the redirector.
+
+    Flow: validate → persist override in DB → SFTP write → nginx -t → reload
+    (with rollback of the on-disk file on nginx -t failure). On deploy
+    failure, the DB override is kept so the operator can keep editing, but
+    the stream is marked not-deployed.
+
+    Stream-level operation: open to any viewer of the redirector.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+
+    try:
+        validate_custom_override(payload.content)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+
+    stream = await svc.update_stream(
+        stream, {"custom_config_override": payload.content, "enabled": True}
+    )
+
+    try:
+        ssh = await _make_ssh_service(svc, redirector, db)
+        result = await run_deploy_single(ssh, redirector.nginx_stream_dir, stream)
+    except SSHConnectionError as e:
+        await svc.update_stream(stream, {"deployed": False})
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        await svc.update_stream(stream, {"deployed": False})
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError) as e:
+        await svc.update_stream(stream, {"deployed": False})
+        raise _ssh_command_error(e)
+
+    if result["success"]:
+        await svc.update_deployed_at(redirector)
+        await svc.update_stream(stream, {"deployed": True})
+    else:
+        await svc.update_stream(stream, {"deployed": False})
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_CONFIG_OVERRIDE_SET",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={
+            "stream_id": stream_id,
+            "redirector_id": redirector_id,
+            "override_bytes": len(payload.content.encode("utf-8")),
+            "deploy_success": result["success"],
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return DeployResult(**result)
+
+
+@router.delete(
+    "/{redirector_id}/streams/{stream_id}/config",
+    response_model=DeployResult,
+)
+async def reset_stream_config(
+    redirector_id: str,
+    stream_id: str,
+    request: Request,
+    current_user: User = Depends(require_permission("redirectors.view")),
+    db: AsyncSession = Depends(get_db),
+):
+    """Clear a stream's custom override and re-deploy the generated config
+    so the on-disk file on the redirector matches the structured fields.
+
+    Stream-level operation: open to any viewer of the redirector.
+    """
+    svc = RedirectorService(db)
+    redirector = await _get_authorized_redirector(
+        redirector_id, current_user, svc, allow_public=True, db=db
+    )
+    stream = await _get_stream_or_404(stream_id, redirector_id, svc)
+
+    had_override = bool(stream.custom_config_override)
+    stream = await svc.update_stream(stream, {"custom_config_override": None})
+
+    try:
+        ssh = await _make_ssh_service(svc, redirector, db)
+        result = await run_deploy_single(ssh, redirector.nginx_stream_dir, stream)
+    except SSHConnectionError as e:
+        await svc.update_stream(stream, {"deployed": False})
+        raise _ssh_connection_error(e)
+    except SSHAuthError as e:
+        await svc.update_stream(stream, {"deployed": False})
+        raise _ssh_auth_error(e)
+    except (NginxReloadError, SSHCommandError) as e:
+        await svc.update_stream(stream, {"deployed": False})
+        raise _ssh_command_error(e)
+
+    if result["success"]:
+        await svc.update_deployed_at(redirector)
+        await svc.update_stream(stream, {"deployed": True})
+    else:
+        await svc.update_stream(stream, {"deployed": False})
+
+    audit = AuditService(db)
+    await audit.log(
+        action="STREAM_CONFIG_OVERRIDE_RESET",
+        user_id=current_user.id,
+        resource_type="STREAM_CONFIG",
+        details={
+            "stream_id": stream_id,
+            "redirector_id": redirector_id,
+            "had_override": had_override,
+            "deploy_success": result["success"],
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    return DeployResult(**result)
 
 
 @router.post("/{redirector_id}/streams/{stream_id}/enable", response_model=DeployResult)

--- a/backend/app/models/redirector.py
+++ b/backend/app/models/redirector.py
@@ -146,6 +146,13 @@ class StreamConfig(Base):
     ssl_protocols = Column(String(100), nullable=False, default="TLSv1.2 TLSv1.3")
     ssl_ciphers = Column(String(200), nullable=False, default="HIGH:!aNULL:!MD5")
 
+    # When set, the generator emits this verbatim instead of rendering from
+    # the structured fields. Used by the "View/Edit config" modal to let
+    # operators hand-edit the nginx config for advanced cases. Cleared by
+    # "Reset to Generated". The authoritative syntax check is nginx -t on
+    # the redirector — we only do cheap structural sanity in the service.
+    custom_config_override = Column(Text, nullable=True)
+
     # If False, the .conf file is removed from the remote redirector
     enabled = Column(Boolean, nullable=False, default=False)
     # True when the config file has been deployed to the remote redirector
@@ -164,6 +171,11 @@ class StreamConfig(Base):
     def filename(self) -> str:
         """Remote filename for this stream config."""
         return f"cyberx_{self.id}.conf"
+
+    @property
+    def has_custom_override(self) -> bool:
+        """True when this stream has a hand-edited config override."""
+        return bool(self.custom_config_override)
 
     def __repr__(self):
         return (

--- a/backend/app/schemas/redirector.py
+++ b/backend/app/schemas/redirector.py
@@ -378,11 +378,22 @@ class StreamConfigOut(BaseModel):
     ssl_ciphers: str
     enabled: bool
     deployed: bool
+    has_custom_override: bool = False
     filename: str
     created_at: datetime
     updated_at: Optional[datetime]
 
     model_config = {"from_attributes": True}
+
+
+class StreamConfigContentUpdate(BaseModel):
+    """Payload for PUT /streams/{id}/config — hand-edited nginx file body.
+
+    The content is validated by nginx_config_service.validate_custom_override
+    in the route handler, then immediately deployed (test + reload on the
+    redirector) so the DB and deployed file stay in sync.
+    """
+    content: str = Field(..., min_length=1, max_length=32768)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/nginx_config_service.py
+++ b/backend/app/services/nginx_config_service.py
@@ -18,12 +18,60 @@ if TYPE_CHECKING:
 
 _UNSAFE_NGINX_CHARS = frozenset("\n\r;{}")
 
+_MAX_OVERRIDE_BYTES = 32 * 1024  # 32 KB ceiling — more than enough for any single stream file
+
 
 def _safe_nginx_value(val: str, field_name: str) -> str:
     """Defense-in-depth: reject values that could break out of an nginx directive."""
     if any(c in _UNSAFE_NGINX_CHARS for c in val):
         raise ValueError(f"Unsafe character in {field_name}: {val!r}")
     return val
+
+
+def validate_custom_override(text: str) -> None:
+    """
+    Cheap structural sanity check for a hand-edited stream config.
+
+    This is NOT an nginx parser — nginx -t on the redirector is the
+    authoritative check. We only guard against obviously malformed input
+    and bytes that would be unsafe to write to disk or would clearly not
+    be an nginx stream server block.
+
+    Raises ValueError on failure.
+    """
+    if text is None:
+        raise ValueError("Custom config must not be null.")
+    if not isinstance(text, str):
+        raise ValueError("Custom config must be a string.")
+    if "\x00" in text:
+        raise ValueError("Custom config contains a null byte.")
+    encoded_len = len(text.encode("utf-8"))
+    if encoded_len == 0:
+        raise ValueError("Custom config must not be empty.")
+    if encoded_len > _MAX_OVERRIDE_BYTES:
+        raise ValueError(
+            f"Custom config exceeds {_MAX_OVERRIDE_BYTES} bytes "
+            f"({encoded_len} bytes provided)."
+        )
+    if "server" not in text or "{" not in text:
+        raise ValueError(
+            "Custom config must contain an nginx 'server { ... }' block."
+        )
+    # Balanced braces, ignoring braces inside '# ...' comment lines.
+    depth = 0
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        for ch in line:
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth < 0:
+                    raise ValueError("Custom config has unbalanced braces (extra '}').")
+    if depth != 0:
+        raise ValueError("Custom config has unbalanced braces (missing '}').")
 
 
 def generate_stream_config(stream: "StreamConfig") -> str:
@@ -34,10 +82,22 @@ def generate_stream_config(stream: "StreamConfig") -> str:
     The file contains one server {} block — no outer stream {} wrapper.
 
     Protocol behaviour:
-        tcp  — plain TCP proxy; optionally with SSL termination
+        tcp  — plain TCP proxy; optionally with TLS bridging (terminate the
+               legitimate cert on the redirector, re-encrypt to the upstream
+               which uses its own self-signed cert, e.g. a CS team server)
         udp  — UDP proxy with reuseport
         dns  — UDP on any port, adds proxy_responses 1 (correct for DNS)
+
+    Override behaviour:
+        If stream.custom_config_override is set, it is returned verbatim
+        and the structured-field path is skipped entirely. The caller is
+        responsible for basic structural validation; nginx -t on the
+        redirector is the authoritative syntax check.
     """
+    override = getattr(stream, "custom_config_override", None)
+    if override:
+        return override if override.endswith("\n") else override + "\n"
+
     now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     protocol = (stream.protocol or "tcp").lower()
     is_dns = protocol == "dns"
@@ -76,7 +136,12 @@ def generate_stream_config(stream: "StreamConfig") -> str:
     if is_dns:
         lines.append("    proxy_responses 1;")
 
-    # --- SSL block (TCP only) ---------------------------------------------
+    # --- TLS bridging block (TCP only) ------------------------------------
+    # Terminates the client TLS handshake on the redirector using the legit
+    # cert, then opens a fresh TLS connection upstream so the CS team server
+    # can keep its own self-signed cert. Without proxy_ssl on, nginx would
+    # send plaintext to a TLS-expecting upstream and the connection would
+    # be dropped immediately.
     if stream.ssl_enabled and not is_udp and stream.ssl_cert_path and stream.ssl_key_path:
         safe_cert = _safe_nginx_value(stream.ssl_cert_path, "ssl_cert_path")
         safe_key = _safe_nginx_value(stream.ssl_key_path, "ssl_key_path")
@@ -88,6 +153,8 @@ def generate_stream_config(stream: "StreamConfig") -> str:
         lines.append(f"    ssl_ciphers {safe_ciphers};")
         lines.append("    ssl_session_cache shared:SSL:10m;")
         lines.append("    ssl_session_timeout 10m;")
+        lines.append("    proxy_ssl on;")
+        lines.append("    proxy_ssl_verify off;")
 
     # --- Access control ---------------------------------------------------
     if stream.access_control_enabled and stream.allowed_cidrs:

--- a/backend/app/services/redirector_service.py
+++ b/backend/app/services/redirector_service.py
@@ -249,13 +249,18 @@ class RedirectorService:
             if field in data and data[field] is not None:
                 setattr(stream, field, data[field])
 
-        # These can legitimately be falsy ([] or False) — handle separately
+        # These can legitimately be falsy ([] or False/None) — handle separately
         if "allowed_cidrs" in data:
             stream.allowed_cidrs = data["allowed_cidrs"]
         if "enabled" in data and data["enabled"] is not None:
             stream.enabled = data["enabled"]
         if "deployed" in data and data["deployed"] is not None:
             stream.deployed = data["deployed"]
+        # custom_config_override: None means "reset to generated" (clear),
+        # non-empty string means "install override". Use a distinct sentinel
+        # key in data to allow both operations.
+        if "custom_config_override" in data:
+            stream.custom_config_override = data["custom_config_override"]
 
         await self.session.commit()
         await self.session.refresh(stream)

--- a/backend/app/services/ssh_service.py
+++ b/backend/app/services/ssh_service.py
@@ -943,6 +943,47 @@ class SSHService:
                                "via sites-enabled/default — auto-fix will remove it.",
             })
 
+            # 3d. Apache2 not holding ports. Kali ships with apache2 preinstalled
+            # and enabled by default, which binds 80/443 and blocks nginx from
+            # starting. We flag it only if it's installed AND actively running
+            # or enabled-at-boot — a dormant-but-installed apache2 is harmless.
+            sudo_n_check = "" if self.username == "root" else "sudo -n "
+            _, _, inst_code = self._exec(
+                client, "dpkg -l apache2 2>/dev/null | grep -q '^ii'"
+            )
+            apache_installed = inst_code == 0
+            if apache_installed:
+                _, _, active_code = self._exec(
+                    client, f"{sudo_n_check}/bin/systemctl is-active apache2 2>/dev/null"
+                )
+                _, _, enabled_code = self._exec(
+                    client, f"{sudo_n_check}/bin/systemctl is-enabled apache2 2>/dev/null"
+                )
+                apache_running = active_code == 0
+                apache_enabled_at_boot = enabled_code == 0
+                apache_ok = not (apache_running or apache_enabled_at_boot)
+                if apache_ok:
+                    apache_detail = "apache2 installed but stopped and disabled."
+                else:
+                    states = []
+                    if apache_running:
+                        states.append("running")
+                    if apache_enabled_at_boot:
+                        states.append("enabled at boot")
+                    apache_detail = (
+                        f"apache2 is {' and '.join(states)} — it will block nginx "
+                        f"from binding ports 80/443. Auto-fix will stop and disable it."
+                    )
+            else:
+                apache_ok = True
+                apache_detail = "apache2 not installed."
+            checks.append({
+                "id": "apache2_not_blocking",
+                "label": "apache2 not blocking ports",
+                "ok": apache_ok,
+                "detail": apache_detail,
+            })
+
             # 4. nginx -t (runs nginx config test — safe, read-only)
             sudo_n = "" if self.username == "root" else "sudo -n "
             out4, _, code = self._exec(
@@ -1089,6 +1130,13 @@ class SSHService:
             "fi\n"
             "# Remove default HTTP site so nginx doesn't hold port 80\n"
             "rm -f /etc/nginx/sites-enabled/default\n"
+            "# Stop and disable apache2 if installed — it blocks nginx on 80/443.\n"
+            "# Kali preinstalls apache2 and enables it by default. We stop + disable\n"
+            "# only; we do NOT uninstall it, so operators can re-enable manually.\n"
+            "if dpkg -l apache2 2>/dev/null | grep -q '^ii'; then\n"
+            "    systemctl stop apache2 2>/dev/null || true\n"
+            "    systemctl disable apache2 2>/dev/null || true\n"
+            "fi\n"
             "# Disable systemd-resolved stub listener if it holds port 53\n"
             "if ss -tulnp 2>/dev/null | grep ':53 ' | grep -q 'systemd-resolve\\|resolved'; then\n"
             "    # Extract real DNS servers from netplan or resolv.conf\n"

--- a/backend/migrations/versions/20260415_000000_add_stream_custom_config_override.py
+++ b/backend/migrations/versions/20260415_000000_add_stream_custom_config_override.py
@@ -5,7 +5,7 @@ verbatim instead of rendering from structured fields. Used by the
 "View/Edit Config" modal to let operators hand-edit the deployed config.
 
 Revision ID: 20260415_000000
-Revises: 20260413_000000
+Revises: 20260414_000000
 Create Date: 2026-04-15 00:00:00
 """
 from alembic import op
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 
 revision = "20260415_000000"
-down_revision = "20260413_000000"
+down_revision = "20260414_000000"
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/20260415_000000_add_stream_custom_config_override.py
+++ b/backend/migrations/versions/20260415_000000_add_stream_custom_config_override.py
@@ -1,0 +1,29 @@
+"""Add custom_config_override column to stream_configs.
+
+Nullable TEXT column. When set, the nginx config generator emits this
+verbatim instead of rendering from structured fields. Used by the
+"View/Edit Config" modal to let operators hand-edit the deployed config.
+
+Revision ID: 20260415_000000
+Revises: 20260413_000000
+Create Date: 2026-04-15 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260415_000000"
+down_revision = "20260413_000000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "stream_configs",
+        sa.Column("custom_config_override", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("stream_configs", "custom_config_override")

--- a/backend/tests/unit/test_nginx_config_service.py
+++ b/backend/tests/unit/test_nginx_config_service.py
@@ -1,0 +1,202 @@
+"""Unit tests for nginx stream config text generator.
+
+These are pure-Python tests — no DB, no SSH. The generator is called with
+a lightweight stand-in object that exposes the same attributes as the
+StreamConfig ORM model.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.nginx_config_service import (
+    generate_stream_config,
+    validate_custom_override,
+)
+
+
+def _make_stream(**overrides):
+    """Build a minimal StreamConfig-shaped object for the generator."""
+    defaults = dict(
+        id="abc123",
+        name="test-stream",
+        protocol="tcp",
+        listen_port=443,
+        cs_ip="10.0.0.5",
+        cs_port=443,
+        access_control_enabled=False,
+        allowed_cidrs=None,
+        ssl_enabled=False,
+        ssl_cert_path=None,
+        ssl_key_path=None,
+        ssl_protocols="TLSv1.2 TLSv1.3",
+        ssl_ciphers="HIGH:!aNULL:!MD5",
+        custom_config_override=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.unit
+class TestGeneratorPlainTcp:
+    def test_plain_tcp_has_proxy_pass_and_no_ssl(self):
+        s = _make_stream(listen_port=8080, cs_port=8080)
+        out = generate_stream_config(s)
+        assert "listen 8080;" in out
+        assert "proxy_pass 10.0.0.5:8080;" in out
+        assert "ssl_certificate" not in out
+        assert "proxy_ssl" not in out
+        assert out.startswith("# CyberX Managed - test-stream")
+        assert out.endswith("\n")
+
+
+@pytest.mark.unit
+class TestGeneratorTlsBridging:
+    def test_tls_bridging_emits_proxy_ssl_on(self):
+        """Regression: bridging requires proxy_ssl on; to re-encrypt upstream.
+
+        Without this directive nginx sends plaintext to the upstream TLS
+        listener and the connection is dropped immediately.
+        """
+        s = _make_stream(
+            ssl_enabled=True,
+            ssl_cert_path="/etc/ssl/certs/legit.pem",
+            ssl_key_path="/etc/ssl/private/legit.key",
+        )
+        out = generate_stream_config(s)
+        assert "listen 443 ssl;" in out
+        assert "ssl_certificate /etc/ssl/certs/legit.pem;" in out
+        assert "ssl_certificate_key /etc/ssl/private/legit.key;" in out
+        assert "proxy_ssl on;" in out
+        assert "proxy_ssl_verify off;" in out
+
+    def test_ssl_enabled_without_paths_falls_back_to_plain_tcp(self):
+        s = _make_stream(ssl_enabled=True, ssl_cert_path=None, ssl_key_path=None)
+        out = generate_stream_config(s)
+        assert "listen 443;" in out
+        assert "ssl" not in out.lower().replace("# cyberx", "")
+
+    def test_udp_ignores_ssl_block(self):
+        s = _make_stream(
+            protocol="udp",
+            listen_port=500,
+            cs_port=500,
+            ssl_enabled=True,
+            ssl_cert_path="/etc/ssl/certs/x.pem",
+            ssl_key_path="/etc/ssl/private/x.key",
+        )
+        out = generate_stream_config(s)
+        assert "listen 500 udp reuseport;" in out
+        assert "ssl_certificate" not in out
+        assert "proxy_ssl" not in out
+
+
+@pytest.mark.unit
+class TestGeneratorDnsAndAcl:
+    def test_dns_adds_proxy_responses(self):
+        s = _make_stream(protocol="dns", listen_port=53, cs_port=53)
+        out = generate_stream_config(s)
+        assert "listen 53 udp reuseport;" in out
+        assert "proxy_responses 1;" in out
+
+    def test_acl_emits_allow_and_deny(self):
+        s = _make_stream(
+            access_control_enabled=True,
+            allowed_cidrs=["10.0.0.0/8", "192.168.1.42"],
+        )
+        out = generate_stream_config(s)
+        assert "allow 10.0.0.0/8;" in out
+        assert "allow 192.168.1.42;" in out
+        assert "deny all;" in out
+
+
+@pytest.mark.unit
+class TestGeneratorCustomOverride:
+    def test_override_returned_verbatim(self):
+        body = "server {\n    listen 9999;\n    proxy_pass 1.2.3.4:9999;\n}\n"
+        s = _make_stream(custom_config_override=body)
+        out = generate_stream_config(s)
+        assert out == body  # exact match, no wrapping, no timestamps
+
+    def test_override_gets_trailing_newline_if_missing(self):
+        body = "server { listen 9999; proxy_pass 1.2.3.4:9999; }"  # no \n
+        s = _make_stream(custom_config_override=body)
+        out = generate_stream_config(s)
+        assert out.endswith("\n")
+        assert out.rstrip("\n") == body
+
+    def test_override_skips_structured_field_rendering(self):
+        """When override is set, cs_ip/listen_port/etc. from fields MUST NOT
+        leak into the output — the override is authoritative."""
+        body = "server { listen 7777; proxy_pass 9.9.9.9:7777; }\n"
+        s = _make_stream(
+            listen_port=443,
+            cs_ip="10.0.0.5",
+            cs_port=443,
+            custom_config_override=body,
+        )
+        out = generate_stream_config(s)
+        assert "10.0.0.5" not in out
+        assert "443" not in out
+        assert "9.9.9.9:7777" in out
+
+    def test_empty_override_falls_through_to_generated(self):
+        """Empty string is treated as 'no override' so the structured path runs."""
+        s = _make_stream(custom_config_override="")
+        out = generate_stream_config(s)
+        assert "# CyberX Managed - test-stream" in out
+        assert "proxy_pass 10.0.0.5:443;" in out
+
+
+@pytest.mark.unit
+class TestValidateCustomOverride:
+    def test_accepts_minimal_server_block(self):
+        validate_custom_override("server {\n    listen 443;\n    proxy_pass 1.2.3.4:443;\n}\n")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError, match="empty"):
+            validate_custom_override("")
+
+    def test_rejects_null_byte(self):
+        with pytest.raises(ValueError, match="null byte"):
+            validate_custom_override("server {\x00}")
+
+    def test_rejects_missing_server_block(self):
+        with pytest.raises(ValueError, match="server"):
+            validate_custom_override("# just a comment, no server block")
+
+    def test_rejects_unbalanced_extra_close(self):
+        with pytest.raises(ValueError, match="unbalanced"):
+            validate_custom_override("server { listen 443; } }")
+
+    def test_rejects_unbalanced_missing_close(self):
+        with pytest.raises(ValueError, match="unbalanced"):
+            validate_custom_override("server { listen 443;")
+
+    def test_ignores_braces_in_comment_lines(self):
+        # Bare '}' inside a comment line must not throw off the balance counter.
+        text = "# here is a stray } in a comment\nserver {\n    listen 443;\n}\n"
+        validate_custom_override(text)
+
+    def test_rejects_oversized(self):
+        big = "server {\n" + ("# padding\n" * 5000) + "}\n"
+        with pytest.raises(ValueError, match="exceeds"):
+            validate_custom_override(big)
+
+    def test_accepts_realistic_tls_bridging_block(self):
+        text = """# CyberX Managed - prod-c2
+server {
+    listen 443 ssl;
+    proxy_pass 10.32.88.189:443;
+    proxy_connect_timeout 60s;
+    proxy_timeout 10m;
+    ssl_certificate /etc/ssl/certs/legit.pem;
+    ssl_certificate_key /etc/ssl/private/legit.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    proxy_ssl on;
+    proxy_ssl_verify off;
+}
+"""
+        validate_custom_override(text)

--- a/docs/REDIRECTOR_MANAGEMENT.md
+++ b/docs/REDIRECTOR_MANAGEMENT.md
@@ -234,19 +234,65 @@ deny all;
 
 Only traffic from listed CIDRs is accepted. All other traffic is dropped.
 
-### SSL/TLS Termination
+### SSL/TLS Bridging
 
-When enabled (TCP only), the redirector terminates TLS and forwards plaintext to the upstream:
+When enabled (TCP only), the redirector **terminates** the client TLS handshake
+with a legitimate certificate stored on the redirector, then opens a **fresh
+TLS connection to the upstream** so C2 teamservers can keep using their own
+self-signed certificate. This is TLS bridging (terminate + re-origin), not
+passthrough — the public cert lives on the redirector, the CS cert lives on
+the teamserver, and nginx sits between them.
 
 ```nginx
-ssl_preread off;
-ssl_certificate /etc/ssl/certs/redir.pem;
-ssl_certificate_key /etc/ssl/private/redir.key;
-ssl_protocols TLSv1.2 TLSv1.3;
-ssl_ciphers HIGH:!aNULL:!MD5;
+server {
+    listen 443 ssl;
+    proxy_pass 10.32.88.189:443;
+    ssl_certificate /etc/ssl/certs/legit.pem;
+    ssl_certificate_key /etc/ssl/private/legit.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    proxy_ssl on;            # re-encrypt to upstream
+    proxy_ssl_verify off;    # accept upstream self-signed cert
+}
 ```
 
-Requires certificate and key files already present on the redirector.
+`proxy_ssl on;` is load-bearing — without it, nginx sends plaintext to the
+upstream TLS listener and the teamserver drops the connection immediately.
+`proxy_ssl_verify off;` is needed because CS and most C2 teamservers use
+self-signed certs that nginx has no CA chain for.
+
+Certificate and key files must already be present on the redirector.
+
+### Custom Config Override
+
+The **View/Edit Config** modal lets operators hand-edit the nginx config
+for a stream when the structured fields can't express what's needed
+(advanced directives, custom variables, experimental tuning). Saving an
+edit:
+
+1. Validates basic structure (non-empty, balanced braces, size ≤ 32 KB,
+   contains a `server` block).
+2. Persists the override in the database on the stream row.
+3. Immediately writes it to the redirector, runs `nginx -t`, and reloads
+   nginx. If `nginx -t` fails the on-disk file is rolled back (previous
+   content or deleted if it was new), but the DB override is kept so the
+   operator can keep editing their draft. The stream is marked
+   `deployed=false` on any failure.
+
+While an override is active:
+- The **generator path is bypassed entirely** — structured-field edits
+  (listen_port, cs_ip, SSL options, etc.) do not affect what is deployed.
+- The UI shows a **drift banner** to warn the operator.
+- Clicking **Reset to Generated** clears the override, re-renders from
+  structured fields, and redeploys in one step.
+
+Internally this is `custom_config_override TEXT NULL` on `stream_configs`
+and the `PUT|DELETE /api/redirectors/{id}/streams/{sid}/config` endpoints.
+Audit events: `STREAM_CONFIG_OVERRIDE_SET` and
+`STREAM_CONFIG_OVERRIDE_RESET` (override body is **not** logged, only its
+byte length).
 
 ---
 
@@ -296,8 +342,16 @@ Requires certificate and key files already present on the redirector.
 | `POST /api/redirectors/{id}/streams/{sid}/deploy` | Deploy stream config to redirector |
 | `POST /api/redirectors/{id}/streams/{sid}/remove` | Remove stream config file from redirector |
 | `GET /api/redirectors/{id}/streams/{sid}/preview` | Preview generated nginx config |
+| `PUT /api/redirectors/{id}/streams/{sid}/config` | Install a hand-edited custom config override and deploy it (test + reload with rollback) |
+| `DELETE /api/redirectors/{id}/streams/{sid}/config` | Clear the custom override and redeploy the generated config |
 | `POST /api/redirectors/{id}/deploy-all` | Enable all streams + deploy |
 | `POST /api/redirectors/{id}/disable-all` | Disable all streams + remove config files |
+
+The regular `PUT /api/redirectors/{id}/streams/{sid}` auto-redeploys to the
+redirector whenever a deploy-sensitive field changes (listen port, proxy
+target, SSL options, ACLs) and the stream was already deployed. This keeps
+the on-disk config on the redirector in sync with the database and prevents
+silent drift. Cosmetic fields (name) still skip the redeploy.
 
 ---
 
@@ -360,6 +414,7 @@ All security-relevant actions are logged via `AuditService`:
 - **Stream module missing** -- install `libnginx-mod-stream` (Debian/Ubuntu) or enable in nginx build
 - **Stream directory missing** -- create `/etc/nginx/stream.d` and add `stream { include /etc/nginx/stream.d/*.conf; }` to nginx.conf
 - **sudo not available** -- the SSH user needs `NOPASSWD` sudo for nginx operations
+- **apache2 blocking ports** -- Kali preinstalls apache2 and enables it by default, which holds ports 80/443 and prevents nginx from binding them. The `apache2_not_blocking` check detects this; **Fix Prerequisites** stops and disables apache2 (without uninstalling it, so operators can re-enable manually).
 
 Use **Fix Prerequisites** to auto-resolve common issues (requires sudo).
 

--- a/docs/REDIRECTOR_MANAGEMENT.md
+++ b/docs/REDIRECTOR_MANAGEMENT.md
@@ -236,12 +236,18 @@ Only traffic from listed CIDRs is accepted. All other traffic is dropped.
 
 ### SSL/TLS Bridging
 
-When enabled (TCP only), the redirector **terminates** the client TLS handshake
-with a legitimate certificate stored on the redirector, then opens a **fresh
-TLS connection to the upstream** so C2 teamservers can keep using their own
-self-signed certificate. This is TLS bridging (terminate + re-origin), not
-passthrough — the public cert lives on the redirector, the CS cert lives on
-the teamserver, and nginx sits between them.
+When **SSL Enabled** is checked on a TCP stream, the redirector performs
+**TLS bridging** — it terminates the client's TLS handshake with a
+legitimate certificate stored on the redirector, then opens a fresh TLS
+connection to the upstream teamserver. This lets C2 teamservers keep
+using their own self-signed certificates while clients see a trusted
+public cert at the edge.
+
+This is bridging (terminate + re-origin), **not** passthrough:
+
+- The public cert lives on the redirector (operator-managed).
+- The teamserver's self-signed cert lives on the teamserver, unchanged.
+- nginx sits between the two and re-encrypts in both directions.
 
 ```nginx
 server {
@@ -258,41 +264,61 @@ server {
 }
 ```
 
-`proxy_ssl on;` is load-bearing — without it, nginx sends plaintext to the
-upstream TLS listener and the teamserver drops the connection immediately.
-`proxy_ssl_verify off;` is needed because CS and most C2 teamservers use
-self-signed certs that nginx has no CA chain for.
+`proxy_ssl on;` is the load-bearing directive here — without it, nginx
+sends **plaintext** to the upstream TLS listener and the teamserver
+drops the connection immediately. `proxy_ssl_verify off;` is required
+because teamservers typically use self-signed certs that nginx has no
+CA chain for; trust is asserted by the infra operator, not by PKI.
 
-Certificate and key files must already be present on the redirector.
+Prerequisites on the redirector:
+
+- The certificate and private key files must already exist at the
+  paths supplied in **SSL Certificate Path** and **SSL Key Path**.
+- The key file must be readable by the nginx user (`www-data` on
+  Debian/Ubuntu/Kali).
 
 ### Custom Config Override
 
 The **View/Edit Config** modal lets operators hand-edit the nginx config
-for a stream when the structured fields can't express what's needed
-(advanced directives, custom variables, experimental tuning). Saving an
-edit:
+for a stream when the structured fields don't cover what they need —
+advanced nginx directives, experimental tuning, or one-off tweaks that
+don't deserve their own schema field.
 
-1. Validates basic structure (non-empty, balanced braces, size ≤ 32 KB,
-   contains a `server` block).
-2. Persists the override in the database on the stream row.
-3. Immediately writes it to the redirector, runs `nginx -t`, and reloads
-   nginx. If `nginx -t` fails the on-disk file is rolled back (previous
-   content or deleted if it was new), but the DB override is kept so the
-   operator can keep editing their draft. The stream is marked
-   `deployed=false` on any failure.
+**When to use it:**
+- You need an nginx directive the wizard doesn't expose (e.g. custom
+  `proxy_buffer_size`, `real_ip_header`, or a `map` block).
+- You want to test a config change without round-tripping through a code
+  deploy.
+- You're debugging a broken stream and need to inspect exactly what the
+  generator would produce, then poke at it.
 
-While an override is active:
-- The **generator path is bypassed entirely** — structured-field edits
-  (listen_port, cs_ip, SSL options, etc.) do not affect what is deployed.
-- The UI shows a **drift banner** to warn the operator.
-- Clicking **Reset to Generated** clears the override, re-renders from
-  structured fields, and redeploys in one step.
+**When to avoid it:** if the change is expressible via the structured
+fields (ports, upstream, SSL, ACLs), use the Edit Stream form instead —
+it stays in sync with wizard validation and survives schema changes.
 
-Internally this is `custom_config_override TEXT NULL` on `stream_configs`
-and the `PUT|DELETE /api/redirectors/{id}/streams/{sid}/config` endpoints.
-Audit events: `STREAM_CONFIG_OVERRIDE_SET` and
-`STREAM_CONFIG_OVERRIDE_RESET` (override body is **not** logged, only its
-byte length).
+**Save flow:**
+
+1. Validate basic structure on the server — non-empty, balanced braces,
+   size ≤ 32 KB, contains a `server` block.
+2. Persist the override on the `stream_configs` row.
+3. SFTP the file onto the redirector, run `nginx -t`, reload nginx.
+4. On `nginx -t` failure, roll back the on-disk file (restore previous
+   content or delete if it was new) and mark the stream
+   `deployed=false`. The DB override is **kept** so the operator can
+   keep editing their broken draft instead of starting over.
+
+**While an override is active**, the generator path is bypassed
+entirely: edits to structured fields (listen_port, cs_ip, SSL options,
+ACLs) do not change what is deployed. The modal shows a drift banner
+and a **Reset to Generated** button that clears the override and
+redeploys the rendered config in one step.
+
+Backed by `custom_config_override TEXT NULL` on `stream_configs` and the
+`PUT|DELETE /api/redirectors/{id}/streams/{sid}/config` endpoints. Audit
+events `STREAM_CONFIG_OVERRIDE_SET` and `STREAM_CONFIG_OVERRIDE_RESET`
+record only the override's byte length — never its content — so
+operators can embed sensitive strings in comments without them appearing
+in audit logs.
 
 ---
 

--- a/frontend/templates/pages/participant/redirector_detail.html
+++ b/frontend/templates/pages/participant/redirector_detail.html
@@ -423,24 +423,45 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
 </div>
 
 <!-- ================================================================
-     Preview Modal
+     View / Edit Config Modal
      ================================================================ -->
 <div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
-                    <i data-feather="eye" class="me-2"></i>Config Preview
+                    <i data-feather="edit-3" class="me-2"></i>View / Edit Config
                     <span id="previewFilename" class="text-muted small ms-2 font-monospace"></span>
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
+                <div id="previewOverrideBanner" class="alert alert-warning py-2 small d-none" role="alert">
+                    <i data-feather="alert-triangle" class="me-1"></i>
+                    This stream is using a <strong>hand-edited config override</strong>.
+                    Changes made via the Edit Stream form (listen port, upstream, SSL, ACLs) will
+                    <strong>not</strong> affect what is deployed until you click
+                    <em>Reset to Generated</em>.
+                </div>
+                <div class="mb-2 small text-muted">
+                    Edit the nginx config directly and click <strong>Save &amp; Apply</strong> to
+                    deploy it. The redirector will run <code>nginx -t</code> and reload; on failure
+                    the file is rolled back but your draft stays in the database so you can keep
+                    editing.
+                </div>
                 <textarea class="form-control font-monospace bg-dark text-light border-0"
-                    id="previewContent" rows="20" readonly></textarea>
+                    id="previewContent" rows="20" spellcheck="false"></textarea>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-outline-warning me-auto d-none"
+                    id="previewResetBtn" onclick="resetStreamConfig()">
+                    <i data-feather="rotate-ccw" class="me-1"></i>Reset to Generated
+                </button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="previewSaveBtn"
+                    onclick="saveStreamConfig()">
+                    <i data-feather="upload" class="me-1"></i>Save &amp; Apply
+                </button>
             </div>
         </div>
     </div>
@@ -723,15 +744,88 @@ async function disableAll() {
 // ============================================================
 // Stream operations
 // ============================================================
+// Tracks which stream the View/Edit Config modal is currently editing so
+// Save & Apply / Reset know which resource to PUT/DELETE against.
+let currentConfigStreamId = null;
+
 async function previewStream(streamId) {
+    currentConfigStreamId = streamId;
     try {
-        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/preview`);
-        const data = await resp.json();
-        document.getElementById('previewFilename').textContent = data.filename;
-        document.getElementById('previewContent').value = data.content;
+        const [streamResp, previewResp] = await Promise.all([
+            csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}`),
+            csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/preview`),
+        ]);
+        const stream = await streamResp.json();
+        const preview = await previewResp.json();
+        document.getElementById('previewFilename').textContent = preview.filename;
+        document.getElementById('previewContent').value = preview.content;
+
+        const hasOverride = !!stream.has_custom_override;
+        document.getElementById('previewOverrideBanner').classList.toggle('d-none', !hasOverride);
+        document.getElementById('previewResetBtn').classList.toggle('d-none', !hasOverride);
+
         previewModal.show();
+        if (window.feather) window.feather.replace();
     } catch (err) {
-        showToast(`Preview failed: ${escHtml(err.message)}`, 'danger');
+        showToast(`Load failed: ${escHtml(err.message)}`, 'danger');
+    }
+}
+
+async function saveStreamConfig() {
+    if (!currentConfigStreamId) return;
+    const content = document.getElementById('previewContent').value;
+    if (!content.trim()) {
+        showToast('Config is empty.', 'warning');
+        return;
+    }
+    const saveBtn = document.getElementById('previewSaveBtn');
+    saveBtn.disabled = true;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${currentConfigStreamId}/config`,
+            {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content }),
+            }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Save failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
+            return;
+        }
+        previewModal.hide();
+        showDeployResult('Save & Apply Config', data);
+        if (data.success) {
+            await loadStreams();
+        }
+    } catch (err) {
+        showToast(`Request failed: ${escHtml(err.message)}`, 'danger');
+    } finally {
+        saveBtn.disabled = false;
+    }
+}
+
+async function resetStreamConfig() {
+    if (!currentConfigStreamId) return;
+    if (!confirm('Reset this stream to the generated config?\n\nThis clears the custom override and redeploys the config rendered from the stream fields.')) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${currentConfigStreamId}/config`,
+            { method: 'DELETE' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Reset failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
+            return;
+        }
+        previewModal.hide();
+        showDeployResult('Reset to Generated', data);
+        if (data.success) {
+            await loadStreams();
+        }
+    } catch (err) {
+        showToast(`Request failed: ${escHtml(err.message)}`, 'danger');
     }
 }
 

--- a/frontend/templates/pages/participant/redirector_detail.html
+++ b/frontend/templates/pages/participant/redirector_detail.html
@@ -438,16 +438,14 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
             <div class="modal-body">
                 <div id="previewOverrideBanner" class="alert alert-warning py-2 small d-none" role="alert">
                     <i data-feather="alert-triangle" class="me-1"></i>
-                    This stream is using a <strong>hand-edited config override</strong>.
-                    Changes made via the Edit Stream form (listen port, upstream, SSL, ACLs) will
-                    <strong>not</strong> affect what is deployed until you click
-                    <em>Reset to Generated</em>.
+                    <strong>Custom override active.</strong>
+                    Edits made from the Add/Edit Stream form (listen port, upstream, SSL, ACLs)
+                    are ignored on this stream until you click <em>Reset to Generated</em>.
                 </div>
                 <div class="mb-2 small text-muted">
-                    Edit the nginx config directly and click <strong>Save &amp; Apply</strong> to
-                    deploy it. The redirector will run <code>nginx -t</code> and reload; on failure
-                    the file is rolled back but your draft stays in the database so you can keep
-                    editing.
+                    Hand-edit the nginx config and click <strong>Save &amp; Apply</strong> to deploy it.
+                    The redirector will run <code>nginx&nbsp;-t</code> and reload; on failure the file is
+                    rolled back automatically, but your draft stays in the editor so you can fix and retry.
                 </div>
                 <textarea class="form-control font-monospace bg-dark text-light border-0"
                     id="previewContent" rows="20" spellcheck="false"></textarea>

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -382,24 +382,45 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
 </div>
 
 <!-- ================================================================
-     Preview Modal
+     View / Edit Config Modal
      ================================================================ -->
 <div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
-                    <i data-feather="eye" class="me-2"></i>Config Preview
+                    <i data-feather="edit-3" class="me-2"></i>View / Edit Config
                     <span id="previewFilename" class="text-muted small ms-2 font-monospace"></span>
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
+                <div id="previewOverrideBanner" class="alert alert-warning py-2 small d-none" role="alert">
+                    <i data-feather="alert-triangle" class="me-1"></i>
+                    This stream is using a <strong>hand-edited config override</strong>.
+                    Changes made via the Edit Stream form (listen port, upstream, SSL, ACLs) will
+                    <strong>not</strong> affect what is deployed until you click
+                    <em>Reset to Generated</em>.
+                </div>
+                <div class="mb-2 small text-muted">
+                    Edit the nginx config directly and click <strong>Save &amp; Apply</strong> to
+                    deploy it. The redirector will run <code>nginx -t</code> and reload; on failure
+                    the file is rolled back but your draft stays in the database so you can keep
+                    editing.
+                </div>
                 <textarea class="form-control font-monospace bg-dark text-light border-0"
-                    id="previewContent" rows="20" readonly></textarea>
+                    id="previewContent" rows="20" spellcheck="false"></textarea>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-outline-warning me-auto d-none"
+                    id="previewResetBtn" onclick="resetStreamConfig()">
+                    <i data-feather="rotate-ccw" class="me-1"></i>Reset to Generated
+                </button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="previewSaveBtn"
+                    onclick="saveStreamConfig()">
+                    <i data-feather="upload" class="me-1"></i>Save &amp; Apply
+                </button>
             </div>
         </div>
     </div>
@@ -637,15 +658,93 @@ async function disableAll() {
 // ============================================================
 // Stream operations
 // ============================================================
+// Tracks which stream the View/Edit Config modal is currently editing so
+// Save & Apply / Reset know which resource to PUT/DELETE against.
+let currentConfigStreamId = null;
+
 async function previewStream(streamId) {
+    currentConfigStreamId = streamId;
     try {
-        const resp = await csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/preview`);
-        const data = await resp.json();
-        document.getElementById('previewFilename').textContent = data.filename;
-        document.getElementById('previewContent').value = data.content;
+        // Pull the stream to detect whether it currently has a custom override,
+        // then pull the rendered preview text (which respects the override).
+        const [streamResp, previewResp] = await Promise.all([
+            csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}`),
+            csrfFetch(`/api/redirectors/${REDIRECTOR_ID}/streams/${streamId}/preview`),
+        ]);
+        const stream = await streamResp.json();
+        const preview = await previewResp.json();
+        document.getElementById('previewFilename').textContent = preview.filename;
+        document.getElementById('previewContent').value = preview.content;
+
+        const hasOverride = !!stream.has_custom_override;
+        document.getElementById('previewOverrideBanner').classList.toggle('d-none', !hasOverride);
+        document.getElementById('previewResetBtn').classList.toggle('d-none', !hasOverride);
+
         previewModal.show();
+        // Re-render feather icons inside the freshly shown modal.
+        if (window.feather) window.feather.replace();
     } catch (err) {
-        showToast(`Preview failed: ${escHtml(err.message)}`, 'danger');
+        showToast(`Load failed: ${escHtml(err.message)}`, 'danger');
+    }
+}
+
+async function saveStreamConfig() {
+    if (!currentConfigStreamId) return;
+    const content = document.getElementById('previewContent').value;
+    if (!content.trim()) {
+        showToast('Config is empty.', 'warning');
+        return;
+    }
+    const saveBtn = document.getElementById('previewSaveBtn');
+    saveBtn.disabled = true;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${currentConfigStreamId}/config`,
+            {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content }),
+            }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Save failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
+            return;
+        }
+        // Deploy result may report nginx -t failure — show it either way so the
+        // operator can read the nginx error and iterate.
+        previewModal.hide();
+        showDeployResult('Save & Apply Config', data);
+        if (data.success) {
+            await loadStreams();
+        }
+    } catch (err) {
+        showToast(`Request failed: ${escHtml(err.message)}`, 'danger');
+    } finally {
+        saveBtn.disabled = false;
+    }
+}
+
+async function resetStreamConfig() {
+    if (!currentConfigStreamId) return;
+    if (!confirm('Reset this stream to the generated config?\n\nThis clears the custom override and redeploys the config rendered from the stream fields.')) return;
+    try {
+        const resp = await csrfFetch(
+            `/api/redirectors/${REDIRECTOR_ID}/streams/${currentConfigStreamId}/config`,
+            { method: 'DELETE' }
+        );
+        const data = await resp.json();
+        if (!resp.ok) {
+            showToast(`Reset failed: ${escHtml(data.detail || 'Unknown error')}`, 'danger');
+            return;
+        }
+        previewModal.hide();
+        showDeployResult('Reset to Generated', data);
+        if (data.success) {
+            await loadStreams();
+        }
+    } catch (err) {
+        showToast(`Request failed: ${escHtml(err.message)}`, 'danger');
     }
 }
 

--- a/frontend/templates/pages/redirectors/detail.html
+++ b/frontend/templates/pages/redirectors/detail.html
@@ -397,16 +397,14 @@ tr.stream-conflict:hover > td { background-color: rgba(220,53,69,0.22) !importan
             <div class="modal-body">
                 <div id="previewOverrideBanner" class="alert alert-warning py-2 small d-none" role="alert">
                     <i data-feather="alert-triangle" class="me-1"></i>
-                    This stream is using a <strong>hand-edited config override</strong>.
-                    Changes made via the Edit Stream form (listen port, upstream, SSL, ACLs) will
-                    <strong>not</strong> affect what is deployed until you click
-                    <em>Reset to Generated</em>.
+                    <strong>Custom override active.</strong>
+                    Edits made from the Add/Edit Stream form (listen port, upstream, SSL, ACLs)
+                    are ignored on this stream until you click <em>Reset to Generated</em>.
                 </div>
                 <div class="mb-2 small text-muted">
-                    Edit the nginx config directly and click <strong>Save &amp; Apply</strong> to
-                    deploy it. The redirector will run <code>nginx -t</code> and reload; on failure
-                    the file is rolled back but your draft stays in the database so you can keep
-                    editing.
+                    Hand-edit the nginx config and click <strong>Save &amp; Apply</strong> to deploy it.
+                    The redirector will run <code>nginx&nbsp;-t</code> and reload; on failure the file is
+                    rolled back automatically, but your draft stays in the editor so you can fix and retry.
                 </div>
                 <textarea class="form-control font-monospace bg-dark text-light border-0"
                     id="previewContent" rows="20" spellcheck="false"></textarea>


### PR DESCRIPTION
## Summary

- **Custom config override** — new View/Edit Config modal lets operators hand-edit a stream's nginx file. Save & Apply runs `nginx -t` on the redirector with automatic rollback on failure; Reset to Generated clears the override and redeploys from structured fields.
- **TLS bridging fix** — generator now emits `proxy_ssl on` + `proxy_ssl_verify off` when SSL is enabled, so nginx re-encrypts to the upstream instead of sending plaintext to a TLS listener. Previous output was silently broken for CS teamservers.
- **Drift fix** — `PUT /streams/{id}` now auto-redeploys when a deploy-sensitive field changes on a live stream, keeping the on-disk config in sync with the database.
- **Apache2 prereq** — new `apache2_not_blocking` check + auto-fix (stop + disable, no uninstall) so Kali redirectors don't block nginx on 80/443.

## Test plan

- [x] `backend/tests/unit/test_nginx_config_service.py` — 19 new generator + validator tests, all green
- [x] Full unit suite — 664 passed, 0 regressions
- [ ] End-to-end validation against a real redirector (deferred to deploy — no SSH target in dev env)
- [ ] OWASP review of diff — completed locally, no CRITICAL/HIGH/MEDIUM findings; one LOW on pre-existing \`showToast\` innerHTML pattern not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)